### PR TITLE
Fixes #23563: When a datasource is deleted, its properties should be deleted

### DIFF
--- a/datasources/README.adoc
+++ b/datasources/README.adoc
@@ -172,4 +172,8 @@ You need to choose one behavior among:
 - Do not change the node property corresponding to that data source,
 - Set the node property corresponding to the data source to a configured value. You have access to a field to fill the value, where JSON is accepted. If the field is let empty, the node property is deleted (ie equivalent to first option).
 
+== Deleting a data source
 
+When a data source is deleted, the corresponding properties on nodes will also be deleted if and only if they were set by the data source (ie property
+name is data source `ID` and property `provider` is `datasources` plugin).
+If you don't want to delete properties linked to a data source, you should only disable it in place of deleting it. 

--- a/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
@@ -37,11 +37,10 @@
 
 package com.normation.plugins.datasources.api
 
+import com.normation.rudder.AuthorizationType
 import com.normation.rudder.api.HttpAction._
 import com.normation.rudder.rest._
 import com.normation.rudder.rest.EndpointSchema.syntax._
-import com.normation.rudder.AuthorizationType
-
 import sourcecode.Line
 
 sealed trait DataSourceApi extends EndpointSchema with GeneralApi with SortIndex
@@ -114,8 +113,8 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val description    = "Get the list of all defined datasources"
     val (action, path) = GET / "datasources"
 
-    override def dataContainer: Option[String] = None
-    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
+    override def dataContainer: Option[String]          = None
+    override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
   final case object GetDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
@@ -123,8 +122,8 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val description    = "Get information about the given datasource"
     val (action, path) = GET / "datasources" / "{datasourceid}"
 
-    override def dataContainer: Option[String] = None
-    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
+    override def dataContainer: Option[String]          = None
+    override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
   final case object DeleteDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {

--- a/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApiImpl.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApiImpl.scala
@@ -337,7 +337,14 @@ class DataSourceApiImpl(
     ): LiftResponse = {
 
       val res = for {
-        source <- dataSourceRepo.delete(DataSourceId(sourceId))
+        source <- dataSourceRepo.delete(
+                    DataSourceId(sourceId),
+                    UpdateCause(
+                      ModificationId(uuidGen.newUuid),
+                      authzToken.actor,
+                      Some(s"Deletion of datasource '${sourceId}' requested by API")
+                    )
+                  )
       } yield {
         JArray((("id" -> sourceId) ~ ("message" -> s"Data source ${sourceId} deleted")) :: Nil)
       }


### PR DESCRIPTION
https://issues.rudder.io/issues/23563

Delete property related to datasource when the datasource is deleted. 

Main changes: 
- factor out the logic to update the node property for the datasource so that it can be used in both update and delete method, 
- add a `cause` to delete. Likely other methods from the repo should have it too. 
- add a `deleteAll` method in `HttpQueryDataSourceService` because it's really it that has the logic to things on node, not the repository (the repo is just the warrant for datasource backend/liveness consistency)
- add a unit test that checks that the properties are really gone when the datasource is deleted.

Note: deletion of a datasource will only remove properties with the `datasource` provider. 
It allows the following use case: 
- configure datasources with "on missing (404), keep node properties"
- get values from remote provider, but for the missing one, set value by hand one nodes
- if you delete the datasource, the properties manage by hand are still there, managed by hand. 

If you don't want to delete properties, you can just disable the datasource in place of deleting it. 
A latter feature could be to add a check box in the deletion confirmation pop-up, asking for what to do. 
