### PR TITLE
Fixes #14330: By default, no group are supervised and new group are not supervised 

### DIFF
--- a/change-validation/src/main/scala/bootstrap/rudder/plugin/MigrateSupervisedGroups.scala
+++ b/change-validation/src/main/scala/bootstrap/rudder/plugin/MigrateSupervisedGroups.scala
@@ -1,0 +1,111 @@
+/*
+*************************************************************************************
+* Copyright 2023 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package bootstrap.rudder.plugin
+
+import com.normation.plugins.changevalidation.ChangeValidationLogger
+import com.normation.plugins.changevalidation.UnsupervisedTargetsRepository
+import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.domain.policies.SimpleTarget
+
+import com.normation.rudder.repository.RoNodeGroupRepository
+
+import better.files.File
+import net.liftweb.common._
+import net.liftweb.json.NoTypeHints
+
+import java.nio.charset.StandardCharsets
+import com.normation.box._
+
+
+final case class OldfileFormat(supervised: List[String])
+
+/*
+ * The validation workflow level
+ */
+class MigrateSupervisedGroups(
+    groupRepository:  RoNodeGroupRepository
+  , unsupervisedRepo: UnsupervisedTargetsRepository
+)  {
+  implicit val formats = net.liftweb.json.Serialization.formats(NoTypeHints)
+  val directory = "/var/rudder/plugin-resources/change-validation"
+  val oldFilename  = "supervised-targets.json"
+
+  def migrate(): Unit = {
+    Box.tryo {
+      val path = directory + "/" + oldFilename
+      val old = File(path)
+      if (!old.exists) { // ok, plugin installed in new version
+        ChangeValidationLogger.debug("No migration needed from supervised to unsupervised groups")
+      } else { // migration needed
+        ChangeValidationLogger.info(s"Old file format for supervised target found: '${path}': migrating")
+        val oldTargetStrings = net.liftweb.json.Serialization.read[OldfileFormat](old.contentAsString(StandardCharsets.UTF_8))
+        val targets = oldTargetStrings.supervised.flatMap(t => RuleTarget.unser(t).flatMap {
+          case t: SimpleTarget => Some(t)
+          case _               => None
+        }
+        ).toSet
+        val unsupervised: Set[SimpleTarget] = (
+          for {
+            groups <- groupRepository.getFullGroupLibrary().toBox
+          } yield {
+            UnsupervisedTargetsRepository.invertTargets(targets, groups)
+          }
+          ) match {
+          case Full(t)     => t
+          case e: EmptyBox =>
+            val msg = (e ?~! s"Error when retrieving group library for migration: all groups will be supervised").messageChain
+            ChangeValidationLogger.warn(msg)
+            Set()
+        }
+        unsupervisedRepo.save(unsupervised) match {
+          case Full(_)     =>
+            old.renameTo(oldFilename + "_migrated")
+            ChangeValidationLogger.info(s"Migration of old supervised group file format done")
+          case e: EmptyBox =>
+            val msg = (e ?~! s"Error when saving supervised group. Please check you configuration")
+            ChangeValidationLogger.warn(msg)
+        }
+      }
+    } match {
+      case Full(_)     => () // done
+      case e: EmptyBox =>
+        val msg = (e ?~! s"Error when migrating supervised group. Please check you configuration")
+        ChangeValidationLogger.warn(msg)
+    }
+  }
+}

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeValidationPluginDef.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeValidationPluginDef.scala
@@ -76,7 +76,7 @@ class ChangeValidationPluginDef(override val status: PluginStatus) extends Defau
     }
 
     // init directory to save JSON
-    ChangeValidationConf.supervisedTargetRepo.checkPathAndInitRepos()
+    ChangeValidationConf.unsupervisedTargetRepo.checkPathAndInitRepos()
   }
 
   override def apis: Option[LiftApiModuleProvider[_ <: EndpointSchema]] = Some(ChangeValidationConf.api)

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsReposiory.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsReposiory.scala
@@ -1,10 +1,12 @@
 package com.normation.plugins.changevalidation
 
+import com.normation.rudder.domain.policies.SimpleTarget
+
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import com.normation.rudder.repository.FullNodeGroupCategory
 
-import com.normation.rudder.domain.policies.SimpleTarget
 import net.liftweb.common.Box
 import net.liftweb.common.Empty
 import net.liftweb.common.Failure
@@ -20,15 +22,26 @@ import scala.util.control.NonFatal
  * json file in given directory.
  * JSON format:
  * {
- *   "supervised": [
+ *   "unsupervised": [
  *     "group:xxxxxx",
  *     "special:allnodes",
  *     ...
  *   ]
  * }
  *
+ * Because of https://issues.rudder.io/issues/14330 we need to
+ * save *un*supervised target so that when a new group is created,
+ * it is automatically supervised.
+ *
  */
-class SupervisedTargetsReposiory(
+object UnsupervisedTargetsRepository {
+  // invert non supervised target to find the ones supervised
+  def invertTargets(unsupervised: Set[SimpleTarget], groupLib: FullNodeGroupCategory): Set[SimpleTarget] = {
+    groupLib.allTargets.values.map(_.target.target).collect { case t: SimpleTarget if(!unsupervised.contains(t)) => t }.toSet
+  }
+}
+
+class UnsupervisedTargetsRepository(
     directory: Path
   , filename : String
 ) {
@@ -71,8 +84,8 @@ class SupervisedTargetsReposiory(
 
     // Always save by replacing the whole file.
     // Sort by name.
-    val targets = SupervisedTargetIds(groups.toList.map( _.target ).sorted) // natural sort on string
-    val jsonString = Serialization.writePretty[SupervisedTargetIds](targets)
+    val targets = UnsupervisedTargetIds(groups.toList.map( _.target ).sorted) // natural sort on string
+    val jsonString = Serialization.writePretty[UnsupervisedTargetIds](targets)
 
     //write file
     try {


### PR DESCRIPTION
https://issues.rudder.io/issues/14330

Make the all groups being supervised by default, and new groups automatically supervised. 
To achieve that without complexity and a need to look to group creation, we just invert what we save in base: we save unsupervised target, and invert the list to get the supervised ones (we were already retrieving all the groups where performance matters, and the invert is trivial, so it should not change much regarding perf). 

To make migration transparent, on first use we read all supervised targets, invert set based on current group lib, and save the new set of unsupervised targets.
We change the name of the file were supervised groups were persisted to `unsupervised-groups.json`, which give us a way to know if the migration already happened.

We still need to keep the old "supervised" json extractor because API still send supervised targets. I prefered to change as little things as possible.

This PR also harmonize around `supervised` vs the very old `monitored`