### PR TITLE
Fixes #23112: Add the role-retrieving OIDC feature to OAuth2

### DIFF
--- a/auth-backends/README.adoc
+++ b/auth-backends/README.adoc
@@ -348,9 +348,9 @@ Each provider needs to then have a bunch of properties defined for it. They are 
 We advise to configure each provider in its own configuration file under `/opt/rudder/etc/rudder-web.properties.d`
 so that it is easier to change or disable some of them.
 
-=== OIDC-provided authorisations for Rudder users
+=== IdP-provided authorisations for Rudder users
 
-You can configure an OIDC provider so that it informs Rudder of the roles the user need to have. This allows to centrally
+You can configure an OAuth2 or OIDC provider so that it informs Rudder of the roles the user need to have. This allows to centrally
 manage both user and authorisation in the same place.
 
 This feature works with the `custom roles` feature provided by the xref:plugins:user-management.adoc[user-management plugin]. Please see that linked documentation to understand how custom roles work in Rudder.

--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -266,7 +266,7 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
 
       RudderConfig.authenticationProviders.addSpringAuthenticationProvider(
         "oauth2",
-        oauth2AuthenticationProvider(rudderUserService)
+        oauth2AuthenticationProvider(rudderUserService, registrationRepository)
       )
       RudderConfig.authenticationProviders.addSpringAuthenticationProvider(
         "oidc",
@@ -343,9 +343,10 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
   }
 
   @Bean def oauth2UserService(
-      rudderUserDetailsService: RudderInMemoryUserDetailsService
+      rudderUserDetailsService: RudderInMemoryUserDetailsService,
+      registrationRepository:   RudderClientRegistrationRepository
   ): OAuth2UserService[OAuth2UserRequest, OAuth2User] = {
-    new RudderOAuth2UserService(rudderUserDetailsService)
+    new RudderOAuth2UserService(rudderUserDetailsService, registrationRepository)
   }
 
   // following beans are the detault one provided by spring security for oauth2 logic
@@ -372,10 +373,13 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
 
   @Bean def jwtDecoderFactory = new OidcIdTokenDecoderFactory()
 
-  @Bean def oauth2AuthenticationProvider(rudderUserDetailsService: RudderInMemoryUserDetailsService) = {
+  @Bean def oauth2AuthenticationProvider(
+      rudderUserDetailsService: RudderInMemoryUserDetailsService,
+      registrationRepository:   RudderClientRegistrationRepository
+  ) = {
     val x = new OAuth2LoginAuthenticationProvider(
       rudderAuthorizationCodeTokenResponseClient(),
-      oauth2UserService(rudderUserDetailsService)
+      oauth2UserService(rudderUserDetailsService, registrationRepository)
     )
     x.setAuthoritiesMapper(userAuthoritiesMapper)
     x
@@ -478,12 +482,14 @@ class RudderDefaultOAuth2AuthorizationRequestResolver(
 
 trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: RudderUserDetail with U] {
 
+  def registrationRepository: RudderClientRegistrationRepository
+  def protocolName:           String
+
   def mapRudderUser(
-      protocolName:             String,
       delegateLoadUser:         R => U,
       rudderUserDetailsService: RudderInMemoryUserDetailsService,
       userRequest:              R,
-      userBuilder:              (U, RudderUserDetail) => T
+      newUserDetails:           (U, RudderUserDetail) => T
   ): T = {
     val user = delegateLoadUser(userRequest)
     val sub  = user.getAttributes.get("sub").toString
@@ -494,89 +500,96 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
     // check that we know that user in our DB
     val rudderUser = rudderUserDetailsService.loadUserByUsername(user.getName)
 
-    userBuilder(user, rudderUser)
+    buildUser(userRequest, user, rudderUser, newUserDetails)
+  }
+
+  def buildUser(userRequest: R, user: U, rudder: RudderUserDetail, userBuilder: (U, RudderUserDetail) => T): T = {
+    val roles = {
+      registrationRepository.registrations.get(userRequest.getClientRegistration.getRegistrationId) match {
+        case None      =>
+          AuthBackendsLogger.trace(
+            s"No configuration found for ${protocolName} registration id: ${userRequest.getClientRegistration.getRegistrationId}"
+          )
+          rudder.roles // if no registration, use user roles
+        case Some(reg) =>
+          if (reg.roles.enabled) {
+            val custom = {
+              try {
+                import scala.jdk.CollectionConverters._
+                user
+                  .getAttribute[java.util.ArrayList[String]](reg.roles.attributeName)
+                  .asScala
+                  .map(r => RudderRoles.findRoleByName(r).runNow)
+                  .flatten
+                  .toSet
+              } catch {
+                case ex: Exception =>
+                  AuthBackendsLogger.warn(
+                    s"Unable to get custom roles for user '${rudder.getUsername}' when looking for attribute '${reg.roles.attributeName}' :${ex.getMessage}'"
+                  )
+                  Set.empty[Role]
+              }
+            }
+
+            if (custom.nonEmpty) {
+              ApplicationLoggerPure.Authz.logEffect.info(
+                s"Principal '${rudder.getUsername}' role list extended with ${protocolName} provided roles: [${custom.toList.map(_.name).sorted.mkString(", ")}] (override: ${reg.roles.over})"
+              )
+            } else {
+              AuthBackendsLogger.debug(
+                s"No roles provided by ${protocolName} in attribute: ${reg.roles.attributeName} (or attribute is missing, or user-management plugin is missing)"
+              )
+            }
+
+            val roles = if (reg.roles.over) {
+              // override means: don't use user role configured in rudder-users.xml
+              custom
+            } else {
+              rudder.roles ++ custom
+            }
+            AuthBackendsLogger.debug(
+              s"Principal '${rudder.getUsername}' final list of roles: [${roles.map(_.name).mkString(", ")}]"
+            )
+            roles
+
+          } else {
+            AuthBackendsLogger.debug(s"${protocolName} configuration is not configured to use token provided roles")
+            rudder.roles
+          }
+      }
+    }
+    // we need to update roles in all cases
+    userBuilder(user, rudder.copy(roles = roles))
   }
 
 }
 
 class RudderOidcUserService(
-    rudderUserDetailsService: RudderInMemoryUserDetailsService,
-    registrationRepository:   RudderClientRegistrationRepository
+    rudderUserDetailsService:            RudderInMemoryUserDetailsService,
+    override val registrationRepository: RudderClientRegistrationRepository
 ) extends OidcUserService with RudderUserServerMapping[OidcUserRequest, OidcUser, RudderUserDetail with OidcUser] {
+
   // we need to use our copy of DefaultOAuth2UserService to log/manage errors
   super.setOauth2UserService(new RudderDefaultOAuth2UserService())
 
+  override val protocolName = "OIDC"
+
   override def loadUser(userRequest: OidcUserRequest): OidcUser = {
-    def buildUser(oidc: OidcUser, rudder: RudderUserDetail): RudderOidcDetails = {
-      val roles = {
-        registrationRepository.registrations.get(userRequest.getClientRegistration.getRegistrationId) match {
-          case None      =>
-            AuthBackendsLogger.trace(
-              s"No configuration found for OIDC registration id: ${userRequest.getClientRegistration.getRegistrationId}"
-            )
-            rudder.roles // if no registration, use user roles
-          case Some(reg) =>
-            if (reg.roles.enabled) {
-              val custom = {
-                try {
-                  import scala.jdk.CollectionConverters._
-                  oidc
-                    .getAttribute[java.util.ArrayList[String]](reg.roles.attributeName)
-                    .asScala
-                    .map(r => RudderRoles.findRoleByName(r).runNow)
-                    .flatten
-                    .toSet
-                } catch {
-                  case ex: Exception =>
-                    AuthBackendsLogger.warn(
-                      s"Unable to get custom roles for user '${rudder.getUsername}' when looking for attribute '${reg.roles.attributeName}' :${ex.getMessage}'"
-                    )
-                    Set.empty[Role]
-                }
-              }
-
-              if (custom.nonEmpty) {
-                ApplicationLoggerPure.Authz.logEffect.info(
-                  s"Principal '${rudder.getUsername}' role list extended with OIDC provided roles: [${custom.toList.map(_.name).sorted.mkString(", ")}] (override: ${reg.roles.over})"
-                )
-              } else {
-                AuthBackendsLogger.debug(
-                  s"No roles provided by OIDC in attribute: ${reg.roles.attributeName} (or attribute is missing, or user-management plugin is missing)"
-                )
-              }
-
-              val roles = if (reg.roles.over) {
-                // override means: don't use user role configured in rudder-users.xml
-                custom
-              } else {
-                rudder.roles ++ custom
-              }
-              AuthBackendsLogger.debug(
-                s"Principal '${rudder.getUsername}' final list of roles: [${roles.map(_.name).mkString(", ")}]"
-              )
-              roles
-
-            } else {
-              AuthBackendsLogger.debug(s"OIDC configuration is not configured to use token provided roles")
-              rudder.roles
-            }
-        }
-      }
-      // we need to update
-      new RudderOidcDetails(oidc, rudder.copy(roles = roles))
-    }
-
-    mapRudderUser("OIDC", super.loadUser(_), rudderUserDetailsService, userRequest, buildUser(_, _))
+    mapRudderUser(super.loadUser(_), rudderUserDetailsService, userRequest, new RudderOidcDetails(_, _))
   }
 }
 
-class RudderOAuth2UserService(rudderUserDetailsService: RudderInMemoryUserDetailsService)
-    extends OAuth2UserService[OAuth2UserRequest, OAuth2User]
+class RudderOAuth2UserService(
+    rudderUserDetailsService:            RudderInMemoryUserDetailsService,
+    override val registrationRepository: RudderClientRegistrationRepository
+) extends OAuth2UserService[OAuth2UserRequest, OAuth2User]
     with RudderUserServerMapping[OAuth2UserRequest, OAuth2User, RudderUserDetail with OAuth2User] {
   val defaultUserService = new RudderDefaultOAuth2UserService()
 
+  override val protocolName = "OAuth2"
+
   override def loadUser(userRequest: OAuth2UserRequest): OAuth2User = {
-    mapRudderUser("Oauth2", defaultUserService.loadUser(_), rudderUserDetailsService, userRequest, new RudderOauth2Details(_, _))
+    mapRudderUser(defaultUserService.loadUser(_), rudderUserDetailsService, userRequest, new RudderOauth2Details(_, _))
   }
 }
 

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/AuthBackendsRepository.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/AuthBackendsRepository.scala
@@ -102,7 +102,7 @@ class AuthBackendsRepository(
 
     val file = JsonFileConfig(
       "file",
-      """By default, Rudder authentication is collocated with user authorisation
+      """By default, Rudder authentication is collocated with user authorization
         |in 'rudder-user.xml' file. The file is located:""".stripMargin,
       "/opt/rudder/etc/rudder-users.xml"
     )

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/AuthBackendsRepository.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/AuthBackendsRepository.scala
@@ -77,7 +77,7 @@ class AuthBackendsRepository(
       }
     }
 
-    // hide a passward with stars
+    // hide a password with stars
     implicit class HideValue(conf: ConfigOption) {
       def hideValue() = conf.copy(value = "****")
     }
@@ -102,7 +102,7 @@ class AuthBackendsRepository(
 
     val file = JsonFileConfig(
       "file",
-      """By default, Rudder authentication is collocated with user authorisatoin
+      """By default, Rudder authentication is collocated with user authorisation
         |in 'rudder-user.xml' file. The file is located:""".stripMargin,
       "/opt/rudder/etc/rudder-users.xml"
     )


### PR DESCRIPTION
https://issues.rudder.io/issues/23112

The role mapping was only done in a OIDC case, in a ` buildUser` function in the OIDC specialized `loadUser` function.
That PR factorize-out the `buildUser` function to put it into the generic `RudderUserServerMapping` trait. That works well because we retrieve group attribute with a function (`getAttribute[java.util.ArrayList[String]](reg.roles.attributeName)`) that is common to both protocol. 
The remaining bits are just gluing:
- pass the protocol name as a parameter for have correct logs
- add the `RudderClientRegistrationRepository` in the trait because it is now required for both, and change class parameters to match it
- generalize the user details creation to adapt to both `OAuth2` and `OIDC` case in there respective implementation.

Also correct a pair of unrelated typos.