### PR TITLE
Fixes #13071: Bad build.conf format breaks node-external-reports info displaying

### DIFF
--- a/node-external-reports/build.conf
+++ b/node-external-reports/build.conf
@@ -15,11 +15,11 @@ plugin-fullname=rudder-plugin-${plugin-name}
 plugin-title-description=View external reports on node details
 
 # Web description
-plugin-web-description=<p>This is a plugin that allows to disaply external text (HTML, raw text) information about\
- nodes in the node details page.</p>\
- <p>The plugin allows to configure a list of report name, root directory, description.</p>\
- <p>When on node details, a new "external reports" tab is displayed, with the list\
- of report available for the node.</p>
+plugin-web-description="""<p>This is a plugin that allows to disaply external text (HTML, raw text) information about
+ nodes in the node details page.
+ The plugin allows to configure a list of report name, root directory, description.
+ When on node details, a new "external reports" tab is displayed, with the list
+ of report available for the node.</p>"""
 
 # Plugin version. It is build as follow: A.B-x.y(.z) with:
 # - A.B: Rudder major.minor
@@ -30,4 +30,3 @@ plugin-branch=1.6
 
 # rudder branch comes from parent
 plugin-version=${rudder-branch}-${plugin-branch}
-s


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13071