### PR TITLE
Fixes #22349: Update user plugin to manage update custom roles

### DIFF
--- a/user-management/src/main/elm/sources/UserManagement.elm
+++ b/user-management/src/main/elm/sources/UserManagement.elm
@@ -105,7 +105,7 @@ update msg model =
         AddUser result ->
              case result of
                  Ok username ->
-                     (model, postReloadConf model )
+                     (model, getUsersConf model )
                          |> createSuccessNotification (username ++ " have been added")
                  Err err ->
                      processApiError err model
@@ -113,7 +113,7 @@ update msg model =
         DeleteUser result ->
              case result of
                   Ok deletedUser ->
-                       ({model | panelMode = Closed, login = "", openDeleteModal = False}, postReloadConf model)
+                       ({model | panelMode = Closed, login = "", openDeleteModal = False}, getUsersConf model)
                            |> createSuccessNotification (deletedUser ++ " have been deleted")
                   Err err ->
                        processApiError err model
@@ -121,7 +121,7 @@ update msg model =
         UpdateUser result ->
              case result of
                   Ok username ->
-                      (model, postReloadConf model)
+                      (model, getUsersConf model)
                         |> createSuccessNotification (username ++ " have been modified")
 
                   Err err ->

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/DataTypes.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/DataTypes.scala
@@ -39,7 +39,7 @@ package com.normation.plugins.usermanagement
 
 import bootstrap.liftweb.PasswordEncoder
 import bootstrap.liftweb.RudderConfig
-import bootstrap.liftweb.UserDetailList
+import bootstrap.liftweb.ValidatedUserList
 import com.normation.rudder.Role
 import com.normation.rudder.Role.Custom
 import net.liftweb.common.Logger
@@ -56,7 +56,7 @@ object UserManagementLogger extends Logger {
 
 object Serialisation {
 
-  implicit class AuthConfigSer(auth: UserDetailList) {
+  implicit class AuthConfigSer(auth: ValidatedUserList) {
     def toJson: JValue = {
       val encoder: String = PassEncoderToString(auth)
       val authBackendsProvider = RudderConfig.authenticationProviders.getConfiguredProviders().map(_.name).toSet
@@ -82,7 +82,7 @@ object Serialisation {
     }
   }
 
-  def PassEncoderToString(auth: UserDetailList): String = {
+  def PassEncoderToString(auth: ValidatedUserList): String = {
     auth.encoder match {
       case PasswordEncoder.MD5    => "MD5"
       case PasswordEncoder.SHA1   => "SHA-1"

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/DataTypes.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/DataTypes.scala
@@ -40,12 +40,14 @@ package com.normation.plugins.usermanagement
 import bootstrap.liftweb.PasswordEncoder
 import bootstrap.liftweb.RudderConfig
 import bootstrap.liftweb.ValidatedUserList
-import com.normation.rudder.Role
 import com.normation.rudder.Role.Custom
+import com.normation.rudder.RudderRoles
+
 import net.liftweb.common.Logger
 import net.liftweb.json.{Serialization => S}
 import net.liftweb.json.JsonAST.JValue
 import org.slf4j.LoggerFactory
+import com.normation.zio._
 
 /**
  * Applicative log of interest for Rudder ops.
@@ -64,7 +66,7 @@ object Serialisation {
       val jUser            = auth.users.map {
         case (_, u) =>
           val (rs, custom) = {
-            UserManagementService.computeRoleCoverage(Role.values, u.authz.authorizationTypes).getOrElse(Set.empty).partition {
+            UserManagementService.computeRoleCoverage(RudderRoles.getAllRoles.runNow.values.toSet, u.authz.authorizationTypes).getOrElse(Set.empty).partition {
               case Custom(_) => false
               case _         => true
             }

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/UserManagementService.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/UserManagementService.scala
@@ -3,20 +3,19 @@ package com.normation.plugins.usermanagement
 import better.files.Dsl.SymbolicOperations
 import better.files.File
 import bootstrap.liftweb.PasswordEncoder
-import bootstrap.liftweb.UserConfigFileError
 import bootstrap.liftweb.UserFile
 import bootstrap.liftweb.UserFileProcessing
+import com.normation.errors.IOResult
+import com.normation.errors.Unexpected
+import com.normation.errors.effectUioUnit
 import com.normation.plugins.usermanagement.UserManagementIO.getUserFilePath
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.Rights
 import com.normation.rudder.Role
 import com.normation.rudder.Role.Custom
-import com.normation.rudder.RoleToRights
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.repository.xml.RudderPrettyPrinter
-import net.liftweb.common.Box
-import net.liftweb.common.Failure
-import net.liftweb.common.Full
-import net.liftweb.util.Helpers.tryo
+import java.util.concurrent.TimeUnit
 import org.springframework.core.io.{ClassPathResource => CPResource}
 import scala.xml.Elem
 import scala.xml.Node
@@ -24,6 +23,8 @@ import scala.xml.NodeSeq
 import scala.xml.parsing.ConstructingParser
 import scala.xml.transform.RewriteRule
 import scala.xml.transform.RuleTransformer
+import zio._
+import zio.syntax._
 
 case class UserFileInfo(userOrigin: List[UserOrigin], digest: String)
 case class UserOrigin(user: User, hashValidHash: Boolean)
@@ -49,41 +50,67 @@ object UserOrigin {
 
 object UserManagementIO {
 
-  def replaceXml(currentXml: NodeSeq, newXml: Node, file: File): Box[File] = {
+  def replaceXml(currentXml: NodeSeq, newXml: Node, file: File): IOResult[Unit] = {
+    // create a backup of rudder-user.xml and roll it back in case of errors during update
+    def withBackup(source: File)(mod: IOResult[Unit]) = {
+      for {
+        stamp  <- ZIO.clockWith(_.currentTime(TimeUnit.MILLISECONDS))
+        backup <- IOResult.attempt(File(file.pathAsString + s"_backup_${stamp}"))
+        _      <- IOResult.attempt(source.copyTo(backup)) // in case of error here, stop
+        _      <- mod.foldZIO(
+                    // failure: we try to restore the backup
+                    err =>
+                      ApplicationLoggerPure.Authz.error(
+                        s"Error when trying to save updated rudder user authorizations, roll-backing to back-upped version. Error was: ${err.fullMsg}"
+                      ) *>
+                      IOResult
+                        .attempt(backup.copyTo(source, overwrite = true))
+                        .foldZIO(
+                          err2 => {
+                            // there, we are in big problem: error in rollback too, likely an FS problem, advice admin
+                            val msg = s"Error when reverting rudder-users.xlm, you will likely need to have a manual action. Backup file is here and won't be deleted automatically: ${backup.pathAsString}. Error was: ${err2.fullMsg}"
+                            ApplicationLoggerPure.Authz.error(msg) *> Unexpected(msg).fail
+                          },
+                          ok => {
+                            effectUioUnit(backup.delete(swallowIOExceptions = true)) *> ApplicationLoggerPure.Authz
+                              .info(s"User file correctly roll-backed") *> Unexpected(
+                              s"And error happened when trying to save rudder-user.xml file, backup version was restore. Error was: ${err.fullMsg}"
+                            ).fail
+                     }),
+                    // in case of update success, we just delete the backup file
+                    ok => effectUioUnit(backup.delete(swallowIOExceptions = true))
+                  )
+      } yield ()
+    }
 
-    if (!file.isWritable) {
-      Failure(s"${file.path} is not writable")
-    } else if (!file.isReadable) {
-      Failure(s"${file.path} is not readable")
-    } else {
-      val p = new RudderPrettyPrinter(300, 4)
-      file.clear()
-      currentXml.foreach { x =>
-        if (x.label == "authentication")
-          file << p.format(newXml)
-        else
-          file << p.format(x)
-      }
-      if (file.contentAsString contains newXml.text)
-        Failure(s"'${file.path}' modification have failed")
-      else
-        Full(file)
+    withBackup(file) {
+      for {
+        writable <- IOResult.attempt(file.isWritable)
+        _        <- ZIO.when(!writable)(Unexpected(s"${file.path} is not writable").fail)
+        readable <- IOResult.attempt(file.isReadable)
+        _        <- ZIO.when(!readable)(Unexpected(s"${file.path} is not readable").fail)
+        p         = new RudderPrettyPrinter(300, 4)
+        _        <- IOResult.attempt(file.clear())
+        _        <- IOResult.attempt {
+                      currentXml.foreach { x =>
+                        if (x.label == "authentication") {
+                          file << p.format(newXml)
+                        } else {
+                          file << p.format(x)
+                        }
+                      }
+                    }
+      } yield ()
     }
   }
 
-  def getUserFilePath: Either[UserConfigFileError, File] = {
-    val resources: Either[UserConfigFileError, UserFile] = UserFileProcessing.getUserResourceFile()
-    resources match {
-      case Left(err) =>
-        Left(err)
-      case Right(r)  =>
-        val file: File = {
-          if (r.name.startsWith("classpath:"))
-            File(new CPResource(UserFileProcessing.DEFAULT_AUTH_FILE_NAME).getPath)
-          else
-            File(r.name)
-        }
-        Right(file)
+  def getUserFilePath: IOResult[File] = {
+    val resources: IOResult[UserFile] = UserFileProcessing.getUserResourceFile()
+    resources.map { r =>
+      if (r.name.startsWith("classpath:"))
+        File(new CPResource(UserFileProcessing.DEFAULT_AUTH_FILE_NAME).getPath)
+      else
+        File(r.name)
     }
   }
 }
@@ -102,6 +129,8 @@ object UserManagementService {
 
   def computeRoleCoverage(roles: Set[Role], authzs: Set[AuthorizationType]): Option[Set[Role]] = {
 
+    def parseAuthzIgnoreError(a: String) = AuthorizationType.parseAuthz(a).getOrElse(Set())
+
     def compareRights(r: Role): Option[Role] = {
       if (r.name == "no_rights") {
         None
@@ -113,7 +142,7 @@ object UserManagementService {
           // Intersection is total
           case cr if cr == roleAuthzNames => Some(r)
           case cr if cr.nonEmpty          =>
-            val test = cr.flatMap(RoleToRights.parseAuthz)
+            val test = cr.flatMap(parseAuthzIgnoreError)
             if (test.isEmpty) {
               None
             } else {
@@ -136,18 +165,18 @@ object UserManagementService {
       // remove authzs taken by a role in custom's rights
       val minCustomAuthz  = customAuthz.diff(rs.flatMap(_.rights.authorizationTypes.map(_.id)))
       val leftoversRights =
-        authzs.diff(rs.flatMap(_.rights.authorizationTypes).union(minCustomAuthz.flatMap(RoleToRights.parseAuthz)))
-      val leftoversCustom: Option[Role] = {
+        authzs.diff(rs.flatMap(_.rights.authorizationTypes).union(minCustomAuthz.flatMap(parseAuthzIgnoreError)))
+      val leftoversCustom: Option[Role]      = {
         if (leftoversRights.nonEmpty)
           Some(Custom(new Rights(leftoversRights.toSeq: _*)))
         else
           None
       }
-      val data = {
+      val data:            Option[Set[Role]] = {
         if (minCustomAuthz.nonEmpty) {
-          Some(rs + Custom(new Rights(minCustomAuthz.flatMap(RoleToRights.parseAuthz).toSeq: _*)))
+          Some(rs + Custom(new Rights(minCustomAuthz.flatMap(parseAuthzIgnoreError).toSeq: _*)))
         } else if (rs == Role.values.diff(Set(Role.NoRights))) {
-          Some(RoleToRights.parseRole(Seq("administrator")).toSet)
+          Some(Set(Role.Administrator))
         } else if (rs.nonEmpty)
           Some(rs)
         else
@@ -164,108 +193,96 @@ object UserManagementService {
     }
   }
 
-  def add(newUser: User, isPreHashed: Boolean): Box[User] = {
-    getUserFilePath match {
-      case Left(err)   =>
-        Failure(err.msg)
-      case Right(file) =>
-        tryo(ConstructingParser.fromFile(file.toJava, preserveWS = true)).flatMap { parsedFile =>
-          val userXML = parsedFile.document().children
-          (userXML \\ "authentication").head match {
-            case e: Elem =>
-              val newXml = {
-                if (isPreHashed) {
-                  e.copy(child = e.child ++ newUser.toNode)
-                } else {
-                  e.copy(child = {
-                    e.child ++ newUser
-                      .copy(password = getHash((userXML \\ "authentication" \ "@hash").text).encode(newUser.password))
-                      .toNode
-                  })
-                }
-              }
-              UserManagementIO.replaceXml(userXML, newXml, file)
-              Full(newUser)
-            case _ =>
-              Failure(s"Wrong formatting : ${file.path}")
-          }
-        }
-    }
+  def add(newUser: User, isPreHashed: Boolean): IOResult[User] = {
+    for {
+      file       <- getUserFilePath
+      parsedFile <- IOResult.attempt(ConstructingParser.fromFile(file.toJava, preserveWS = true))
+      userXML    <- IOResult.attempt(parsedFile.document().children)
+      user       <- (userXML \\ "authentication").head match {
+                      case e: Elem =>
+                        val newXml = {
+                          if (isPreHashed) {
+                            e.copy(child = e.child ++ newUser.toNode)
+                          } else {
+                            e.copy(child = {
+                              e.child ++ newUser
+                                .copy(password = getHash((userXML \\ "authentication" \ "@hash").text).encode(newUser.password))
+                                .toNode
+                            })
+                          }
+                        }
+                        UserManagementIO.replaceXml(userXML, newXml, file) *> newUser.succeed
+                      case _ =>
+                        Unexpected(s"Wrong formatting : ${file.path}").fail
+                    }
+    } yield user
   }
 
-  def remove(toDelete: String): Box[File] = {
-    getUserFilePath match {
-      case Left(err)   =>
-        Failure(err.msg)
-      case Right(file) =>
-        tryo(ConstructingParser.fromFile(file.toJava, preserveWS = true)).flatMap { parsedFile =>
-          val userXML  = parsedFile.document().children
-          val toUpdate = (userXML \\ "authentication").head
-          val newXml   = new RuleTransformer(new RewriteRule {
-            override def transform(n: Node): NodeSeq = n match {
-              case user: Elem if (user \ "@name").text == toDelete => NodeSeq.Empty
-              case other => other
-            }
-          }).transform(toUpdate).head
-          UserManagementIO.replaceXml(userXML, newXml, file)
-        }
-    }
+  def remove(toDelete: String): IOResult[Unit] = {
+    for {
+      file       <- getUserFilePath
+      parsedFile <- IOResult.attempt(ConstructingParser.fromFile(file.toJava, preserveWS = true))
+      userXML    <- IOResult.attempt(parsedFile.document().children)
+      toUpdate    = (userXML \\ "authentication").head
+      newXml      = new RuleTransformer(new RewriteRule {
+                      override def transform(n: Node): NodeSeq = n match {
+                        case user: Elem if (user \ "@name").text == toDelete => NodeSeq.Empty
+                        case other => other
+                      }
+                    }).transform(toUpdate).head
+      _          <- UserManagementIO.replaceXml(userXML, newXml, file)
+    } yield ()
   }
 
-  def update(currentUser: String, newUser: User, isPreHashed: Boolean): Box[File] = {
-    getUserFilePath match {
-      case Left(err)   =>
-        Failure(err.msg)
-      case Right(file) =>
-        tryo(ConstructingParser.fromFile(file.toJava, preserveWS = true)).flatMap { parsedFile =>
-          val userXML  = parsedFile.document().children
-          val toUpdate = (userXML \\ "authentication").head
-          val newXml   = new RuleTransformer(new RewriteRule {
-            override def transform(n: Node): NodeSeq = n match {
-              case user: Elem if (user \ "@name").text == currentUser =>
-                // for each user's parameters, if a new user's parameter is empty we decide to keep the original one
-                val newRoles    = if (newUser.role.isEmpty) (user \ "@role").text.split(",").toSet else newUser.role
-                val newUsername = if (newUser.username.isEmpty) currentUser else newUser.username
-                val newPassword = if (newUser.password.isEmpty) {
-                  (user \ "@password").text
-                } else {
-                  if (isPreHashed) newUser.password
-                  else getHash((userXML \\ "authentication" \ "@hash").text).encode(newUser.password)
-                }
+  def update(currentUser: String, newUser: User, isPreHashed: Boolean): IOResult[Unit] = {
+    for {
+      file       <- getUserFilePath
+      parsedFile <- IOResult.attempt(ConstructingParser.fromFile(file.toJava, preserveWS = true))
+      userXML    <- IOResult.attempt(parsedFile.document().children)
+      toUpdate    = (userXML \\ "authentication").head
+      newXml      = new RuleTransformer(new RewriteRule {
+                      override def transform(n: Node): NodeSeq = n match {
+                        case user: Elem if (user \ "@name").text == currentUser =>
+                          // for each user's parameters, if a new user's parameter is empty we decide to keep the original one
+                          val newRoles    = if (newUser.role.isEmpty) (user \ "@role").text.split(",").toSet else newUser.role
+                          val newUsername = if (newUser.username.isEmpty) currentUser else newUser.username
+                          val newPassword = if (newUser.password.isEmpty) {
+                            (user \ "@password").text
+                          } else {
+                            if (isPreHashed) newUser.password
+                            else getHash((userXML \\ "authentication" \ "@hash").text).encode(newUser.password)
+                          }
 
-                User(newUsername, newPassword, newRoles).toNode
+                          User(newUsername, newPassword, newRoles).toNode
 
-              case other => other
-            }
-          }).transform(toUpdate).head
-          UserManagementIO.replaceXml(userXML, newXml, file)
-        }
-    }
+                        case other => other
+                      }
+                    }).transform(toUpdate).head
+      _          <- UserManagementIO.replaceXml(userXML, newXml, file)
+    } yield ()
   }
 
-  def getAll: Box[UserFileInfo] = {
-    getUserFilePath match {
-      case Left(err)   =>
-        Failure(err.msg)
-      case Right(file) =>
-        tryo(ConstructingParser.fromFile(file.toJava, preserveWS = true)).flatMap { parsedFile =>
-          val userXML = parsedFile.document().children
-          (userXML \\ "authentication").head match {
-            case e: Elem =>
-              val digest = (userXML \\ "authentication" \ "@hash").text.toUpperCase
-              val users  = e
-                .map(u => {
-                  val password     = (u \ "@password").text
-                  val user         = User((u \ "@name").text, (u \ "@password").text, (u \ "@role").map(_.text).toSet)
-                  val hasValidHash = UserOrigin.verifyHash(digest, password)
-                  UserOrigin(user, hasValidHash)
-                })
-                .toList
-              Full(UserFileInfo(users, digest))
-            case _ =>
-              Failure(s"Wrong formatting : ${file.path}")
-          }
-        }
-    }
+  def getAll: IOResult[UserFileInfo] = {
+    for {
+      file       <- getUserFilePath
+      parsedFile <- IOResult.attempt(ConstructingParser.fromFile(file.toJava, preserveWS = true))
+      userXML    <- IOResult.attempt(parsedFile.document().children)
+      toUpdate    = (userXML \\ "authentication").head
+      res        <- (userXML \\ "authentication").head match {
+                      case e: Elem =>
+                        val digest = (userXML \\ "authentication" \ "@hash").text.toUpperCase
+                        val users  = e
+                          .map(u => {
+                            val password     = (u \ "@password").text
+                            val user         = User((u \ "@name").text, (u \ "@password").text, (u \ "@role").map(_.text).toSet)
+                            val hasValidHash = UserOrigin.verifyHash(digest, password)
+                            UserOrigin(user, hasValidHash)
+                          })
+                          .toList
+                        UserFileInfo(users, digest).succeed
+                      case _ =>
+                        Unexpected(s"Wrong formatting : ${file.path}").fail
+                    }
+    } yield res
   }
 }

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/UserManagementService.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/UserManagementService.scala
@@ -265,7 +265,6 @@ object UserManagementService {
       file       <- getUserFilePath
       parsedFile <- IOResult.attempt(ConstructingParser.fromFile(file.toJava, preserveWS = true))
       userXML    <- IOResult.attempt(parsedFile.document().children)
-      toUpdate    = (userXML \\ "authentication").head
       res        <- (userXML \\ "authentication").head match {
                       case e: Elem =>
                         val digest = (userXML \\ "authentication" \ "@hash").text.toUpperCase

--- a/user-management/src/test/scala/com/normation/plugins/usermanagement/RoleComputationTest.scala
+++ b/user-management/src/test/scala/com/normation/plugins/usermanagement/RoleComputationTest.scala
@@ -16,48 +16,48 @@ class RoleComputationTest extends Specification {
 
   "Computation of Role Coverage over Rights" should {
 
-//    "return 'None' when parameters are empty" in {
-//      (computeRoleCoverage(Set(Role.User), Set()) must beNone) and
-//      (computeRoleCoverage(Set(), Set(AuthorizationType.Compliance.Read)) must beNone) and
-//      (computeRoleCoverage(Set(), Set()) must beNone)
-//    }
-//
-//    "return 'None' when authzs contains no_rights" in {
-//      (computeRoleCoverage(Set(Role.User), Set(AuthorizationType.NoRights)) must beNone) and
-//      (computeRoleCoverage(Set(Role.User), Set(AuthorizationType.NoRights) ++ AuthorizationType.allKind) must beNone)
-//    }
-//
-//    "return a 'Custom' role for empty intersection" in {
-//      computeRoleCoverage(Set(Role.User), Set(AuthorizationType.Compliance.Read)) must beEqualTo(
-//        Some(Set(Role.forAuthz(AuthorizationType.Compliance.Read)))
-//      )
-//    }
-//
-//    "contains 'Inventory' and 'Custom' roles" in {
-//      computeRoleCoverage(
-//        Role.values,
-//        Set(AuthorizationType.Compliance.Read) ++ Role.Inventory.rights.authorizationTypes
-//      ) must beEqualTo(Some(Set(Role.Inventory, Role.forAuthz(AuthorizationType.Compliance.Read))))
-//    }
-//
-//    "only detect 'Inventory' role" in {
-//      computeRoleCoverage(
-//        Set(Role.Inventory),
-//        Role.Inventory.rights.authorizationTypes
-//      ) must beEqualTo(Some(Set(Role.Inventory)))
-//    }
-//
-//    "only detect one custom role" in { // why ?
-//      val a: Set[AuthorizationType] = Set(
-//        AuthorizationType.UserAccount.Read,
-//        AuthorizationType.UserAccount.Write,
-//        AuthorizationType.UserAccount.Edit
-//      )
-//      computeRoleCoverage(
-//        Set(Role.User, Role.Inventory),
-//        a
-//      ) must beEqualTo(Some(Set(Role.forAuthz(a))))
-//    }
+    "return 'None' when parameters are empty" in {
+      (computeRoleCoverage(Set(Role.User), Set()) must beNone) and
+      (computeRoleCoverage(Set(), Set(AuthorizationType.Compliance.Read)) must beNone) and
+      (computeRoleCoverage(Set(), Set()) must beNone)
+    }
+
+    "return 'None' when authzs contains no_rights" in {
+      (computeRoleCoverage(Set(Role.User), Set(AuthorizationType.NoRights)) must beNone) and
+      (computeRoleCoverage(Set(Role.User), Set(AuthorizationType.NoRights) ++ AuthorizationType.allKind) must beNone)
+    }
+
+    "return a 'Custom' role for empty intersection" in {
+      computeRoleCoverage(Set(Role.User), Set(AuthorizationType.Compliance.Read)) must beEqualTo(
+        Some(Set(Role.forAuthz(AuthorizationType.Compliance.Read)))
+      )
+    }
+
+    "contains 'Inventory' and 'Custom' roles" in {
+      computeRoleCoverage(
+        Role.values,
+        Set(AuthorizationType.Compliance.Read) ++ Role.Inventory.rights.authorizationTypes
+      ) must beEqualTo(Some(Set(Role.Inventory, Role.forAuthz(AuthorizationType.Compliance.Read))))
+    }
+
+    "only detect 'Inventory' role" in {
+      computeRoleCoverage(
+        Set(Role.Inventory),
+        Role.Inventory.rights.authorizationTypes
+      ) must beEqualTo(Some(Set(Role.Inventory)))
+    }
+
+    "only detect one custom role" in { // why ?
+      val a: Set[AuthorizationType] = Set(
+        AuthorizationType.UserAccount.Read,
+        AuthorizationType.UserAccount.Write,
+        AuthorizationType.UserAccount.Edit
+      )
+      computeRoleCoverage(
+        Set(Role.User, Role.Inventory),
+        a
+      ) must beEqualTo(Some(Set(Role.forAuthz(a))))
+    }
 
     "return administrator " in {
       computeRoleCoverage(
@@ -66,18 +66,18 @@ class RoleComputationTest extends Specification {
       ) must beEqualTo(Some(Set(Role.Administrator)))
     }
 
-//    "allows intersection between know roles" in {
-//      computeRoleCoverage(
-//        Set(Role.Inventory, Role.User),
-//        Role.User.rights.authorizationTypes ++ Role.Inventory.rights.authorizationTypes
-//      ) must beEqualTo(Some(Set(Role.User, Role.Inventory)))
-//    }
-//
-//    "ignore NoRights role" in {
-//      computeRoleCoverage(
-//        Set(Role.NoRights, Role.User),
-//        Role.User.rights.authorizationTypes
-//      ) must beEqualTo(Some(Set(Role.User)))
-//    }
+    "allows intersection between know roles" in {
+      computeRoleCoverage(
+        Set(Role.Inventory, Role.User),
+        Role.User.rights.authorizationTypes ++ Role.Inventory.rights.authorizationTypes
+      ) must beEqualTo(Some(Set(Role.User, Role.Inventory)))
+    }
+
+    "ignore NoRights role" in {
+      computeRoleCoverage(
+        Set(Role.NoRights, Role.User),
+        Role.User.rights.authorizationTypes
+      ) must beEqualTo(Some(Set(Role.User)))
+    }
   }
 }

--- a/user-management/src/test/scala/com/normation/plugins/usermanagement/RoleComputationTest.scala
+++ b/user-management/src/test/scala/com/normation/plugins/usermanagement/RoleComputationTest.scala
@@ -5,11 +5,10 @@ import com.normation.rudder.AuthorizationType
 import com.normation.rudder.Role
 import com.normation.rudder.Role.Custom
 import com.normation.rudder.RudderRoles
-
+import com.normation.zio._
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import com.normation.zio._
 
 @RunWith(classOf[JUnitRunner])
 class RoleComputationTest extends Specification {
@@ -17,155 +16,68 @@ class RoleComputationTest extends Specification {
 
   "Computation of Role Coverage over Rights" should {
 
-    "return 'None' when parameters are empty" in {
-      val role = parseRoles(List("user"))
-      computeRoleCoverage(role, Set()) must beNone
-      computeRoleCoverage(Set(), Set(AuthorizationType.Compliance.Read)) must beNone
-      computeRoleCoverage(Set(), Set()) must beNone
-    }
-
-    "return 'None' when authzs contains no_rights" in {
-      val role = parseRoles(List("user"))
-      computeRoleCoverage(role, Set(AuthorizationType.NoRights)) must beNone
-      computeRoleCoverage(role, Set(AuthorizationType.NoRights) ++ AuthorizationType.allKind) must beNone
-    }
-
-    "return a 'Custom' role for empty intersection" in {
-      val role = parseRoles(List("user"))
-      computeRoleCoverage(role, Set(AuthorizationType.Compliance.Read)) match {
-        case Some(r) =>
-          r.head match {
-            case Custom(_) => success
-            case knowRole  => failure(s"Unexpected role : ${knowRole.name}")
-          }
-        case None    => success
-      }
-    }
-
-    "contains 'Inventory' and 'Custom' roles" in {
-      //      val role = parseRoles(List("inventory", "user"))
-      val role = Role.values.map(_.name).toList
-
-      computeRoleCoverage(
-        parseRoles(role)
-        //        role
-        ,
-        Set(AuthorizationType.Compliance.Read) ++ Role.Inventory.rights.authorizationTypes
-      ) match {
-        case Some(rs) =>
-          val rolesName = rs.map(_.name.toLowerCase)
-          if (rolesName.contains("inventory") && rolesName.contains("custom")) {
-            rs.find {
-              case Custom(_) => true
-              case _         => false
-            } match {
-              case Some(r) =>
-                if (r.rights.displayAuthorizations == "compliance_read")
-                  success
-                else
-                  failure(s"wrong rights")
-              case None    => failure(s"Missing role : $rs")
-            }
-          } else {
-            failure(s"Missing role : $rs")
-          }
-        case None     => failure("No roles found")
-      }
-    }
-
-    "only detect 'Inventory' role" in {
-      val role = parseRoles(List("inventory"))
-      computeRoleCoverage(
-        role,
-        Role.Inventory.rights.authorizationTypes
-      ) match {
-        case Some(rs) =>
-          val rolesName = rs.map(_.name.toLowerCase)
-          if (rolesName.size == 1) {
-            rs.head match {
-              case r if r.name == "inventory" => success
-              case r                          => failure(s"Wrong role : ${r.name}")
-            }
-          } else {
-            failure(s"Excepted 1 custom role, instead : ${rolesName.size} role(s)")
-          }
-        case None     => failure("No roles found")
-      }
-    }
-
-    "only detect one custom role" in {
-      val role = parseRoles(List("inventory", "user"))
-      computeRoleCoverage(
-        role,
-        Set(
-          AuthorizationType.UserAccount.Read,
-          AuthorizationType.UserAccount.Write,
-          AuthorizationType.UserAccount.Edit
-        )
-      ) match {
-        case Some(rs) =>
-          val rolesName = rs.map(_.name.toLowerCase)
-          if (rolesName.size == 1) {
-            rs.head match {
-              case Custom(_) => success
-              case r         => failure(s"Unexpected role : ${r.name}")
-            }
-          } else {
-            failure(s"Excepted 1 custom role, instead : ${rolesName.size} role(s)")
-          }
-        case None     => failure("No roles found")
-      }
-    }
+//    "return 'None' when parameters are empty" in {
+//      (computeRoleCoverage(Set(Role.User), Set()) must beNone) and
+//      (computeRoleCoverage(Set(), Set(AuthorizationType.Compliance.Read)) must beNone) and
+//      (computeRoleCoverage(Set(), Set()) must beNone)
+//    }
+//
+//    "return 'None' when authzs contains no_rights" in {
+//      (computeRoleCoverage(Set(Role.User), Set(AuthorizationType.NoRights)) must beNone) and
+//      (computeRoleCoverage(Set(Role.User), Set(AuthorizationType.NoRights) ++ AuthorizationType.allKind) must beNone)
+//    }
+//
+//    "return a 'Custom' role for empty intersection" in {
+//      computeRoleCoverage(Set(Role.User), Set(AuthorizationType.Compliance.Read)) must beEqualTo(
+//        Some(Set(Role.forAuthz(AuthorizationType.Compliance.Read)))
+//      )
+//    }
+//
+//    "contains 'Inventory' and 'Custom' roles" in {
+//      computeRoleCoverage(
+//        Role.values,
+//        Set(AuthorizationType.Compliance.Read) ++ Role.Inventory.rights.authorizationTypes
+//      ) must beEqualTo(Some(Set(Role.Inventory, Role.forAuthz(AuthorizationType.Compliance.Read))))
+//    }
+//
+//    "only detect 'Inventory' role" in {
+//      computeRoleCoverage(
+//        Set(Role.Inventory),
+//        Role.Inventory.rights.authorizationTypes
+//      ) must beEqualTo(Some(Set(Role.Inventory)))
+//    }
+//
+//    "only detect one custom role" in { // why ?
+//      val a: Set[AuthorizationType] = Set(
+//        AuthorizationType.UserAccount.Read,
+//        AuthorizationType.UserAccount.Write,
+//        AuthorizationType.UserAccount.Edit
+//      )
+//      computeRoleCoverage(
+//        Set(Role.User, Role.Inventory),
+//        a
+//      ) must beEqualTo(Some(Set(Role.forAuthz(a))))
+//    }
 
     "return administrator " in {
-      val role = Role.values.map(_.name).toList
       computeRoleCoverage(
-        parseRoles(role),
+        Role.values,
         AuthorizationType.allKind
-      ) match {
-        case Some(rs) =>
-          if (rs.size == 1 && rs.head.name == "administrator")
-            success
-          else
-            failure("Excepted only administrator role")
-        case _        => failure("Nothing returned")
-      }
+      ) must beEqualTo(Some(Set(Role.Administrator)))
     }
 
-    "allows intersection between know roles" in {
-      val role = parseRoles(List("inventory", "user"))
-      computeRoleCoverage(
-        role,
-        Role.User.rights.authorizationTypes ++ Role.Inventory.rights.authorizationTypes
-      ) match {
-        case Some(rs) =>
-          val rolesName = rs.map(_.name.toLowerCase)
-          if (rolesName.size == 2 && rs.forall(r => r.name == "inventory" || r.name == "user"))
-            success
-          else
-            failure(s"Excepted inventory and user role, instead : ${rolesName.mkString(",")}")
-        case None     => failure("No roles found")
-      }
-    }
-
-    "ignore NoRights role" in {
-      val role = parseRoles(List("no_rights", "user"))
-      computeRoleCoverage(
-        role,
-        Role.User.rights.authorizationTypes
-      ) match {
-        case Some(rs) =>
-          val rolesName = rs.map(_.name.toLowerCase)
-          if (rolesName.size == 1) {
-            rs.head match {
-              case r if r.name == "user" => success
-              case r                     => failure(s"Wrong role : ${r.name}")
-            }
-          } else {
-            failure(s"Excepted 'User' role, instead : ${rolesName.mkString(",")}")
-          }
-        case None     => failure("No roles found")
-      }
-    }
+//    "allows intersection between know roles" in {
+//      computeRoleCoverage(
+//        Set(Role.Inventory, Role.User),
+//        Role.User.rights.authorizationTypes ++ Role.Inventory.rights.authorizationTypes
+//      ) must beEqualTo(Some(Set(Role.User, Role.Inventory)))
+//    }
+//
+//    "ignore NoRights role" in {
+//      computeRoleCoverage(
+//        Set(Role.NoRights, Role.User),
+//        Role.User.rights.authorizationTypes
+//      ) must beEqualTo(Some(Set(Role.User)))
+//    }
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/22349

There is a lot of things to change in the way that plugin works, but in that PR I limited to what is the minimum to make it compatible with Rudder 7.3 changes + an auto-backup of `rudder-user.xml` file in case of problem - because we didn't have anything for that, and it would make rudder broken. 

So, the changes related to API changes in core are: 
- reflect name changes from rudder (`RudderRoles`)
- update function from `Box` to `ZIO` (reflecting changes in backend + general direction of where we are going)

Other changes that were needed:
- add a backup/rollback logic if something goes badly when writting the new `rudder-users.xml` file. At least, let the user know that he is not hopeless. 
- remove useless duplicate call to reload after each changes. The reload is done in back-end (no the responsibility of UI). I changed to call to `getUserList` to force refresh UI, which seemed to be the wanted logic, but even that should be removed: the API return of POST should send the wanted updated model, and UI just handle that, which will remove more useless roundtrip to backend.


What is not done but need to be done to have a "user management plugin with custom roles":
- bare minimum: rework the role coverture logic to keep custom role. If the user is defined with some role, the plugin MUST NOT change them, it's only when the role are defined from authz from the UI
- API need to be changed to use ZIO and our API tooling, which implies also changing JSON serialisation
- add the possibility to define custom role if the extended authz plugin is there
- a correct handling of errors from the UI side. We just get a blanck screen with a "error happened" notification, without any way for the user to know what to do. At least say "try to reload", or better handle the error correctly to let the user know things went wrongly, but we did what was needed which is XXX. 