### PR TITLE
Fixes #21889: package dependency is named python3-requests and not python-requests

### DIFF
--- a/centreon/packaging/metadata
+++ b/centreon/packaging/metadata
@@ -5,8 +5,8 @@
   "build-date": "${maven.build.timestamp}",
   "build-commit": "${commit-id}",
   "depends": {
-    "apt": [ "python-requests" ],
-    "rpm": [ "python-requests" ]
+    "apt": [ "python3-requests" ],
+    "rpm": [ "python3-requests" ]
   },
   "content": {
     "files.txz": "/opt/rudder/"


### PR DESCRIPTION
https://issues.rudder.io/issues/21889