### PR TITLE
Fixes #21115: Update dependencies from #21102

### DIFF
--- a/datasources/pom-template.xml
+++ b/datasources/pom-template.xml
@@ -74,22 +74,16 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.17</version>
+      <version>${snakeyaml-version}</version>
       <scope>test</scope>
     </dependency>
 
 
     <!-- Tests: a rest server -->
     <dependency>
-      <groupId>org.http4s</groupId>
-      <artifactId>http4s-dsl_${scala-binary-version}</artifactId>
-      <version>${http4s-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.http4s</groupId>
-      <artifactId>http4s-blaze-server_${scala-binary-version}</artifactId>
-      <version>${http4s-version}</version>
+      <groupId>io.d11</groupId>
+      <artifactId>zhttp_${scala-binary-version}</artifactId>
+      <version>${zhttp-version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/datasources/src/test/resources/logback-test.xml
+++ b/datasources/src/test/resources/logback-test.xml
@@ -37,11 +37,9 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <Pattern>%d{[yyyy-MM-dd HH:mm:ss]} %-5level %logger - %msg%n%xEx{0}</Pattern>
     </encoder>
   </appender>
-  
+
   <root level="warn">
     <appender-ref ref="STDOUT" />
   </root>
-  
-  <logger name="org.http4s.blaze.channel.ServerChannelGroup" level="warn" />
- 
+
 </configuration>

--- a/helloworld/src/main/scala/bootstrap/rudder/plugin/HelloWorldConf.scala
+++ b/helloworld/src/main/scala/bootstrap/rudder/plugin/HelloWorldConf.scala
@@ -6,6 +6,8 @@ import com.normation.plugins.helloworld.HelloWorldPluginDef
 import com.normation.plugins.helloworld.CheckRudderPluginEnableImpl
 import com.normation.plugins.helloworld.extension.{CreateRuleEditFormExtension, CreateRuleExtension}
 import com.normation.plugins.helloworld.service.LogAccessInDb
+import com.normation.utils.ParseVersion
+
 import bootstrap.liftweb.RudderConfig
 import net.liftweb.common.Loggable
 
@@ -44,7 +46,8 @@ object Module1 extends Loggable with RudderPluginModule {
     val status = new PluginEnableImpl(){}
     val name = PluginName("rudder-plugin-module1")
     val shortName = "module1"
-    val version = PluginVersion(0,0,1)
+    // version parsing error are not handled
+    val version = PluginVersion(ParseVersion.parse("7.0.0").getOrElse(???), ParseVersion.parse("0.0.1").getOrElse(???))
     val versionInfo = None
     val basePackage = "com.normation.plugins.helloworld"
     val description : NodeSeq  = Text {

--- a/main-build.conf
+++ b/main-build.conf
@@ -15,7 +15,7 @@
 # Only rudder branch is defined here.
 # Version of Rudder used to build the plugin.
 # It defined the API/ABI used and it is important for binary compatibility
-branch-type=nightly
-rudder-version=7.1.0
-common-version=2.0.0
+branch-type=next
+rudder-version=7.2.0~alpha1
+common-version=2.1.0
 private-version=2.1.0

--- a/plugins-common/pom-template.xml
+++ b/plugins-common/pom-template.xml
@@ -174,8 +174,8 @@
     </dependency>
 
     <!-- from rudder-web: use:
-      mvn dependency:resolve -Dsort=true | grep "compile\|provided" | awk '{print $2}' | \
-        awk -F':' '{print "<dependency><groupId>"$1"</groupId><artifactId>"$2"</artifactId><scope>provided</scope></dependency>"}'
+    mvn dependency:resolve | grep "compile\|provided" | awk '{print $2}' | \
+     awk -F':' '{print "<dependency><groupId>"$1"</groupId><artifactId>"$2"</artifactId><scope>provided</scope></dependency>"}' | sort -u
     -->
     <dependency><groupId>antlr</groupId><artifactId>antlr</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>ca.mrvisser</groupId><artifactId>sealerate_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
@@ -184,19 +184,25 @@
     <dependency><groupId>co.fs2</groupId><artifactId>fs2-core_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>co.fs2</groupId><artifactId>fs2-io_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.chuusai</groupId><artifactId>shapeless_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>com.comcast</groupId><artifactId>ip4s-core_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.alonsodomin.cron4s</groupId><artifactId>cron4s-core_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.ben-manes.caffeine</groupId><artifactId>caffeine</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.ghik</groupId><artifactId>silencer-lib_${scala-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.pathikrit</groupId><artifactId>better-files_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>com.github.scopt</groupId><artifactId>scopt_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.seancfoley</groupId><artifactId>ipaddress</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.google.code.findbugs</groupId><artifactId>jsr305</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.google.errorprone</groupId><artifactId>error_prone_annotations</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.googlecode.javaewah</groupId><artifactId>JavaEWAH</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.ibm.icu</groupId><artifactId>icu4j</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>com.google.errorprone</groupId><artifactId>error_prone_annotations</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.jayway.jsonpath</groupId><artifactId>json-path</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.lihaoyi</groupId><artifactId>fastparse_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.lihaoyi</groupId><artifactId>geny_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.lihaoyi</groupId><artifactId>sourcecode_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>commons-codec</groupId><artifactId>commons-codec</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>commons-fileupload</groupId><artifactId>commons-fileupload</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>commons-io</groupId><artifactId>commons-io</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>com.normation</groupId><artifactId>scala-ldap</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>com.normation</groupId><artifactId>utils</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.normation.inventory</groupId><artifactId>inventory-api</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.normation.inventory</groupId><artifactId>inventory-fusion</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.normation.inventory</groupId><artifactId>inventory-provisioning-core</artifactId><scope>provided</scope></dependency>
@@ -204,8 +210,6 @@
     <dependency><groupId>com.normation.rudder</groupId><artifactId>rudder-core</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.normation.rudder</groupId><artifactId>rudder-rest</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.normation.rudder</groupId><artifactId>rudder-templates</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.normation</groupId><artifactId>scala-ldap</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.normation</groupId><artifactId>utils</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.propensive</groupId><artifactId>magnolia_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.propensive</groupId><artifactId>mercator_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.softwaremill.quicklens</groupId><artifactId>quicklens_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
@@ -214,24 +218,21 @@
     <dependency><groupId>com.unboundid</groupId><artifactId>unboundid-ldapsdk</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.zaxxer</groupId><artifactId>HikariCP</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.zaxxer</groupId><artifactId>nuprocess</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>commons-codec</groupId><artifactId>commons-codec</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>commons-fileupload</groupId><artifactId>commons-fileupload</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>commons-io</groupId><artifactId>commons-io</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect-thirdparty-boopickle-shaded_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect-thirdparty-boopickle-shaded_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>zio-interop-cats_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>zio-json_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>zio-stacktracer_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>zio-streams_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>io.scalaland</groupId><artifactId>chimney_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>javax.servlet</groupId><artifactId>javax.servlet-api</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>joda-time</groupId><artifactId>joda-time</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>net.java.dev.jna</groupId><artifactId>jna</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>net.liftweb</groupId><artifactId>lift-actor_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>net.liftweb</groupId><artifactId>lift-common_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>net.liftweb</groupId><artifactId>lift-json-ext_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>net.liftweb</groupId><artifactId>lift-json_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>net.liftweb</groupId><artifactId>lift-json-ext_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>net.liftweb</groupId><artifactId>lift-markdown_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>net.liftweb</groupId><artifactId>lift-util_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>net.liftweb</groupId><artifactId>lift-webkit_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
@@ -245,8 +246,8 @@
     <dependency><groupId>org.bouncycastle</groupId><artifactId>bcutil-jdk15on</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.checkerframework</groupId><artifactId>checker-qual</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.eclipse.jgit</groupId><artifactId>org.eclipse.jgit</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.graalvm.js</groupId><artifactId>js-scriptengine</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.graalvm.js</groupId><artifactId>js</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.graalvm.js</groupId><artifactId>js-scriptengine</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.graalvm.regex</groupId><artifactId>regex</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.graalvm.sdk</groupId><artifactId>graal-sdk</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.graalvm.truffle</groupId><artifactId>truffle-api</artifactId><scope>provided</scope></dependency>
@@ -260,24 +261,18 @@
     <dependency><groupId>org.ow2.asm</groupId><artifactId>asm</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.reflections</groupId><artifactId>reflections</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scalaj</groupId><artifactId>scalaj-http_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scala-lang</groupId><artifactId>scala-compiler</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scala-lang</groupId><artifactId>scala-library</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scala-lang</groupId><artifactId>scalap</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scala-lang</groupId><artifactId>scala-reflect</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-collection-compat_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-parallel-collections_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-parser-combinators_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-xml_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.scala-lang</groupId><artifactId>scala-compiler</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.scala-lang</groupId><artifactId>scala-library</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.scala-lang</groupId><artifactId>scala-reflect</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.scala-lang</groupId><artifactId>scalap</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.scalaj</groupId><artifactId>scalaj-http_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.scodec</groupId><artifactId>scodec-bits_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.springframework.ldap</groupId><artifactId>spring-ldap-core</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-config</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-core</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-crypto</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-ldap</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-web</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.springframework</groupId><artifactId>spring-aop</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.springframework</groupId><artifactId>spring-beans</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.springframework</groupId><artifactId>spring-context</artifactId><scope>provided</scope></dependency>
@@ -286,14 +281,23 @@
     <dependency><groupId>org.springframework</groupId><artifactId>spring-jcl</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.springframework</groupId><artifactId>spring-tx</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.springframework</groupId><artifactId>spring-web</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.springframework.ldap</groupId><artifactId>spring-ldap-core</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-config</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-core</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-crypto</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-ldap</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-web</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-core_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-free_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-postgres_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.tpolecat</groupId><artifactId>typename_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.typelevel</groupId><artifactId>cats-core_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect-kernel_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect-std_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.typelevel</groupId><artifactId>cats-free_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.typelevel</groupId><artifactId>cats-kernel_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>literally_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.typelevel</groupId><artifactId>simulacrum-scalafix-annotations_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>xerces</groupId><artifactId>xercesImpl</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>xml-apis</groupId><artifactId>xml-apis</artifactId><scope>provided</scope></dependency>


### PR DESCRIPTION
https://issues.rudder.io/issues/21115

Main changes here are:
- update the list of `provided` dependencies. The command needed a little update, perhaps due to changes in mvn plugins. Sorting was impacted.
- remove `http4s`, add `zio-http`. Their API are very, very near, so it was okayish to migrate. 
Notice that `zio-http` seems to be even faster than http4s and much simpler, so we could certainly use that in other tests. 