### PR TITLE
Fixes #23254: User management plugin incorrectly understand OIDC roles

### DIFF
--- a/user-management/README.adoc
+++ b/user-management/README.adoc
@@ -16,7 +16,7 @@ This plugin allows to get new capabilities for user management:
 - and a UI is added in Rudder `Administration` menu to help with user management.
 
 Note that the xref:plugins:api-authorizations.adoc[API authorizations] plugin also extends user
-rights with a self-service UI to manage an API token to perform API calls with their personal account. 
+rights with a self-service UI to manage an API token to perform API calls with their personal account.
 See the xref:plugins:api-authorizations.adoc[plugin documentation] if you need more info about that feature.
 
 
@@ -190,9 +190,20 @@ The UI is available in the `Administration` menu on `User management` entry (1):
 image::docs/images/usermanagement-ui.png[]
 
 With that UI, you can add a new user (2), reload `/opt/rudder/etc/rudder-users.xml` file from disk (3) and see
-what is the current authentication method configured for users (see the xref:plugins:auth-backends.adoc[authentication
+what is the current authentication method configured for users (4) (see the xref:plugins:auth-backends.adoc[authentication
 backends plugin] for more information on that subject).
-You also have access to the list of configured users and their permissions (5). When you click on a user, you get
+You also have access to the list of configured users and their permissions (5).
+
+[WARNING]
+====
+
+The given role list is the one statically configured in `/opt/rudder/etc/rudder-users.xml`. Some plugin
+are able to change that list when user logs in if centralized authorization management is used. For example, OIDC plugin can do that.
+In that case, the actual list of role the user got is logged in the application logs and a warning message is displayed in (4).
+
+====
+
+When you click on a user, you get
 the user details and you can update them:
 
 image::docs/images/usermanagement-ui-user-details.png[]

--- a/user-management/src/main/elm/sources/Init.elm
+++ b/user-management/src/main/elm/sources/Init.elm
@@ -1,7 +1,7 @@
 module Init exposing (..)
 
 import ApiCalls exposing (getUsersConf)
-import DataTypes exposing (Authorization, Model, Msg(..), PanelMode(..), StateInput(..))
+import DataTypes exposing (Authorization, Model, Msg(..), PanelMode(..), RoleListOverride(..), StateInput(..))
 import Dict exposing (fromList)
 import Html.Attributes exposing (style)
 import Http
@@ -19,7 +19,7 @@ authorizations =
 init : { contextPath : String } -> ( Model, Cmd Msg )
 init flags =
     let
-        initModel = Model flags.contextPath "" (fromList []) (fromList []) [] authorizations Toasty.initialState Closed "" "" True ValidInputs [] [] False False
+        initModel = Model flags.contextPath "" (fromList []) (fromList []) [] None authorizations Toasty.initialState Closed "" "" True ValidInputs [] [] False False
     in
     ( initModel
     , getUsersConf initModel

--- a/user-management/src/main/elm/sources/JsonDecoder.elm
+++ b/user-management/src/main/elm/sources/JsonDecoder.elm
@@ -1,6 +1,6 @@
 module JsonDecoder exposing (..)
 
-import DataTypes exposing (Authorization, Role, RoleConf, User, UsersConf)
+import DataTypes exposing (Authorization, Role, RoleConf, RoleListOverride(..), User, UsersConf)
 import Json.Decode as D exposing (Decoder)
 import Json.Decode.Pipeline exposing (required)
 
@@ -22,8 +22,20 @@ decodeCurrentUsersConf : Decoder UsersConf
 decodeCurrentUsersConf =
     D.succeed UsersConf
         |> required "digest" D.string
+        |> required "roleListOverride" decodeRoleListOverride
         |> required "authenticationBackends" (D.list <| D.string)
         |> required "users" (D.list <| decodeUser)
+
+decodeRoleListOverride : Decoder RoleListOverride
+decodeRoleListOverride =
+  D.string |> D.andThen
+    (\str ->
+      case str of
+        "extend"   -> D.succeed Extend
+        "override" -> D.succeed Override
+        _          -> D.succeed None
+    )
+
 
 decodeUser : Decoder User
 decodeUser =

--- a/user-management/src/main/elm/sources/UserManagement.elm
+++ b/user-management/src/main/elm/sources/UserManagement.elm
@@ -2,7 +2,7 @@ module UserManagement exposing (processApiError, update)
 
 import ApiCalls exposing (addUser, computeRoleCoverage, getRoleConf, getUsersConf, postReloadConf, updateUser)
 import Browser
-import DataTypes exposing (Authorization, Model, Msg(..), PanelMode(..), Provider(..), StateInput(..), User, Username, Users, toProvider)
+import DataTypes exposing (Authorization, Model, Msg(..), PanelMode(..), StateInput(..), User, Username, Users, userProviders)
 import Dict exposing (fromList)
 import Http exposing (..)
 import Init exposing (createErrorNotification, createSuccessNotification, defaultConfig, init, subscriptions)
@@ -37,11 +37,10 @@ update msg model =
             case result of
                 Ok u ->
                     let
-                        knownProviders = List.filter (\p -> p /= Unknown) (List.map toProvider u.authenticationBackends)
                         recordUser =
                             List.map (\x -> (x.login, (Authorization x.authz  x.permissions))) u.users
                         newModel =
-                            { model | users = fromList recordUser, digest = u.digest, providers = knownProviders}
+                            { model | roleListOverride = u.roleListOverride, users = fromList recordUser, digest = u.digest, providers = (userProviders u.authenticationBackends)}
 
                     in
                     ( newModel, getRoleConf model )


### PR DESCRIPTION
https://issues.rudder.io/issues/23254

A first PR for the problematic of dynamic role. This one is done so that it is compatible with current Rudder 7.3 and so we don't have the real configuration option for OIDC role override. So we just add a generic warning message to avoid surprise. 

This PR also correct the fact that the list of authentication providers is hard coded in user management (to provide human readable version ?) and that authentication provider out of that not-maintained list are IGNORED. 
At some point, we will have a type for providers, with their properties (does it override roles, etc), but we should never ignore unknown providers! I just removed the types, because they would likely be something else. 
This was why OIDC was not listed and so user got false information.

Message:
![image](https://github.com/Normation/rudder-plugins/assets/44649/e2062457-5f4b-45d6-bb40-2b8a71549d8e)
![image](https://github.com/Normation/rudder-plugins/assets/44649/e0b0a8d7-632d-4b4a-836c-cf91fa6a51be)

