### PR TITLE
Fixes #23348: not allowed to access errors because rudder plugins are missing AuthorizationApiMapping 

### DIFF
--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/api/AuthBackendsApi.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/api/AuthBackendsApi.scala
@@ -56,6 +56,8 @@ import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModule0
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
+import com.normation.rudder.AuthorizationType
+
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import net.liftweb.json._
@@ -75,6 +77,7 @@ object AuthBackendsApi       extends ApiModuleProvider[AuthBackendsApi] {
     val description    = "Get information about current authentication configuration"
     val (action, path) = GET / "authbackends" / "current-configuration"
 
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
     override def dataContainer: Option[String] = None
   }
 

--- a/branding/src/main/scala/com/normation/rudder/rest/BrandingApiSchema.scala
+++ b/branding/src/main/scala/com/normation/rudder/rest/BrandingApiSchema.scala
@@ -38,6 +38,8 @@
 package com.normation.rudder.rest
 
 import com.normation.rudder.api.HttpAction._
+import com.normation.rudder.AuthorizationType
+
 import sourcecode.Line
 
 /*
@@ -54,7 +56,7 @@ object BrandingApiEndpoints extends ApiModuleProvider[BrandingApiSchema] {
     val description    = "Get branding plugin configuration"
     val (action, path) = GET / "branding"
     val dataContainer: Option[String] = None
-
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
   final case object UpdateBrandingConf extends BrandingApiSchema with ZeroParam with StartsAtVersion10 with SortIndex {

--- a/change-validation/src/main/scala/bootstrap/rudder/plugin/ChangeValidationConf.scala
+++ b/change-validation/src/main/scala/bootstrap/rudder/plugin/ChangeValidationConf.scala
@@ -44,6 +44,7 @@ import bootstrap.liftweb.RudderConfig.restDataSerializer
 import bootstrap.liftweb.RudderConfig.restExtractorService
 import bootstrap.liftweb.RudderConfig.techniqueRepository
 import bootstrap.liftweb.RudderConfig.workflowLevelService
+
 import com.normation.box._
 import com.normation.eventlog.EventActor
 import com.normation.plugins.PluginStatus
@@ -73,17 +74,13 @@ import com.normation.plugins.changevalidation.api.ChangeRequestApi
 import com.normation.plugins.changevalidation.api.ChangeRequestApiImpl
 import com.normation.plugins.changevalidation.api.SupervisedTargetsApi
 import com.normation.plugins.changevalidation.api.SupervisedTargetsApiImpl
+import com.normation.plugins.changevalidation.api.ValidatedUserApi
 import com.normation.plugins.changevalidation.api.ValidatedUserApiImpl
-import com.normation.rudder.AuthorizationType
-import com.normation.rudder.AuthorizationType.Deployer
-import com.normation.rudder.AuthorizationType.Validator
-import com.normation.rudder.api.ApiAclElement
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.workflows.ChangeRequest
 import com.normation.rudder.rest.ApiModuleProvider
-import com.normation.rudder.rest.AuthorizationApiMapping
 import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
@@ -93,6 +90,7 @@ import com.normation.rudder.services.workflows.NodeGroupChangeRequest
 import com.normation.rudder.services.workflows.RuleChangeRequest
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.services.workflows.WorkflowService
+
 import java.nio.file.Paths
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
@@ -324,29 +322,7 @@ object ChangeValidationConf extends RudderPluginModule {
     )
     new LiftApiModuleProvider[EndpointSchema] {
       override def schemas = new ApiModuleProvider[EndpointSchema] {
-        override def endpoints = SupervisedTargetsApi.endpoints ::: ChangeRequestApi.endpoints
-
-        import AuthorizationApiMapping.ToAuthz
-
-        /*
-         * Here, rights are not sufficiently precise: the check need to know the value
-         * of the "status" parameter to decide if a validator (resp a deployer) can do
-         * what he asked for.
-         */
-        override def authorizationApiMapping: AuthorizationApiMapping = new AuthorizationApiMapping {
-          override def mapAuthorization(authz: AuthorizationType): List[ApiAclElement] = {
-            authz match {
-              case Deployer.Read   => ChangeRequestApi.ListChangeRequests.x :: ChangeRequestApi.ChangeRequestsDetails.x :: Nil
-              case Deployer.Write  => ChangeRequestApi.DeclineRequestsDetails.x :: ChangeRequestApi.AcceptRequestsDetails.x :: Nil
-              case Deployer.Edit   => ChangeRequestApi.UpdateRequestsDetails.x :: Nil
-              case Validator.Read  => ChangeRequestApi.ListChangeRequests.x :: ChangeRequestApi.ChangeRequestsDetails.x :: Nil
-              case Validator.Write => ChangeRequestApi.DeclineRequestsDetails.x :: ChangeRequestApi.AcceptRequestsDetails.x :: Nil
-              case Validator.Edit  => ChangeRequestApi.UpdateRequestsDetails.x :: Nil
-
-              case _ => Nil
-            }
-          }
-        }
+        override def endpoints = ValidatedUserApi.endpoints ::: SupervisedTargetsApi.endpoints ::: ChangeRequestApi.endpoints
       }
 
       override def getLiftEndpoints(): List[LiftApiModule] =

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowService.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowService.scala
@@ -266,10 +266,10 @@ class TwoValidationStepsWorkflowServiceImpl(
   }
 
   def isEditable(currentUserRights: Seq[String], currentStep: WorkflowNodeId, isCreator: Boolean): Boolean = {
-    val authorizedRoles = currentUserRights.filter(role => role == Role.Validator.name || role == Role.Deployer.name)
+    val authorizedRoles = currentUserRights.filter(role => role == Role.BuiltinName.Validator.value || role == Role.BuiltinName.Deployer.value)
     currentStep match {
-      case Validation.id     => authorizedRoles.contains(Role.Validator.name) || isCreator
-      case Deployment.id     => authorizedRoles.contains(Role.Deployer.name)
+      case Validation.id     => authorizedRoles.contains(Role.BuiltinName.Validator.value) || isCreator
+      case Deployment.id     => authorizedRoles.contains(Role.BuiltinName.Deployer.value)
       case Deployed.id       => false
       case Cancelled.id      => false
       case WorkflowNodeId(x) =>

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ChangeRequestApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ChangeRequestApi.scala
@@ -93,6 +93,7 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
     val description    = "List all change requests"
     val (action, path) = GET / "changeRequests"
 
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Deployer.Read, AuthorizationType.Validator.Read)
     override def dataContainer: Option[String] = None
   }
   final case object ChangeRequestsDetails  extends ChangeRequestApi with OneParam with StartsAtVersion3 with SortIndex  {
@@ -100,6 +101,7 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
     val description    = "Get information about given change request"
     val (action, path) = GET / "changeRequests" / "{id}"
 
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Deployer.Read, AuthorizationType.Validator.Read)
     override def dataContainer: Option[String] = None
   }
   final case object DeclineRequestsDetails extends ChangeRequestApi with OneParam with StartsAtVersion3 with SortIndex  {
@@ -107,6 +109,7 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
     val description    = "Decline given change request"
     val (action, path) = DELETE / "changeRequests" / "{id}"
 
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Deployer.Write, AuthorizationType.Deployer.Edit, AuthorizationType.Validator.Write, AuthorizationType.Validator.Edit)
     override def dataContainer: Option[String] = None
   }
   final case object AcceptRequestsDetails  extends ChangeRequestApi with OneParam with StartsAtVersion3 with SortIndex  {
@@ -114,6 +117,7 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
     val description    = "Accept given change request"
     val (action, path) = POST / "changeRequests" / "{id}" / "accept"
 
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Deployer.Write, AuthorizationType.Deployer.Edit, AuthorizationType.Validator.Write, AuthorizationType.Validator.Edit)
     override def dataContainer: Option[String] = None
   }
   final case object UpdateRequestsDetails  extends ChangeRequestApi with OneParam with StartsAtVersion3 with SortIndex  {
@@ -121,6 +125,7 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
     val description    = "Update information about given change request"
     val (action, path) = POST / "changeRequests" / "{id}"
 
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Deployer.Write, AuthorizationType.Deployer.Edit, AuthorizationType.Validator.Write, AuthorizationType.Validator.Edit)
     override def dataContainer: Option[String] = None
   }
 

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/SupervisedTargetsApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/SupervisedTargetsApi.scala
@@ -59,6 +59,8 @@ import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModule0
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
+import com.normation.rudder.AuthorizationType
+
 import net.liftweb.common._
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
@@ -81,6 +83,7 @@ object SupervisedTargetsApi       extends ApiModuleProvider[SupervisedTargetsApi
     val (action, path) = GET / "changevalidation" / "supervised" / "targets"
 
     override def dataContainer: Option[String] = None
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
   final case object UpdateSupervisedTargets extends SupervisedTargetsApi with ZeroParam with StartsAtVersion10 {
     val z              = implicitly[Line].value

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ValidatedUserApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ValidatedUserApi.scala
@@ -54,6 +54,8 @@ import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModule0
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
+import com.normation.rudder.AuthorizationType
+
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
 import net.liftweb.http.LiftResponse
@@ -74,6 +76,7 @@ object ValidatedUserApi       extends ApiModuleProvider[ValidatedUserApi] {
     val (action, path) = GET / "users"
 
     override def dataContainer: Option[String] = None
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
   final case object DeleteValidatedUsersDetails extends ValidatedUserApi with OneParam with StartsAtVersion3 with SortIndex  {
     val z              = implicitly[Line].value

--- a/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
@@ -40,6 +40,8 @@ package com.normation.plugins.datasources.api
 import com.normation.rudder.api.HttpAction._
 import com.normation.rudder.rest._
 import com.normation.rudder.rest.EndpointSchema.syntax._
+import com.normation.rudder.AuthorizationType
+
 import sourcecode.Line
 
 sealed trait DataSourceApi extends EndpointSchema with GeneralApi with SortIndex
@@ -113,6 +115,7 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val (action, path) = GET / "datasources"
 
     override def dataContainer: Option[String] = None
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
   final case object GetDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
@@ -121,6 +124,7 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val (action, path) = GET / "datasources" / "{datasourceid}"
 
     override def dataContainer: Option[String] = None
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
   final case object DeleteDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/api/UserManagementApi.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/api/UserManagementApi.scala
@@ -81,6 +81,7 @@ object UserManagementApi       extends ApiModuleProvider[UserManagementApi] {
     val description    = "Get information about registered users in Rudder"
     val (action, path) = GET / "usermanagement" / "users"
 
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
     override def dataContainer: Option[String] = None
   }
 
@@ -89,6 +90,7 @@ object UserManagementApi       extends ApiModuleProvider[UserManagementApi] {
     val description    = "Get roles and their authorizations"
     val (action, path) = GET / "usermanagement" / "roles"
 
+    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
     override def dataContainer: Option[String] = None
   }
 

--- a/user-management/src/test/scala/com/normation/plugins/usermanagement/RoleComputationTest.scala
+++ b/user-management/src/test/scala/com/normation/plugins/usermanagement/RoleComputationTest.scala
@@ -16,34 +16,34 @@ class RoleComputationTest extends Specification {
   "Computation of Role Coverage over Rights" should {
 
     "return 'None' when parameters are empty" in {
-      (computeRoleCoverage(Set(Role.User), Set()) must beNone) and
+      (computeRoleCoverage(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)), Set()) must beNone) and
       (computeRoleCoverage(Set(), Set(AuthorizationType.Compliance.Read)) must beNone) and
       (computeRoleCoverage(Set(), Set()) must beNone)
     }
 
     "return 'None' when authzs contains no_rights" in {
-      (computeRoleCoverage(Set(Role.User), Set(AuthorizationType.NoRights)) must beNone) and
-      (computeRoleCoverage(Set(Role.User), Set(AuthorizationType.NoRights) ++ AuthorizationType.allKind) must beNone)
+      (computeRoleCoverage(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)), Set(AuthorizationType.NoRights)) must beNone) and
+      (computeRoleCoverage(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)), Set(AuthorizationType.NoRights) ++ AuthorizationType.allKind) must beNone)
     }
 
     "return a 'Custom' role for empty intersection" in {
-      computeRoleCoverage(Set(Role.User), Set(AuthorizationType.Compliance.Read)) must beEqualTo(
+      computeRoleCoverage(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)), Set(AuthorizationType.Compliance.Read)) must beEqualTo(
         Some(Set(Role.forRight(AuthorizationType.Compliance.Read)))
       )
     }
 
     "contains 'Inventory' and 'Custom' roles" in {
       computeRoleCoverage(
-        Role.values,
-        Set(AuthorizationType.Compliance.Read) ++ Role.Inventory.rights.authorizationTypes
-      ) must beEqualTo(Some(Set(Role.Inventory, Role.forRight(AuthorizationType.Compliance.Read))))
+        Role.allBuiltInRoles.values.toSet,
+        Set(AuthorizationType.Compliance.Read) ++ Role.allBuiltInRoles(Role.BuiltinName.Inventory.value).rights.authorizationTypes
+      ) must beEqualTo(Some(Set(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value), Role.forRight(AuthorizationType.Compliance.Read))))
     }
 
     "only detect 'Inventory' role" in {
       computeRoleCoverage(
-        Set(Role.Inventory),
-        Role.Inventory.rights.authorizationTypes
-      ) must beEqualTo(Some(Set(Role.Inventory)))
+        Set(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value)),
+        Role.allBuiltInRoles(Role.BuiltinName.Inventory.value).rights.authorizationTypes
+      ) must beEqualTo(Some(Set(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value))))
     }
 
     "only detect one custom role" in { // why ?
@@ -53,30 +53,30 @@ class RoleComputationTest extends Specification {
         AuthorizationType.UserAccount.Edit
       )
       computeRoleCoverage(
-        Set(Role.User, Role.Inventory),
+        Set(Role.allBuiltInRoles(Role.BuiltinName.User.value), Role.allBuiltInRoles(Role.BuiltinName.Inventory.value)),
         a
       ) must beEqualTo(Some(Set(Role.forRights(a))))
     }
 
     "return administrator " in {
       computeRoleCoverage(
-        Role.values,
+        Role.allBuiltInRoles.values.toSet,
         AuthorizationType.allKind
       ) must beEqualTo(Some(Set(Role.Administrator)))
     }
 
     "allows intersection between know roles" in {
       computeRoleCoverage(
-        Set(Role.Inventory, Role.User),
-        Role.User.rights.authorizationTypes ++ Role.Inventory.rights.authorizationTypes
-      ) must beEqualTo(Some(Set(Role.User, Role.Inventory)))
+        Set(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value), Role.allBuiltInRoles(Role.BuiltinName.User.value)),
+        Role.allBuiltInRoles(Role.BuiltinName.User.value).rights.authorizationTypes ++ Role.allBuiltInRoles(Role.BuiltinName.Inventory.value).rights.authorizationTypes
+      ) must beEqualTo(Some(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value), Role.allBuiltInRoles(Role.BuiltinName.Inventory.value))))
     }
 
     "ignore NoRights role" in {
       computeRoleCoverage(
-        Set(Role.NoRights, Role.User),
-        Role.User.rights.authorizationTypes
-      ) must beEqualTo(Some(Set(Role.User)))
+        Set(Role.NoRights, Role.allBuiltInRoles(Role.BuiltinName.User.value)),
+        Role.allBuiltInRoles(Role.BuiltinName.User.value).rights.authorizationTypes
+      ) must beEqualTo(Some(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value))))
     }
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/23348

Use the new facility provided by https://github.com/Normation/rudder/pull/5004 to declare rights along with the API schema. Correct a bunch of API rights which were using the default one (`Administrator.Write`) in place of something less powerful (often `Administration.Read`)

For change validation: 
- the dedicated api right mapper is not useful anymore, 
- it was missing `ValidatedUser` in the list of aggregated endpoints, which was causing specific additional problems. 