### PR TITLE
Fixes #13924: Make python dependency a warning instead of check in notify packaging

### DIFF
--- a/notify/README.adoc
+++ b/notify/README.adoc
@@ -19,7 +19,7 @@ notifications and tickets opening in GLPI.
 == Installation
 
 * Your Rudder server must have python-requests and python-configparser
-installed.
+installed. (either by your favorite package manager or python module installer)
 * Install the package on the Rudder server :
   `/opt/rudder/bin/rudderpkg install-file <plugin>.rpkg`
 * Edit the configuration file in `/opt/rudder/etc/notify.conf`. This

--- a/notify/packaging/metadata
+++ b/notify/packaging/metadata
@@ -5,7 +5,7 @@
   "build-date": "${maven.build.timestamp}",
   "build-commit": "${commit-id}",
   "depends": {
-    "binary": [ "python-configparser"
+    "python": [ "python-configparser"
               , "python-requests"
               ]
   },


### PR DESCRIPTION
https://issues.rudder.io/issues/13924