### PR TITLE
Fixes #17160: On high load after a reboot, generation fails because scale-out-relay not OK

### DIFF
--- a/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/ScaleOutRelayPluginDef.scala
+++ b/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/ScaleOutRelayPluginDef.scala
@@ -43,7 +43,10 @@ class ScalaOutRelayPluginDef(override val status: PluginStatus) extends DefaultP
 
   override val basePackage = "com.normation.plugins.scaleoutrelay"
 
-  def init = {}
+  def init = {
+    // check that the plugin is enable to workaround #17160
+    ScalaOutRelayLogger.info(s"Checking for plugin status: ${if(status.isEnabled()) "enabled" else "disabled"}")
+  }
 
   def oneTimeInit : Unit = {}
 


### PR DESCRIPTION
https://issues.rudder.io/issues/17160