### PR TITLE
Fixes #20778: Add Oauth2/openid connect backend

### DIFF
--- a/auth-backends/README.adoc
+++ b/auth-backends/README.adoc
@@ -12,7 +12,23 @@ other general information.
 
 = Authentication backends
 
-This plugins allows to use alternative authentication backends for Rudder: LDAP/AD and radius.
+This plugins allows to use alternative authentication backends for Rudder: SAMLv2/OpenID Connect, LDAP/AD and radius (DEPRECATED).
+
+Each authentication method is detailed below. Users are expected to know how an authentication system works independently from Rudder to configure it in Rudder: you will likely need authentication token, URLs, and other properties provided by your company.
+
+== Configure login form rendering
+
+By default, the standard Rudder login form is displayed. SSO backends like OpenID Connect ones add links to the relevant SSO own login page below that Rudder login form. When you use such an authentication method, you want to hide or totaly remove Rudder own login form to avoid to confuse you user. For that, you can use the following property:
+
+```
+rudder.auth.displayLoginForm=show
+```
+
+Possible values are:
+
+* `show` [default]: show Rudder login form as usual
+* `hide`: hide the login form below a toggle button. This is a good option if you want to let your user only see SSO links by default, but still have access to the login form for special cases (like, typically, for emergency admin access when the SSO or network to it is down)
+* `remove`: completly remove Rudder login form.
 
 == Configure enabled backends
 
@@ -60,7 +76,7 @@ systemctl restart rudder-jetty
 =====
 
 
-For example, to use first and `ldap` authentication, and then in case the user is not found
+For example, to use first an `ldap` authentication, and then in case the user is not found
 in `ldap`, fall-back in file authentication, you will specify:
 
 
@@ -82,6 +98,13 @@ For example, that `rudder-users.xml` file will configure "admin" by file access,
 ======
 
 Be careful to have only one `rudder.auth.provider` property in your file!
+
+======
+
+[WARNING]
+======
+
+If an error happened in one of the authentication modules, the following in the provider sequence won't be tried.
 
 ======
 
@@ -260,7 +283,95 @@ To correct that problem, you need to remove that restriction (and update your ce
   * `jdk.certpath.disabledAlgorithms`
 * restart `rudder-jetty`
 
-== Radius backend configuration
+=== OAUTHv2 / OpenID Connect
+
+https://openid.net/connect/[OpenID Connect] (OIDC) is a very common SSO protocol to authenticate and manage authorizations of users in a decentralized, multi-tenant set-up (ie, typically web applications nowadays). It's built on top of `OAUTHv2` and replace it in most new cases.
+
+These protocols delegate the actual authentication to an identity provider (IdP) that in turns send the relevant authentication information to the client, i.e. to Rudder in our case. These `IdP` can be public providers, like https://google.com[Google], deployed and managed internally in a company, like ForgeRock's open source https://forgerock.github.io/openam-community-edition/[OpenAM], or used as SaaS, like https://okta.com[Okta] - and often, providers do a mix of these things.
+
+Rudder support plain old `OAUTHv2` and `OpentID Connect`. They have several normalized scenario and Rudder supports the most common for a web application server side authentication: https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authentication using Authorization Code Flow].
+
+You can configure several providers at the same time.
+The are defined by an identifier in a comma-separated list in the following property:
+
+```
+rudder.auth.oauth2.provider.registrations=okta,google
+```
+
+
+Each provider needs to then have a bunch of properties defined for it. They are listed below and all follow the pattern `rudder.auth.oauth2.provider.${providerID}.${subPath} where `providerId` is the ID in the previous list, and `subPath` is the remaining name of the property.
+
+In the next below description, we use `okta` as a provider. We chose this one because OAUTHv2/OpenID Connect configuration can be a bit complicated and full of jargon, and so having a real, well documented reference is helpful - and https://developer.okta.com/docs/guides/implement-grant-type/authcode/main/#next-steps[Okta provides that].
+
+```
+# The provider name as it will be displayed in Rudder authentication page (and logs)
+rudder.auth.oauth2.provider.okta.name=Okta
+# A more detailed explanation message displayed near the provider name in authentication page.
+rudder.auth.oauth2.provider.okta.ui.infoMessage=OpenID Connect SSO (Okta)
+
+# In Oauth2/OIDC, a client (ie, Rudder) is identifier by a pair of credentials:
+# - 1/ an id,
+# - 2/ a corresponding secret key.
+#
+# 1/ Identifier of the application you created in your IdP for Rudder.
+#    In Okta, it will be listed under https://xxxx-admin.okta.com/admin/apps/active
+#    once you created it with "Create App Integration". If you click on your application,
+#    it's located in "Client Credential > Client ID".
+#
+rudder.auth.oauth2.provider.okta.client.id=0oa3snkopsIRIIHb35d7
+#
+# 2/ The corresponding "client secret", available when you click on your application
+#    in https://xxxx-admin.okta.com/admin/apps/active in "Client Credential > Client Secret"
+rudder.auth.oauth2.provider.okta.client.secret=-0Q5jGbdvV5WkfGNJwHfkOP0FdZ5vhqPYav7icYb
+#
+# Names the OAUTHv2 "realm" that should be included in the identity token once
+# authentication is done. These information should be documented by your IdP documentation.
+# Rudder only need to have at least the attribute that will be used for `userId` (see next
+# property)
+rudder.auth.oauth2.provider.okta.scope=openid, email, profile
+#
+# The attribute that will be used for `userId` (generally, it's either a login or email).
+# The value of that attribute will be used to retrieved Rudder internal user, its rights, etc.
+rudder.auth.oauth2.provider.okta.userNameAttributeName=email
+#
+# The next 4 URLs are the redirection URLs towards the IdP and which correspdonds to
+# each step of the authentication process (yes, the protocol does a lot of redirection):
+# - `uri.auth`: first URL, Rudder ask for a code request. User is then redirected by
+#    the IdP towards its own login form. It then redirect to Rudder with a code to process.
+# - `uri.token`: Rudder returned the code processed with its client secret. The IdP process it
+     and return an authentication token to Rudder.
+# - `uri.userInfo`: Rudder uses the authentication token to get user information on that URL
+# - `uri.jwkSet`: in the case of OIDC, the token is a signed JWT token. That last url is the
+#   URL where Rudder can get the IdP public key to sign the token.
+rudder.auth.oauth2.provider.okta.uri.auth=https://xxxx.okta.com/oauth2/v1/authorize
+rudder.auth.oauth2.provider.okta.uri.token=https://xxxx.okta.com/oauth2/v1/token
+rudder.auth.oauth2.provider.okta.uri.userInfo=https://xxxx.okta.com/oauth2/v1/userinfo
+rudder.auth.oauth2.provider.okta.uri.jwkSet=https://xxxx.okta.com/oauth2/v1/keys
+#
+# The following properties are necessary for each provider configuration but should not be modified.
+#
+# The protocol scheme used for authentication - Rudder only supports with authorisation code.
+rudder.auth.oauth2.provider.okta.grantType=authorization_code
+# Rudder URL towards which the identity provider redirects
+rudder.auth.oauth2.provider.okta.client.redirect={baseUrl}/login/oauth2/code/{registrationId}
+# Authentication type - Rudder only supports basic.
+rudder.auth.oauth2.provider.okta.authMethod=basic
+```
+
+
+=== Radius backend
+
+[WARNING]
+=====
+
+Radius backend is deprecated as of Rudder 7.0. It will be removed in a 
+next version of Rudder. 
+You should try to replace it with an other backend. In case that backend is
+a must have for you, please contact Rudder company for discussing how to help
+you migrate away of Radius of get specific support for it.
+
+=====
+
 
 Below follow the configuration properties that need to be added in
 `/opt/rudder/etc/rudder-web.properties` file to configure the Radius

--- a/auth-backends/pom-template.xml
+++ b/auth-backends/pom-template.xml
@@ -60,12 +60,55 @@
           <artifactId>commons-logging</artifactId>
           <groupId>commons-logging</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>spring-context</artifactId>
+          <groupId>org.springframework</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>net.jradius</groupId>
       <artifactId>jradius-dictionary</artifactId>
       <version>1.1.5</version>
+    </dependency>
+    <!-- Needed for OICD / OAUTH2 -->
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-core</artifactId>
+      <version>${spring-security-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-client</artifactId>
+      <version>${spring-security-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-jose</artifactId>
+      <version>${spring-security-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- undeclared needed dependency -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+       <version>2.12.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>8.22</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/auth-backends/src/main/resources/applicationContext-security-auth-oauth2.xml
+++ b/auth-backends/src/main/resources/applicationContext-security-auth-oauth2.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2022 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+In accordance with the terms of section 7 (7. Additional Terms.) of
+the GNU Affero GPL v3, the copyright holders add the following
+Additional permissions:
+Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+licence, when you create a Related Module, this Related Module is
+not considered as a part of the work and may be distributed under the
+license agreement of your choice.
+A "Related Module" means a set of sources files including their
+documentation that, without modification of the Source Code, enables
+supplementary functions or services in addition to those offered by
+the Software.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+-->
+
+<!-- do not delete - this is the empty configuration file for spring bean for rootAdmin backend -->
+
+<beans:beans xmlns="http://www.springframework.org/schema/security"
+    xmlns:beans="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-5.3.xsd">
+
+
+</beans:beans>

--- a/auth-backends/src/main/resources/applicationContext-security-auth-oidc.xml
+++ b/auth-backends/src/main/resources/applicationContext-security-auth-oidc.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2022 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+In accordance with the terms of section 7 (7. Additional Terms.) of
+the GNU Affero GPL v3, the copyright holders add the following
+Additional permissions:
+Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+licence, when you create a Related Module, this Related Module is
+not considered as a part of the work and may be distributed under the
+license agreement of your choice.
+A "Related Module" means a set of sources files including their
+documentation that, without modification of the Source Code, enables
+supplementary functions or services in addition to those offered by
+the Software.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+-->
+
+<!-- do not delete - this is the empty configuration file for spring bean for rootAdmin backend -->
+
+<beans:beans xmlns="http://www.springframework.org/schema/security"
+    xmlns:beans="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-5.3.xsd">
+
+
+</beans:beans>

--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -37,20 +37,73 @@
 
 package bootstrap.rudder.plugin
 
-import bootstrap.liftweb.AuthBackendsProvider
-import bootstrap.liftweb.RudderConfig
-import bootstrap.liftweb.RudderProperties
 import com.normation.plugins.RudderPluginModule
+import com.normation.plugins.authbackends.AuthBackendsLogger
 import com.normation.plugins.authbackends.AuthBackendsPluginDef
 import com.normation.plugins.authbackends.AuthBackendsRepository
 import com.normation.plugins.authbackends.CheckRudderPluginEnableImpl
+import com.normation.plugins.authbackends.LoginFormRendering
+import com.normation.plugins.authbackends.RudderPropertyBasedOAuth2RegistrationDefinition
 import com.normation.plugins.authbackends.api.AuthBackendsApiImpl
+import com.normation.plugins.authbackends.snippet.Oauth2LoginBanner
+import com.normation.rudder.domain.logger.PluginLogger
+import com.normation.rudder.web.services.RudderUserDetail
+
+import bootstrap.liftweb.AuthBackendsProvider
+import bootstrap.liftweb.RudderConfig
+import bootstrap.liftweb.RudderInMemoryUserDetailsService
+import bootstrap.liftweb.RudderProperties
+import com.typesafe.config.ConfigException
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationProvider
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient
+import org.springframework.security.oauth2.client.oidc.authentication.OidcAuthorizationCodeAuthenticationProvider
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter
+import org.springframework.security.oauth2.core.oidc.OidcIdToken
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority
+import org.springframework.security.web.DefaultSecurityFilterChain
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+
+import java.util
+
+import com.normation.zio._
 
 
 /*
  * Actual configuration of the plugin logic
  */
 object AuthBackendsConf extends RudderPluginModule {
+  /*
+   * property name to do what to know with the login form:
+   */
+  val DISPLAY_LOGIN_FORM_PROP = "rudder.auth.displayLoginForm"
 
   // Radius client WARN about a lot of things, which produce very long stack trace with rudder.
   // If the user didn't explicitly set level, change it to error. User is still able to change
@@ -76,6 +129,13 @@ object AuthBackendsConf extends RudderPluginModule {
   }
 
   RudderConfig.authenticationProviders.addProvider(authBackendsProvider)
+  RudderConfig.authenticationProviders.addProvider(new AuthBackendsProvider() {
+    override def authenticationBackends: Set[String] = Set("oauth2", "oidc")
+    override def name: String = s"Oauth2 and OpenID Connect authentication backends provider: '${authenticationBackends.mkString("','")}"
+    override def allowedToUseBackend(name: String): Boolean = pluginStatusService.isEnabled
+  })
+
+  lazy val oauth2registrations = RudderPropertyBasedOAuth2RegistrationDefinition.make().runNow
 
   lazy val pluginDef = new AuthBackendsPluginDef(AuthBackendsConf.pluginStatusService)
 
@@ -83,4 +143,219 @@ object AuthBackendsConf extends RudderPluginModule {
       RudderConfig.restExtractorService
     , new AuthBackendsRepository(RudderConfig.authenticationProviders, RudderProperties.config)
   )
+
+  lazy val loginFormRendering = try {
+    LoginFormRendering.parse(RudderProperties.config.getString(DISPLAY_LOGIN_FORM_PROP)) match {
+      case Right(v)  => v
+      case Left(err) =>
+        PluginLogger.warn(s"Error for property '${DISPLAY_LOGIN_FORM_PROP}': ${err}")
+    }
+  } catch {
+    case ex: ConfigException => // if not defined, default to "show"
+      LoginFormRendering.Show
+  }
+
+  // oauth2 button on login page
+  RudderConfig.snippetExtensionRegister.register(new Oauth2LoginBanner(pluginStatusService, pluginDef.version, oauth2registrations))
+
+}
+
+
+/*
+ * Entry point for spring. Because we love factories!
+ */
+@Configuration
+class AuthBackendsSpringConfiguration extends ApplicationContextAware {
+
+  /*
+   * Manually create the update security filter chain to include OAUTH2/OIDC related filters.
+   *
+   * Here, the correct solution would likely be to use a code-base
+   * configuration in place of applicationContext-security.xml,
+   * and provide a hook in the `HttpSecurity` configurer to let plugins
+   * add their configuration. Everything would be so much easier.
+   * Since we don't have that code base config, we need to:
+   * - all the (oauth2, oidc)AuthenticationProvider by hand in rudder (since we don't have an xml file for them)
+   * - build filter by hand. To know what to do and avoid NPEs, we look how it's done in the code configurer class
+   * - hi-jack the main security filter, declared in applicationContext-security.xml, update the list of filters,
+   *   and put it back into spring.
+   */
+  var appContext: ApplicationContext = null
+  override def setApplicationContext(applicationContext: ApplicationContext): Unit = {
+    // create the two OAUTH2 filters that are going to be added in the filter chain.
+    // logic copy/pasted from OAuth2LoginConfigurer init and configure methods
+    def createFilters(rudderUserDetailsService: RudderInMemoryUserDetailsService) = {
+      val authenticationFilter: OAuth2LoginAuthenticationFilter = new OAuth2LoginAuthenticationFilter(
+        clientRegistrationRepository, authorizedClientRepository, loginProcessingUrl
+      )
+
+      val authorizationRequestFilter = new OAuth2AuthorizationRequestRedirectFilter(authorizationRequestResolver)
+      authorizationRequestFilter.setAuthorizationRequestRepository(authorizationRequestRepository)
+      // request cache ?
+      // authorizationRequestFilter.setRequestCache( ??? )
+
+      authenticationFilter.setFilterProcessesUrl(loginProcessingUrl)
+      authenticationFilter.setAuthorizationRequestRepository(authorizationRequestRepository)
+      authenticationFilter.setAuthenticationSuccessHandler(rudderOauth2AuthSuccessHandler)
+
+      (authorizationRequestFilter, authenticationFilter)
+    }
+
+
+    appContext = applicationContext
+
+    val http = appContext.getBean("mainHttpSecurityFilters", classOf[DefaultSecurityFilterChain])
+
+    val rudderUserService = appContext.getBean("rudderUserDetailsService", classOf[RudderInMemoryUserDetailsService])
+    val (oAuth2AuthorizationRequestRedirectFilter, oAuth2LoginAuthenticationFilter) = createFilters(rudderUserService)
+
+    // add authentication providers to rudder list
+
+    RudderConfig.authenticationProviders.addSpringAuthenticationProvider("oauth2", oauth2AuthenticationProvider(rudderUserService))
+    RudderConfig.authenticationProviders.addSpringAuthenticationProvider("oidc", oidcAuthenticationProvider(rudderUserService))
+    val manager = appContext.getBean("org.springframework.security.authenticationManager", classOf[AuthenticationManager])
+    oAuth2LoginAuthenticationFilter.setAuthenticationManager(manager)
+
+    val filters = http.getFilters
+    filters.add(3, oAuth2AuthorizationRequestRedirectFilter)
+    filters.add(4, oAuth2LoginAuthenticationFilter)
+    val newSecurityChain = new DefaultSecurityFilterChain(http.getRequestMatcher, filters)
+
+    appContext.getAutowireCapableBeanFactory.configureBean(newSecurityChain, "mainHttpSecurityFilters")
+  }
+
+
+
+  @Bean def rudderOauth2AuthSuccessHandler: AuthenticationSuccessHandler = new SimpleUrlAuthenticationSuccessHandler("/secure/index.html")
+
+  /**
+   * We read configuration for OIDC providers in rudder config files.
+   * The format is defined in
+   */
+  @Bean def clientRegistrationRepository: ClientRegistrationRepository = {
+    val registrations = (for {
+        _ <- AuthBackendsConf.oauth2registrations.updateRegistration(RudderProperties.config)
+        r <- AuthBackendsConf.oauth2registrations.registrations.get
+      } yield {
+        r.toMap
+      }).runNow
+    if(registrations.isEmpty) {
+      AuthBackendsLogger.error(s"No registration configured, please disable OAUTH2 provider or correct registration")
+    }
+
+    new ClientRegistrationRepository {
+      val map = registrations
+      override def findByRegistrationId(registrationId: String): ClientRegistration = {
+        map.get(registrationId) match {
+          case None    => null
+          case Some(x) => x.registration
+        }
+      }
+    }
+  }
+
+  /**
+   * We don't use rights provided by spring, nor the one provided by OAUTH2, so
+   * alway map user to role `ROLE_USER`
+   */
+  @Bean def userAuthoritiesMapper = {
+    import scala.jdk.CollectionConverters._
+
+    new GrantedAuthoritiesMapper {
+      override def mapAuthorities(authorities: util.Collection[_ <: GrantedAuthority]): util.Collection[_ <: GrantedAuthority] = {
+        authorities.asScala.flatMap {
+          case _: OidcUserAuthority | _: OAuth2UserAuthority =>
+            Some(new SimpleGrantedAuthority("ROLE_USER"))
+          case _ => None //ignore, no granted authority for it
+        }
+      }.asJavaCollection
+    }
+  }
+
+
+  /**
+   *  Retrieve rudder user based on information provided in the oidc token.
+   *  Create an hybride Oidc/Rudder UserDetails.
+   */
+  @Bean def oidcUserService(rudderUserDetailsService: RudderInMemoryUserDetailsService): OidcUserService = {
+    new OidcUserService() {
+      override def loadUser(userRequest: OidcUserRequest): OidcUser = {
+        val user = super.loadUser(userRequest)
+
+        // check that we know that user in our DB
+        val rudderUser = rudderUserDetailsService.loadUserByUsername(user.getUserInfo.getPreferredUsername)
+
+        new RudderOidcDetails(user, rudderUser)
+      }
+    }
+  }
+
+  @Bean def oauth2UserService(rudderUserDetailsService: RudderInMemoryUserDetailsService): OAuth2UserService[OAuth2UserRequest, OAuth2User] = {
+    val defaultUserService = new DefaultOAuth2UserService()
+
+    new OAuth2UserService[OAuth2UserRequest, OAuth2User]() {
+      override def loadUser(userRequest: OAuth2UserRequest): OAuth2User = {
+        val user = defaultUserService.loadUser(userRequest)
+
+        // check that we know that user in our DB
+        val rudderUser = rudderUserDetailsService.loadUserByUsername(user.getName)
+
+        new RudderOauth2Details(user, rudderUser)
+      }
+    }
+  }
+
+  // following beans are the detault one provided by spring security for oauth2 logic
+
+  val authorizationRequestBaseUri = "/oauth2/authorization"
+  val loginProcessingUrl = "/login/oauth2/code/*"
+
+  @Bean def authorizationRequestResolver = new DefaultOAuth2AuthorizationRequestResolver(
+    clientRegistrationRepository, authorizationRequestBaseUri
+  )
+
+  @Bean def authorizedClientRepository: OAuth2AuthorizedClientRepository =
+    new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(authorizedClientService)
+
+  @Bean def authorizedClientService: OAuth2AuthorizedClientService =
+    new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository)
+
+  @Bean def authorizationRequestRepository = new HttpSessionOAuth2AuthorizationRequestRepository()
+
+  @Bean def rudderAuthorizationCodeTokenResponseClient() = {
+    new DefaultAuthorizationCodeTokenResponseClient()
+  }
+
+  @Bean def jwtDecoderFactory = new OidcIdTokenDecoderFactory()
+
+  @Bean def oauth2AuthenticationProvider(rudderUserDetailsService: RudderInMemoryUserDetailsService) = {
+    val x = new OAuth2LoginAuthenticationProvider(rudderAuthorizationCodeTokenResponseClient(), oauth2UserService(rudderUserDetailsService))
+    x.setAuthoritiesMapper(userAuthoritiesMapper)
+    x
+  }
+
+  @Bean def oidcAuthenticationProvider(rudderUserDetailsService: RudderInMemoryUserDetailsService): OidcAuthorizationCodeAuthenticationProvider = {
+    val x = new OidcAuthorizationCodeAuthenticationProvider(
+      rudderAuthorizationCodeTokenResponseClient(),
+      oidcUserService(rudderUserDetailsService)
+    )
+    x.setJwtDecoderFactory(jwtDecoderFactory)
+    x.setAuthoritiesMapper(userAuthoritiesMapper)
+    x
+  }
+}
+
+// a couple of dedicated user details that have the needed information for the SSO part
+
+final class RudderOidcDetails(oidc: OidcUser, rudder: RudderUserDetail) extends RudderUserDetail(rudder.account, rudder.roles, rudder.apiAuthz) with OidcUser {
+  override def getClaims: util.Map[String, AnyRef] = oidc.getClaims
+  override def getUserInfo: OidcUserInfo = oidc.getUserInfo
+  override def getIdToken: OidcIdToken = oidc.getIdToken
+  override def getAttributes: util.Map[String, AnyRef] = oidc.getAttributes
+  override def getName: String = oidc.getName
+}
+
+final class RudderOauth2Details(oauth2: OAuth2User, rudder: RudderUserDetail) extends RudderUserDetail(rudder.account, rudder.roles, rudder.apiAuthz) with OAuth2User {
+  override def getAttributes: util.Map[String, AnyRef] = oauth2.getAttributes
+  override def getName: String = oauth2.getName
 }

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/Oauth2Authentication.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/Oauth2Authentication.scala
@@ -1,0 +1,236 @@
+/*
+*************************************************************************************
+* Copyright 2021 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.plugins.authbackends
+
+import com.normation.errors._
+import com.typesafe.config.Config
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod
+import zio._
+import zio.syntax._
+
+/**
+ * This file contain logic related to Oauth2/OpenID Connect authentication and
+ * user data sharing.
+ *
+ * In spring security, Oauth2 is implemented in a dedicated filter that
+ * intercept request before other authentication methods (the exact order is
+ * defined in: https://docs.spring.io/spring-security/site/docs/5.3.9.RELEASE/reference/html5/#servlet-security-filters)
+ *
+ * It requires registration to oauth2 services as a client, and several oauth2
+ * services can be configured: this is contractualized by implementing the `InMemoryOAuth2AuthorizedClientService` trait
+ * In our case, the configuration is done in the rudder property configuration file, and
+ * we just parse the different client and register them in an in memory immutable map.
+ *
+ * The other important aspect is the identifier used to match the user on the oauth service.
+ * For now, that identifier must be use as login in rudder.
+ *
+ */
+
+/*
+ * Data container class to add our properties to spring ClientRegistration ones
+ */
+final case class RudderClientRegistration(registration: ClientRegistration, infoMsg: String)
+
+/*
+ * Client registration definition based on rudder property file:
+ * - read property `rudder.auth.oauth2.client.registrations` which give a comma-separated
+ *   list of client registration to oauth2 providers
+ * - for each registration, read the needed properties based on template
+ *   `rudder.auth.oauth2.client.${registration}.${propertyName}`
+ */
+object RudderPropertyBasedOAuth2RegistrationDefinition {
+
+  val A_NAME            = "name"
+  val A_CLIENT_ID       = "client.id"
+  val A_CLIENT_SECRET   = "client.secret"
+  val A_CLIENT_REDIRECT = "client.redirect"
+  val A_AUTH_METHOD     = "authMethod"
+  val A_GRANT_TYPE      = "grantType"
+  val A_INFO_MESSAGE    = "ui.infoMessage"
+  val A_SCOPE           = "scope"
+  val A_URI_AUTH        = "uri.auth"
+  val A_URI_TOKEN       = "uri.token"
+  val A_URI_USER_INFO   = "uri.userInfo"
+  val A_URI_JWK_SET     = "uri.jwkSet"
+  val A_PIVOT_ATTR      = "userNameAttributeName"
+
+  val authMethods = {
+    import ClientAuthenticationMethod._
+    List(BASIC, POST, NONE)
+  }
+
+  val grantTypes = {
+    import AuthorizationGrantType._
+    List(AUTHORIZATION_CODE, REFRESH_TOKEN, CLIENT_CREDENTIALS, PASSWORD) // IMPLICIT is deprecated for security reason
+  }
+
+  val baseProperty = "rudder.auth.oauth2.provider"
+
+  val registrationAttributes = Map(
+      A_NAME            -> "human readable name to use in the button 'login with XXXX'"
+    , A_CLIENT_ID       -> "id generated in the Oauth2 service provider to identify rudder as a client app"
+    , A_CLIENT_SECRET   -> "the corresponding secret key"
+    , A_CLIENT_REDIRECT -> "rudder URL to redirect to once authentication is done on the provider (must be resolvable from user bowser)"
+    , A_AUTH_METHOD     -> s"authentication method to use (${authMethods.map(_.getValue).mkString(",")})"
+    , A_GRANT_TYPE      -> s"authorization grant type to use (${grantTypes.map(_.getValue).mkString(",")}"
+    , A_INFO_MESSAGE    -> "message displayed in the login form, for example to tell the user what login he must use"
+    , A_SCOPE           -> "data scope to request access to"
+    , A_URI_AUTH        -> "provider URL to contact for main authentication (see provider documentation)"
+    , A_URI_TOKEN       -> "provider URL to contact for token verification (see provider documentation)"
+    , A_URI_USER_INFO   -> "provider URL to contact to get user information (see provider documentation)"
+    , A_URI_JWK_SET     -> "provider URL to check signature of JWT token (see provider documentation)"
+    , A_PIVOT_ATTR      -> "the attribute used to find local app user"
+  )
+
+
+  def parseAuthenticationMethod(method: String): PureResult[ClientAuthenticationMethod] = {
+    authMethods.find( _.getValue.equalsIgnoreCase(method)) match {
+      case None    => Left(Inconsistency(s"Requested OAUTh2 authentication methods '${method}' is not recognized, please use one of: ${authMethods.map(_.getValue).mkString("'","','","'")}"))
+      case Some(m) => Right(m)
+    }
+  }
+
+  def parseAuthorizationGrantType(grant: String): PureResult[AuthorizationGrantType] = {
+    grantTypes.find( _.getValue.equalsIgnoreCase(grant)) match {
+      case None    => Left(Inconsistency(s"Requested OAUTh2 authorization grant type '${grant}' is not recognized, please use one of: ${grantTypes.map(_.getValue).mkString("'","','","'")}"))
+      case Some(m) => Right(m)
+    }
+  }
+
+  def readOneRegistration(id: String, config: Config): IOResult[RudderClientRegistration] = {
+
+    // utility method that read key in config and fails with an error message if
+    // not found.
+    def read(key: String): IOResult[String] = {
+      val path = baseProperty + "." + id + "." + key
+      IOResult.effect(s"Missing key '${path}' for OAUTH2 registration '${id}' (${registrationAttributes(key)})")(
+        config.getString(path)
+      )
+    }
+    for {
+      name           <- read(A_NAME)
+      clientId       <- read(A_CLIENT_ID)
+      clientSecret   <- read(A_CLIENT_SECRET)
+      clientRedirect <- read(A_CLIENT_REDIRECT)
+      authMethod     <- read(A_AUTH_METHOD).flatMap(parseAuthenticationMethod(_).toIO)
+      grantTypes     <- read(A_GRANT_TYPE).flatMap(parseAuthorizationGrantType(_).toIO)
+      infoMessage    <- read(A_INFO_MESSAGE)
+      scopes         <- read(A_SCOPE).map(_.split(",").map(_.trim))
+      uriAuth        <- read(A_URI_AUTH)
+      uriToken       <- read(A_URI_TOKEN)
+      uriUserInfo    <- read(A_URI_USER_INFO)
+      pivotAttr      <- read(A_PIVOT_ATTR)
+      jwkSetUri      <- read(A_URI_JWK_SET)
+    } yield {
+      RudderClientRegistration(
+        ClientRegistration
+          .withRegistrationId(id)
+          .clientId(clientId)
+          .clientSecret(clientSecret)
+          .clientAuthenticationMethod(authMethod)
+          .authorizationGrantType(grantTypes)
+          .redirectUriTemplate(clientRedirect)
+          .scope(scopes:_*)
+          .authorizationUri(uriAuth)
+          .tokenUri(uriToken)
+          .userInfoUri(uriUserInfo)
+          .userNameAttributeName(pivotAttr)
+          .clientName(name)
+          .jwkSetUri(jwkSetUri)
+          .build()
+        , infoMessage
+      )
+    }
+  }
+
+  def readProviders(config: Config): IOResult[List[String]] = {
+    val path = baseProperty + ".registrations"
+    IOResult.effect(s"Missing property '${path}' which define the comma separated list of provider registration to use for OAUTH2.")(
+      config.getString(path).split(",").map(_.trim).toList
+    )
+  }
+
+  /*
+   * Read the whole set of providers with their registrations.
+   * We return a list to keep the order provided in the config file.
+   */
+  def readAllRegistrations(config: Config): UIO[List[(String, RudderClientRegistration)]] = {
+    for {
+      // we don't want to fail if the list of provider is missing, just log it as a warning
+      providers     <- readProviders(config).catchAll(err => AuthBackendsLoggerPure.warn(err.fullMsg) *> Nil.succeed)
+      // we don't want to fail if one of the registration is not ok, just log it
+      _             <- AuthBackendsLoggerPure.info(s"List of configured providers for oauth2/OpenIDConnect: ${providers.mkString(", ")}")
+      registrations <- ZIO.foreach(providers) { p =>
+                         readOneRegistration(p, config).foldM(
+                             err =>
+                               AuthBackendsLoggerPure.error(s"Error when reading OAUTH2 configuration for registration to '${p}' provider: ${err.fullMsg}'") *>
+                               None.succeed
+                           , res =>
+                               AuthBackendsLoggerPure.debug(s"New registration for provider '${p}': ${res} ") *>
+                               Some((p, res)).succeed
+                         )
+                       }
+    } yield registrations.flatten
+  }
+
+
+  def make(): IOResult[RudderPropertyBasedOAuth2RegistrationDefinition] = {
+    for {
+      ref <- Ref.make(List.empty[(String, RudderClientRegistration)])
+    } yield {
+      new RudderPropertyBasedOAuth2RegistrationDefinition(ref)
+    }
+  }
+
+}
+
+class RudderPropertyBasedOAuth2RegistrationDefinition(val registrations: Ref[List[(String, RudderClientRegistration)]]) {
+  import RudderPropertyBasedOAuth2RegistrationDefinition._
+
+
+  /*
+   * read information from config and update internal cache
+   */
+  def updateRegistration(config: Config): UIO[Unit] = {
+    for {
+      newOnes <- readAllRegistrations(config)
+      _       <- registrations.set(newOnes)
+    } yield ()
+  }
+
+}
+

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/snippet/Oauth2LoginBanner.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/snippet/Oauth2LoginBanner.scala
@@ -1,0 +1,117 @@
+/*
+*************************************************************************************
+* Copyright 2018 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+
+package com.normation.plugins.authbackends.snippet
+
+import com.normation.plugins.PluginExtensionPoint
+import com.normation.plugins.PluginStatus
+import com.normation.plugins.PluginVersion
+import com.normation.plugins.authbackends.LoginFormRendering
+import com.normation.plugins.authbackends.RudderPropertyBasedOAuth2RegistrationDefinition
+import com.normation.rudder.web.snippet.Login
+
+import bootstrap.rudder.plugin.AuthBackendsConf
+import net.liftweb.http.js._
+import JsCmds._
+import JE._
+import net.liftweb.util.Helpers._
+
+import scala.reflect.ClassTag
+import scala.xml.NodeSeq
+
+import com.normation.zio._
+
+
+class Oauth2LoginBanner(val status: PluginStatus, version: PluginVersion, registrations: RudderPropertyBasedOAuth2RegistrationDefinition)(implicit val ttag: ClassTag[Login]) extends PluginExtensionPoint[Login] {
+
+
+  /*
+   * The url on which we need to redirect to get the authentication by oauth2 be triggered
+   */
+  def redirectUrl(registrationId: String): String = {
+    "/oauth2/authorization/" + registrationId
+  }
+
+  def pluginCompose(snippet:Login) : Map[String, NodeSeq => NodeSeq] = Map(
+    "display" -> guard(display(_))
+  )
+
+  def display(xml: NodeSeq): NodeSeq = {
+
+    val rgs = registrations.registrations.get.runNow
+
+    val oauth2providers = if(rgs.nonEmpty) {
+      <div class="col-xs-12">
+        <h4 class="welcome col-xs-12">Log using OAUTH2 provider:</h4>
+        {
+           rgs.map { case (id, r) =>
+            <div class="form-group col-xs-12">
+             <label for="valid" class="sr-only">Sign in with Okta provider</label>
+             <div class="input-group col-xs-12">
+               <a class="btn btn-warning-rudder col-xs-12" href={ redirectUrl(id) } role="button">{ r.infoMsg }</a>
+             </div>
+           </div>
+           }
+        }
+      </div>
+    } else {
+      <div id="oauth2providers">
+        <div class="col-xs-12">
+          <h4 class="welcome col-xs-12">OAUTH2 backend is enabled, but no providers are correctly configured</h4>
+        </div>
+      </div>
+    }
+
+    /*
+     * The form can be
+     */
+    val selector = (
+      "#contact"     #> ((x:NodeSeq) =>  AuthBackendsConf.loginFormRendering match {
+                          case LoginFormRendering.Show   => x
+                          case LoginFormRendering.Hide   =>  // indentation is strange because need to be saw as one xml
+                            Script(OnLoad(JsRaw(""" $ ("#toggleLoginFormButton").click(function() {{ $("#toggleLoginForm").toggle(); }}); """))) ++
+                            <button id="toggleLoginFormButton" class="btn btn-default btn-xs">show non-SSO login form
+                            </button><div id="toggleLoginForm" style="display: none">{x}</div>
+                          case LoginFormRendering.Remove => NodeSeq.Empty
+                        }) &
+      ".form-footer" #> ((x:NodeSeq) =>  oauth2providers++ x)
+    )
+
+    selector(xml)
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/20778

Add the possibility to have an Oauthv2/OIDC (openid connect) SSO authentication in Rudder. 
Under the hood, it uses spring-security module for Oauthv2 (https://docs.spring.io/spring-security/reference/5.7/reactive/oauth2/index.html). 
The main difficulties is that contrary to other existing backend, Oauthv2 is a change in the list of security filter chain, not a new authentication "data base" for the web authentication filter. 
So we need to hack existing chain (configured in main rudder) and hand-build missing filters for oauth/oidc and but them back at the correct place. This is complicated. It's done in `AuthBackendsConf.scala` in `AuthBackendsSpringConfiguration`.

In that class: 
- we read and update existing filter chain in `setApplicationContext` method (spring method for "do stuff with spring stuff, even the goriest one that would not be allowed elsewhere")
- all `@Bean` below are just the need plumbing to build by hand what spring would do with the `<oauth>` smart tag, that we can't use, because we can't "inject" xml config file once the main `<http>` chain is built (we can just add new `<http>` chain, which is useless)
Even with that, we still need `applicationContext-security-auth-oidc.xml` and `applicationContext-security-auth-oauth2.xml` because it's these files that allows our licence system to know if the corresponding "auth backend" are enabled (so, ~ useless for the logic of authenticating users with oauth, needed for plumbing with license check).

We also need to extends what is a `userDetails` because oauth has its own with specific infor related to the protocol (some info can be shared between the identity provider and an application like rudder). 

`Oauth2Authentication.scala` is just for parsing the complicated configuration needed for oauth and build an easy to deal with data structure. You can see an attempt to explain needed configuration properties in the `README.adoc`.

Finally, when we have an Single Sign On solution, we likely don't want to show to standard rudder login form, since, well, you're supposed to log on the identity provider site. But perhaps you still want to show it for emergency (like "no more network with the identity provider"). So there's a new config option with the plugin to either `show`, `hide` (ie hide but available with a toggle button), or `remove` (ie: don't sent the HTML at all) Rudder form. 