### PR TITLE
Fixes #22580: Plugin writes "roles" in place of "permissions"

### DIFF
--- a/user-management/README.adoc
+++ b/user-management/README.adoc
@@ -111,6 +111,12 @@ They are provided for convenience, but if they don't fit your need you can defin
 |validator | Can access and act on compliance and validator part
 |====
 
+[INFO]
+====
+Built-in roles, like right, can use `\_` in their name. Custom-roles are not allowed to
+use `_` in their name.
+====
+
 The precise permission set for each role is presented below:
 
 .Permission for pre-defined roles

--- a/user-management/src/main/elm/sources/DataTypes.elm
+++ b/user-management/src/main/elm/sources/DataTypes.elm
@@ -24,14 +24,14 @@ type alias Role =
     }
 
 type alias Authorization =
-    { roles : List String
+    { permissions : List String
     , custom: List String
     }
 
 type alias User =
     { login : String
     , authz : List String
-    , role : List String
+    , permissions : List String
     }
 
 type Provider

--- a/user-management/src/main/elm/sources/Init.elm
+++ b/user-management/src/main/elm/sources/Init.elm
@@ -14,7 +14,7 @@ subscriptions model =
 
 authorizations : Authorization
 authorizations =
-    {roles = [], custom = []}
+    {permissions = [], custom = []}
 
 init : { contextPath : String } -> ( Model, Cmd Msg )
 init flags =

--- a/user-management/src/main/elm/sources/JsonDecoder.elm
+++ b/user-management/src/main/elm/sources/JsonDecoder.elm
@@ -30,7 +30,7 @@ decodeUser =
     D.succeed User
         |> required "login" D.string
         |> required "authz" (D.list <| D.string)
-        |> required "role" (D.list <| D.string)
+        |> required "permissions" (D.list <| D.string)
 
 decodeApiRoleCoverage : Decoder Authorization
 decodeApiRoleCoverage =
@@ -41,8 +41,8 @@ decodeRoleCoverage =
     let
         response =
             D.succeed Authorization
-                |> required "role" (D.list <| D.string)
-                |> required "authz" (D.list <| D.string)
+                |> required "permissions" (D.list <| D.string)
+                |> required "custom" (D.list <| D.string)
     in
         D.at [ "coverage" ] response
 

--- a/user-management/src/main/elm/sources/JsonEncoder.elm
+++ b/user-management/src/main/elm/sources/JsonEncoder.elm
@@ -8,8 +8,8 @@ encodeAuthorization: Authorization -> Value
 encodeAuthorization authorizations =
     object
     [ ("action", string "rolesCoverageOnRights")
-    , ("role", list (\s -> string s) authorizations.roles)
-    , ("authz", list (\s -> string s) authorizations.roles)
+    , ("permissions", list (\s -> string s) authorizations.permissions)
+    , ("authz", list (\s -> string s) authorizations.permissions)
     ]
 
 encodeUser: (User, String) -> Value
@@ -17,7 +17,7 @@ encodeUser (user, password) =
     object
     [ ("username", string user.login)
     , ("password", string password)
-    , ("role", list (\s -> string s) (user.authz ++  user.role))
+    , ("permissions", list (\s -> string s) (user.authz ++  user.permissions))
     ]
 
 encodeAddUser: AddUserForm -> Value
@@ -25,6 +25,6 @@ encodeAddUser userForm =
     object
     [ ("username", string userForm.user.login)
     , ("password", string userForm.password)
-    , ("role", list (\s -> string s) (userForm.user.authz ++  userForm.user.role))
+    , ("permissions", list (\s -> string s) (userForm.user.authz ++  userForm.user.permissions))
     , ("isPreHashed", bool userForm.isPreHashed)
     ]

--- a/user-management/src/main/elm/sources/UserManagement.elm
+++ b/user-management/src/main/elm/sources/UserManagement.elm
@@ -23,7 +23,7 @@ getUser: Username -> Users -> Maybe User
 getUser username users =
     case (Dict.get username users) of
         Just a ->
-           Just (User username a.custom a.roles)
+           Just (User username a.custom a.permissions)
         Nothing ->
             Nothing
 
@@ -39,7 +39,7 @@ update msg model =
                     let
                         knownProviders = List.filter (\p -> p /= Unknown) (List.map toProvider u.authenticationBackends)
                         recordUser =
-                            List.map (\x -> (x.login, (Authorization x.authz  x.role))) u.users
+                            List.map (\x -> (x.login, (Authorization x.authz  x.permissions))) u.users
                         newModel =
                             { model | users = fromList recordUser, digest = u.digest, providers = knownProviders}
 
@@ -131,9 +131,9 @@ update msg model =
             ({model | authzToAddOnSave = r :: model.authzToAddOnSave}, Cmd.none)
         RemoveRole user r ->
             let
-                newRoles = List.filter (\x -> r /= x) user.role
+                newRoles = List.filter (\x -> r /= x) user.permissions
                 newAuthz = List.filter (\x -> r /= x) user.authz
-                newUser = {user | role = newRoles, authz = newAuthz}
+                newUser = {user | permissions = newRoles, authz = newAuthz}
             in
             ({model | panelMode = EditMode newUser}, updateUser model user.login (DataTypes.AddUserForm newUser "" model.isHashedPasswd))
         Notification subMsg ->

--- a/user-management/src/main/elm/sources/View.elm
+++ b/user-management/src/main/elm/sources/View.elm
@@ -222,7 +222,7 @@ displayRightPanel model =
                 ]
            ]
            , button [class "btn btn-sm btn-danger btn-delete",onClick (OpenDeleteModal user.login)] [text "Delete"]
-           , button [class "btn btn-sm btn-success btn-save", onClick (SubmitUpdatedInfos {user | role = user.role ++ model.authzToAddOnSave})] [text "Save"]
+           , button [class "btn btn-sm btn-success btn-save", onClick (SubmitUpdatedInfos {user | permissions = user.permissions ++ model.authzToAddOnSave})] [text "Save"]
         ]
     ]
 
@@ -230,7 +230,7 @@ displayUsersConf : Model -> Users -> Html Msg
 displayUsersConf model u =
     let
         users =
-            (List.map (\(name, rights) -> (User name rights.custom rights.roles)) (Dict.toList u)) |> List.map (\user -> displayUser user)
+            (List.map (\(name, rights) -> (User name rights.custom rights.permissions)) (Dict.toList u)) |> List.map (\user -> displayUser user)
         newUserMenu =
             if model.panelMode == AddMode then
                 displayRightPanelAddUser model
@@ -314,7 +314,7 @@ displayAddAuth model user  =
                         , div [id "remove-role",class "fa fa-times", onClick (RemoveRole user x)] []
                     ]
 
-            ) (user.role ++ user.authz)
+            ) (user.permissions ++ user.authz)
         roles = userRoles ++ newAddedRole
     in
     if (List.isEmpty roles) then
@@ -329,7 +329,7 @@ displayAuth user  =
             List.map (
                 \x ->
                     span [ class "auth" ][text x]
-            ) (user.role ++ user.authz)
+            ) (user.permissions ++ user.authz)
     in
     if (List.isEmpty userRoles) then
         span[class "list-auths-empty"]

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/DataTypes.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/DataTypes.scala
@@ -42,12 +42,11 @@ import bootstrap.liftweb.RudderConfig
 import bootstrap.liftweb.ValidatedUserList
 import com.normation.rudder.Role.Custom
 import com.normation.rudder.RudderRoles
-
+import com.normation.zio._
 import net.liftweb.common.Logger
 import net.liftweb.json.{Serialization => S}
 import net.liftweb.json.JsonAST.JValue
 import org.slf4j.LoggerFactory
-import com.normation.zio._
 
 /**
  * Applicative log of interest for Rudder ops.
@@ -66,10 +65,13 @@ object Serialisation {
       val jUser            = auth.users.map {
         case (_, u) =>
           val (rs, custom) = {
-            UserManagementService.computeRoleCoverage(RudderRoles.getAllRoles.runNow.values.toSet, u.authz.authorizationTypes).getOrElse(Set.empty).partition {
-              case Custom(_) => false
-              case _         => true
-            }
+            UserManagementService
+              .computeRoleCoverage(RudderRoles.getAllRoles.runNow.values.toSet, u.authz.authorizationTypes)
+              .getOrElse(Set.empty)
+              .partition {
+                case Custom(_) => false
+                case _         => true
+              }
           }
           JsonUser(
             u.getUsername,
@@ -103,7 +105,7 @@ final case class JsonAuthConfig(
 )
 
 final case class JsonUser(
-    login: String,
-    authz: Set[String],
-    role:  Set[String]
+    login:       String,
+    authz:       Set[String],
+    permissions: Set[String]
 )

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/Serialization.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/Serialization.scala
@@ -15,17 +15,17 @@ object Serialization {
   }
 
   def serializeUser(u: User): JValue = {
-    (("username"  -> u.username)
-    ~ ("password" -> u.password)
-    ~ ("role"     -> u.role))
+    (("username"     -> u.username)
+    ~ ("password"    -> u.password)
+    ~ ("permissions" -> u.permissions))
   }
 
   def serializeRole(rs: Set[Role]): JValue = {
-    val (roles, customs) = rs.partition {
+    val (permissions, customs) = rs.partition {
       case Custom(_) => false
       case _         => true
     }
-    (("role" -> roles.map(_.name))
+    (("permissions" -> permissions.map(_.name))
     ~ ("custom" -> customs.flatMap(_.rights.authorizationTypes.map(_.id)).toSeq.sorted))
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/22580

A pr that mostly change `role` into `permissions`. The main point of attention is to remain able to read the old `role` tag from rudder 7.2-