### PR TITLE
Fixes #18248: rudder-api-client should be a dependency of CIS

### DIFF
--- a/cis/packaging/metadata
+++ b/cis/packaging/metadata
@@ -4,6 +4,10 @@
   "version": "${plugin-version}",
   "build-date": "${maven.build.timestamp}",
   "build-commit": "${commit-id}",
+  "depends": {
+    "apt": [ "rudder-api-client" ],
+    "rpm": [ "rudder-api-client" ]
+  },
   "content": {
     "files.txz": "/var/rudder/",
     "configuration.txz": "/var/rudder/packages/${plugin-id}/"


### PR DESCRIPTION
https://issues.rudder.io/issues/18248