### PR TITLE
Fixes #13749: Allow to build no license plugin with licensed target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PUB_LIBS =
 PRIV_LIBS = plugins-common-private
 LIBS= $(PUB_LIBS) $(PRIV_LIBS)
 
-PLUGINS = api-authorizations auth-backends branding change-validation datasources helloworld node-external-reports scale-out-relay user-management
+PLUGINS = api-authorizations auth-backends branding change-validation datasources helloworld node-external-reports scale-out-relay user-management vault glpi centreon
 PLUGINS-LICENSED = $(addsuffix -licensed,$(PLUGINS))
 ALL = $(LIBS) $(PLUGINS)
 

--- a/makefiles/common-plugin.mk
+++ b/makefiles/common-plugin.mk
@@ -8,5 +8,5 @@ include ../makefiles/common.mk
 std-files:
 
 licensed-files:
-	echo "License not supported for this kind of plugin" && /bin/false
+	echo "License not supported for this kind of plugin, building without license"
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13749