### PR TITLE
Fixes #22492: Scale-out-relay: missing command node-to-relay due to upmerge

### DIFF
--- a/scale-out-relay/packaging/postinst
+++ b/scale-out-relay/packaging/postinst
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -e
 
+# Force policy regeneration at restart
+touch /opt/rudder/etc/trigger-policy-generation
+cp /opt/rudder/share/plugins/scale-out-relay/server-node-to-relay /opt/rudder/share/commands/
+cp /opt/rudder/share/plugins/scale-out-relay/server-relay-to-node /opt/rudder/share/commands/
+echo "Plugin scale-out-relay successfully installed"


### PR DESCRIPTION
https://issues.rudder.io/issues/22492

Revert back line that were incorrectly upmerged in https://github.com/Normation/rudder-plugins/commit/13d42153faf61aa8a9513dbf6deea3985d719703#diff-7507dfd2e40a78a835e6d6b9f355a48fdc9005811548262f7a918490bc02954d