### PR TITLE
Fixes #19182: Change validation details page is not accessible anymore when a Node group query has been modified

### DIFF
--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestChangesForm.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestChangesForm.scala
@@ -56,7 +56,7 @@ import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.parameters._
 import com.normation.rudder.domain.policies._
-import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.domain.queries.QueryTrait
 import com.normation.rudder.domain.workflows._
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.rule.category.RuleCategory
@@ -448,7 +448,7 @@ class ChangeRequestChangesForm(
         diff          : ModifyNodeGroupDiff
       , group         : NodeGroup
   ) = {
-    def displayQuery(query:Option[Query]) = query match {
+    def displayQuery(query:Option[QueryTrait]) = query match {
         case None => "None"
         case Some(q) => q.toJSONString
       }

--- a/main-build.conf
+++ b/main-build.conf
@@ -23,5 +23,5 @@ lib-common-private=1.3
 
 # Version of Rudder used to build the plugin.
 # It defined the API/ABI used and it is important for binary compatibility
-rudder-build-version=6.2.0
+rudder-build-version=6.2.6
 rudder-build-version-nightly=6.2.7-SNAPSHOT


### PR DESCRIPTION
https://issues.rudder.io/issues/19182