### PR TITLE
Fixes #15249: Add set -e to qa-test in order to force its failure when a test is not passed

### DIFF
--- a/qa-test
+++ b/qa-test
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -e
 
 find . -name '*.py' | grep -v share/python | grep -v zabbix | xargs -r pylint -E --disable=C,R,undefined-variable  --persistent=n --init-hook="sys.path[0:0] = ['./centreon/share/python']"


### PR DESCRIPTION
https://issues.rudder.io/issues/15249