### PR TITLE
Fixes #21826: Port plugins to ZIO2

### DIFF
--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -284,7 +284,7 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
       } yield {
         r.toMap
       }
-    ).foldM(
+    ).foldZIO(
       err => (if(AuthBackendsConf.isOauthConfiguredByUser) {
                AuthBackendsLoggerPure.error(err.fullMsg)
              } else {

--- a/branding/src/main/scala/com/normation/plugins/branding/BrandingConfService.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/BrandingConfService.scala
@@ -87,11 +87,11 @@ class BrandingConfService(configFilePath: String) {
 
   private def reloadCacheInternal(init: Boolean, ref: Ref[Either[RudderError, BrandingConf]]) : IOResult[BrandingConf] = {
     (for {
-      path   <- IOResult.effect(Paths.get(configFilePath))
-      exists <- IOResult.effect(Files.exists(path))
+      path   <- IOResult.attempt(Paths.get(configFilePath))
+      exists <- IOResult.attempt(Files.exists(path))
       res    <- if(exists) {
                   for {
-                    content <- IOResult.effect(s"Error when trying to read file: ${configFilePath}")(
+                    content <- IOResult.attempt(s"Error when trying to read file: ${configFilePath}")(
                                  File(configFilePath).contentAsString(StandardCharsets.UTF_8)
                                )
                     json    <- parseOpt(content).notOptional("Could nor parse correctly Branding plugin configuration file")
@@ -130,7 +130,7 @@ class BrandingConfService(configFilePath: String) {
     import net.liftweb.json.prettyRender
     val content = prettyRender(BrandingConf.serialize(newConf))
     (for {
-      _ <- IOResult.effect {
+      _ <- IOResult.attempt {
              val path = Paths.get(configFilePath)
              if (!Files.exists(path)) {
                Files.createDirectories(path.getParent)

--- a/branding/src/main/scala/com/normation/plugins/branding/BrandingPluginDef.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/BrandingPluginDef.scala
@@ -48,8 +48,6 @@ import com.normation.plugins.PluginStatus
 import com.normation.plugins.DefaultPluginDef
 import com.normation.rudder.AuthorizationType.Administration
 
-import scala.xml.NodeSeq
-
 class BrandingPluginDef(override val status: PluginStatus) extends DefaultPluginDef {
 
   override val basePackage = "com.normation.plugins.branding"

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeValidationPluginDef.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeValidationPluginDef.scala
@@ -38,7 +38,7 @@
 package com.normation.plugins.changevalidation
 
 import bootstrap.liftweb.{Boot, MenuUtils}
-import bootstrap.liftweb.Boot.{redirection, userIsAllowed}
+import bootstrap.liftweb.Boot.redirection
 import bootstrap.rudder.plugin.ChangeValidationConf
 import com.normation.plugins._
 import com.normation.rudder.AuthorizationType
@@ -61,7 +61,6 @@ import net.liftweb.sitemap.Loc.TestAccess
 import net.liftweb.sitemap.LocPath.stringToLocPath
 import net.liftweb.sitemap.Menu
 
-import scala.xml.NodeSeq
 
 class ChangeValidationPluginDef(override val status: PluginStatus) extends DefaultPluginDef {
 

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowService.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowService.scala
@@ -56,7 +56,7 @@ import com.normation.utils.StringUuidGenerator
 import net.liftweb.common._
 import com.normation.box._
 import com.normation.errors._
-import zio.UIO
+import zio._
 
 
 
@@ -322,7 +322,7 @@ class TwoValidationStepsWorkflowServiceImpl(
                     notificationService.sendNotification(Deployed, cr)
                   case _ =>
                     ChangeValidationLoggerPure.debug(s"Not sending email for update from '${from.id.value}' to '${to.id.value}''") *>
-                    UIO.unit
+                    ZIO.unit
                 }
     } yield ()
   }

--- a/datasources/pom-template.xml
+++ b/datasources/pom-template.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>io.d11</groupId>
       <artifactId>zhttp_${scala-binary-version}</artifactId>
-      <version>${zhttp-version}</version>
+      <version>${zio-http-version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/datasources/src/main/scala/com/normation/plugins/datasources/DataSourcesPluginDef.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/DataSourcesPluginDef.scala
@@ -48,7 +48,6 @@ import net.liftweb.sitemap.Loc.TestAccess
 import net.liftweb.sitemap.LocPath.stringToLocPath
 import net.liftweb.sitemap.Menu
 import com.normation.plugins.PluginStatus
-import com.normation.rudder.AuthorizationType
 import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
 import com.normation.zio._

--- a/datasources/src/main/scala/com/normation/plugins/datasources/DataTypes.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/DataTypes.scala
@@ -45,7 +45,7 @@ import com.typesafe.config.ConfigValue
 import net.liftweb.common.Logger
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
-import zio.duration._
+import zio._
 
 /**
  * Applicative log of interest for Rudder ops.

--- a/datasources/src/main/scala/com/normation/plugins/datasources/Serialization.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/Serialization.scala
@@ -53,7 +53,7 @@ import cats._
 import cats.implicits._
 import com.normation.rudder.domain.properties.GenericProperty._
 import com.typesafe.config.ConfigRenderOptions
-import zio.duration.Duration
+import zio._
 
 object Translate {
   implicit class DurationToScala(d: Duration) {

--- a/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApiImpl.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApiImpl.scala
@@ -80,8 +80,8 @@ import com.normation.plugins.datasources.api.{DataSourceApi => API}
 import com.normation.box._
 import com.normation.rudder.domain.properties.GenericProperty._
 import net.liftweb.json.JsonAST.JArray
-import zio.duration.Duration
 import com.normation.zio._
+import zio._
 
 class DataSourceApiImpl (
     extractor         : RestExtractorService

--- a/datasources/src/test/scala/com/normation/plugins/datasources/api/RestDataSourceTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/api/RestDataSourceTest.scala
@@ -57,7 +57,7 @@ import net.liftweb.json.JsonParser
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
-import zio.duration._
+import zio._
 import com.normation.zio._
 
 
@@ -87,8 +87,7 @@ class RestDataSourceTest extends Specification with Loggable {
     , restTestSetUp.uuidGen
   )
 
-  val apiVersions = ApiVersion(13 , true) :: ApiVersion(14 , false) :: Nil
-  val liftRules = TraitTestApiFromYamlFiles.buildLiftRules(dataSourceApi9 :: Nil, apiVersions, None)
+  val liftRules = TraitTestApiFromYamlFiles.buildLiftRules(dataSourceApi9 :: Nil, restTestSetUp.apiVersions, Some(restTestSetUp.userService))
   val restTest = new RestTest(liftRules._2)
   restTestSetUp.rudderApi.addModules(dataSourceApi9.getLiftEndpoints())
 

--- a/main-build.conf
+++ b/main-build.conf
@@ -13,7 +13,7 @@
 # Only rudder branch is defined here.
 # Version of Rudder used to build the plugin.
 # It defined the API/ABI used and it is important for binary compatibility
-branch-type=nightly
-rudder-version=7.2.1
+branch-type=next
+rudder-version=7.3.0~alpha1
 common-version=2.1.0
 private-version=2.1.0

--- a/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/NodeExternalReportPluginDef.scala
+++ b/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/NodeExternalReportPluginDef.scala
@@ -36,14 +36,13 @@
 
 package com.normation.plugins.nodeexternalreports
 
-import com.normation.rudder.AuthorizationType
 import com.normation.plugins._
 import com.normation.plugins.nodeexternalreports.service.NodeExternalReportApi
-import bootstrap.liftweb.{Boot, ClassPathResource, MenuUtils}
+import bootstrap.liftweb.{ClassPathResource, MenuUtils}
 import net.liftweb.common.Loggable
 import net.liftweb.http.ClasspathTemplates
 import net.liftweb.http.LiftRules
-import net.liftweb.sitemap.Loc.{LocGroup, Template, TestAccess}
+import net.liftweb.sitemap.Loc.{LocGroup, Template}
 import net.liftweb.sitemap.LocPath.stringToLocPath
 import com.normation.plugins.PluginStatus
 import net.liftweb.sitemap.Menu

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/services/ReportSanitizer.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/services/ReportSanitizer.scala
@@ -16,7 +16,7 @@ class ReportSanitizer(policyFile: String) {
     val cr = as.scan(input.content, policy)
 
     for {
-      report <- IOResult.effect (xml.XML.loadString(cr.getCleanHTML))
+      report <- IOResult.attempt (xml.XML.loadString(cr.getCleanHTML))
     } yield {
       report
     }

--- a/plugins-common/pom-template.xml
+++ b/plugins-common/pom-template.xml
@@ -189,7 +189,6 @@
     <dependency><groupId>com.github.ben-manes.caffeine</groupId><artifactId>caffeine</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.ghik</groupId><artifactId>silencer-lib_${scala-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.pathikrit</groupId><artifactId>better-files_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.github.scopt</groupId><artifactId>scopt_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.seancfoley</groupId><artifactId>ipaddress</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.google.code.findbugs</groupId><artifactId>jsr305</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.googlecode.javaewah</groupId><artifactId>JavaEWAH</artifactId><scope>provided</scope></dependency>
@@ -221,6 +220,7 @@
     <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect-thirdparty-boopickle-shaded_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>zio_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-internal-macros_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>zio-interop-cats_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>zio-json_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>dev.zio</groupId><artifactId>zio-stacktracer_${scala-binary-version}</artifactId><scope>provided</scope></dependency>

--- a/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/ScaleOutRelayService.scala
+++ b/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/ScaleOutRelayService.scala
@@ -117,7 +117,7 @@ class ScaleOutRelayService(
                         actionLogger.saveDemoteToNode(modId, actor, nodeInfo, reason)
                       } else {
                         ScaleOutRelayLoggerPure.debug(s"Node '${nodeId.value}' is already a simple node, nothing to do.") *>
-                        UIO.unit
+                        ZIO.unit
                       }
     } yield {
       asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/UserManagementPluginDef.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/UserManagementPluginDef.scala
@@ -37,11 +37,9 @@
 
 package com.normation.plugins.usermanagement
 
-import bootstrap.liftweb.Boot.userIsAllowed
 import bootstrap.liftweb.{Boot, MenuUtils}
 import bootstrap.rudder.plugin.UserManagementConf
 import com.normation.plugins._
-import com.normation.rudder.AuthorizationType
 import com.normation.rudder.AuthorizationType.Administration
 import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
@@ -51,8 +49,6 @@ import net.liftweb.sitemap.Loc.Template
 import net.liftweb.sitemap.Loc.TestAccess
 import net.liftweb.sitemap.LocPath.stringToLocPath
 import net.liftweb.sitemap.Menu
-
-import scala.xml.NodeSeq
 
 class UserManagementPluginDef(override val status: PluginStatus) extends DefaultPluginDef {
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21826

Same general changes than https://github.com/Normation/rudder/pull/4507 but in addition, some more related to Datasources. We use since rudder 7.2 `zhttp` for the tests which simplifies a lot the cats dependencies spagghetti ball. The bad point is that for `ZIO 2`, we need to use `2.0.0.x` version, which happens to have a breaking change in the semantic of URL pattern matching. It caused some troubles to be identified. Most of the other changes in [UpdateHttpDatasetTest.scala](https://github.com/Normation/rudder-plugins/pull/501/files#diff-44d43b7b8b22fabae4537dae04dcf91ea30fe5594278681a49ffe9e43951e4e8) 
Are related to either reodering of code, some cleaning (partly thanks to better ZIO features and partly because the dev are better with it). 
The removal of test clock worked, which is suprising. 
