### PR TITLE
Fixes #23444: Impact of adding UserInfo base on public plugins

### DIFF
--- a/auth-backends/README.adoc
+++ b/auth-backends/README.adoc
@@ -475,7 +475,7 @@ so that it is easier to change or disable some of them.
 
 === IdP-provided authorisations for Rudder users
 
-You can configure an OAuth2 or OIDC provider so that it informs Rudder of the roles the user need to have. This allows to centrally
+You can configure an `OAuth2` or `OIDC` provider so that it informs Rudder of the roles the user need to have. This allows to centrally
 manage both user and authorisation in the same place.
 
 This feature works with the `custom roles` feature provided by the xref:plugins:user-management.adoc[user-management plugin]. Please see that linked documentation to understand how custom roles work in Rudder.
@@ -487,6 +487,15 @@ You need three additional properties to enable and configure that property for a
   are merged with the `rudder-users.xml` ones.
 
 See the example configuration file below for details about these property values.
+
+=== IdP provisioning for Rudder users
+
+You can configure an `OAuth2` or `OIDC` provider so that users that are correctly authenticated with it can be automatically created in Rudder. This allows to avoid changing `rudder-users.xml` file.
+By default, user provisioned by that way don't have any rights. You will need to also configure roles provisioning through your IdP (see previous section).
+
+To allow IdP provisioning of users, set property `enableProvisionning` to `true` (default `false`).
+
+See the example configuration file below for details about that property.
 
 === Example configuration for `okta` provider
 
@@ -578,9 +587,9 @@ rudder.auth.oauth2.provider.okta.grantType=authorization_code
 rudder.auth.oauth2.provider.okta.authMethod=client_secret_basic
 
 #
-# Properties to configure roles provisioning through the OIDC token
+# Properties to configure roles and users provisioning through the OIDC token
 #
-# enable Rudder user role provisioning by the OIDC IdP. use `true` or `false` (default)
+# enable Rudder user role provisioning by the OIDC IdP. Use `true` or `false` (default)
 rudder.auth.oauth2.provider.okta.roles.enabled=true
 #Name of the OIDC token attribute that will hold rudder roles. This is something that you identity provider
 #administrator will give you. The attribute value must be a OAuth list of string, ie in the format:
@@ -590,7 +599,10 @@ rudder.auth.oauth2.provider.okta.roles.attribute=rudderroles
 #Define if the provided list of roles should *override* or *be appended to* the list of roles configured for
 #the user in the `rudder-users.xml` file. Use `false` for append (default), `true` for override.
 rudder.auth.oauth2.provider.okta.roles.override=true
-
+# enable Rudder user provisioning by the OIDC IdP. Use `true` or `false` (default).
+# Users provisioned through that channel don't have roles, you will need to also
+# provisioned roles thanks to IdP.
+rudder.auth.oauth2.provider.okta.enableProvisionning=true
 
 ```
 

--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -55,14 +55,16 @@ import com.normation.plugins.authbackends.api.AuthBackendsApiImpl
 import com.normation.plugins.authbackends.snippet.Oauth2LoginBanner
 import com.normation.rudder.Role
 import com.normation.rudder.RudderRoles
+import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.domain.logger.PluginLogger
-import com.normation.rudder.web.services.RudderUserDetail
+import com.normation.rudder.users._
 import com.normation.zio._
 import com.typesafe.config.ConfigException
 import java.util
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import org.joda.time.DateTime
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.context.annotation.Bean
@@ -76,6 +78,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper
+import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationProvider
@@ -91,17 +94,8 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequestEntityConverter
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
-import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
-import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository
-import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter
-import org.springframework.security.oauth2.core.OAuth2AccessToken
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException
-import org.springframework.security.oauth2.core.OAuth2AuthorizationException
-import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.client.web._
+import org.springframework.security.oauth2.core._
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.oidc.OidcIdToken
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo
@@ -208,7 +202,7 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
    * and provide a hook in the `HttpSecurity` configurer to let plugins
    * add their configuration. Everything would be so much easier.
    * Since we don't have that code base config, we need to:
-   * - all the (oauth2, oidc)AuthenticationProvider by hand in rudder (since we don't have an xml file for them)
+   * - init all the (oauth2, oidc)AuthenticationProvider by hand in rudder (since we don't have an xml file for them)
    * - build filter by hand. To know what to do and avoid NPEs, we look how it's done in the code configurer class
    * - hi-jack the main security filter, declared in applicationContext-security.xml, update the list of filters,
    *   and put it back into spring.
@@ -256,11 +250,11 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
 
       RudderConfig.authenticationProviders.addSpringAuthenticationProvider(
         "oauth2",
-        oauth2AuthenticationProvider(rudderUserService, registrationRepository)
+        oauth2AuthenticationProvider(rudderUserService, registrationRepository, RudderConfig.userRepository)
       )
       RudderConfig.authenticationProviders.addSpringAuthenticationProvider(
         "oidc",
-        oidcAuthenticationProvider(rudderUserService, registrationRepository)
+        oidcAuthenticationProvider(rudderUserService, registrationRepository, RudderConfig.userRepository)
       )
       val manager =
         applicationContext.getBean("org.springframework.security.authenticationManager", classOf[AuthenticationManager])
@@ -327,16 +321,18 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
    */
   @Bean def oidcUserService(
       rudderUserDetailsService: RudderInMemoryUserDetailsService,
-      registrationRepository:   RudderClientRegistrationRepository
+      registrationRepository:   RudderClientRegistrationRepository,
+      userRepository:           UserRepository
   ): OidcUserService = {
-    new RudderOidcUserService(rudderUserDetailsService, registrationRepository)
+    new RudderOidcUserService(rudderUserDetailsService, registrationRepository, userRepository)
   }
 
   @Bean def oauth2UserService(
       rudderUserDetailsService: RudderInMemoryUserDetailsService,
-      registrationRepository:   RudderClientRegistrationRepository
+      registrationRepository:   RudderClientRegistrationRepository,
+      userRepository:           UserRepository
   ): OAuth2UserService[OAuth2UserRequest, OAuth2User] = {
-    new RudderOAuth2UserService(rudderUserDetailsService, registrationRepository)
+    new RudderOAuth2UserService(rudderUserDetailsService, registrationRepository, userRepository)
   }
 
   // following beans are the default one provided by spring security for oauth2 logic
@@ -365,11 +361,12 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
 
   @Bean def oauth2AuthenticationProvider(
       rudderUserDetailsService: RudderInMemoryUserDetailsService,
-      registrationRepository:   RudderClientRegistrationRepository
+      registrationRepository:   RudderClientRegistrationRepository,
+      userRepository:           UserRepository
   ) = {
     val x = new OAuth2LoginAuthenticationProvider(
       rudderAuthorizationCodeTokenResponseClient(),
-      oauth2UserService(rudderUserDetailsService, registrationRepository)
+      oauth2UserService(rudderUserDetailsService, registrationRepository, userRepository)
     )
     x.setAuthoritiesMapper(userAuthoritiesMapper)
     x
@@ -377,11 +374,12 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
 
   @Bean def oidcAuthenticationProvider(
       rudderUserDetailsService: RudderInMemoryUserDetailsService,
-      registrationRepository:   RudderClientRegistrationRepository
+      registrationRepository:   RudderClientRegistrationRepository,
+      userRepository:           UserRepository
   ): OidcAuthorizationCodeAuthenticationProvider = {
     val x = new OidcAuthorizationCodeAuthenticationProvider(
       rudderAuthorizationCodeTokenResponseClient(),
-      oidcUserService(rudderUserDetailsService, registrationRepository)
+      oidcUserService(rudderUserDetailsService, registrationRepository, userRepository)
     )
     x.setJwtDecoderFactory(jwtDecoderFactory)
     x.setAuthoritiesMapper(userAuthoritiesMapper)
@@ -402,7 +400,7 @@ class RudderClientRegistrationRepository(val registrations: Map[String, RudderCl
 }
 
 final class RudderOidcDetails(oidc: OidcUser, rudder: RudderUserDetail)
-    extends RudderUserDetail(rudder.account, rudder.roles, rudder.apiAuthz, rudder.nodePerms) with OidcUser {
+    extends RudderUserDetail(rudder.account, rudder.status, rudder.roles, rudder.apiAuthz, rudder.nodePerms) with OidcUser {
   override def getClaims:     util.Map[String, AnyRef] = oidc.getClaims
   override def getUserInfo:   OidcUserInfo             = oidc.getUserInfo
   override def getIdToken:    OidcIdToken              = oidc.getIdToken
@@ -411,7 +409,7 @@ final class RudderOidcDetails(oidc: OidcUser, rudder: RudderUserDetail)
 }
 
 final class RudderOauth2Details(oauth2: OAuth2User, rudder: RudderUserDetail)
-    extends RudderUserDetail(rudder.account, rudder.roles, rudder.apiAuthz, rudder.nodePerms) with OAuth2User {
+    extends RudderUserDetail(rudder.account, rudder.status, rudder.roles, rudder.apiAuthz, rudder.nodePerms) with OAuth2User {
   override def getAttributes: util.Map[String, AnyRef] = oauth2.getAttributes
   override def getName:       String                   = oauth2.getName
 }
@@ -478,6 +476,7 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
   def mapRudderUser(
       delegateLoadUser:         R => U,
       rudderUserDetailsService: RudderInMemoryUserDetailsService,
+      userRepository:           UserRepository,
       userRequest:              R,
       newUserDetails:           (U, RudderUserDetail) => T
   ): T = {
@@ -487,15 +486,46 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
       s"Identifying ${protocolName} user info with sub: '${sub}' on rudder user base using login: '${user.getName}'"
     )
 
-    // check that we know that user in our DB
-    val rudderUser = rudderUserDetailsService.loadUserByUsername(user.getName)
+    val optReg = registrationRepository.registrations.get(userRequest.getClientRegistration.getRegistrationId)
 
-    buildUser(userRequest, user, rudderUser, newUserDetails)
+    // check that we know that user in our DB, else if "provisioning" is enabled, create it
+    val rudderUser = {
+      try {
+        rudderUserDetailsService.loadUserByUsername(user.getName)
+      } catch {
+        case ex: UsernameNotFoundException if (optReg.map(_.provisioning).getOrElse(false)) =>
+          val idp = optReg.map(_.registration.getRegistrationId).getOrElse("")
+          // provisioning is enabled, create the user and try again
+          (userRepository
+            .setExistingUsers(
+              protocolName,
+              List(user.getName),
+              EventTrace(
+                RudderEventActor,
+                DateTime.now(),
+                s"Provisioning is enabled for ${protocolName} '${idp}'"
+              )
+            ) *> ApplicationLoggerPure.User.info(
+            s"User '${user.getName}' automatically created because provisioning is enabled for ${protocolName} '${idp}'"
+          )).runNow
+
+          // retry
+          rudderUserDetailsService.loadUserByUsername(user.getName)
+      }
+    }
+
+    buildUser(optReg, userRequest, user, rudderUser, newUserDetails)
   }
 
-  def buildUser(userRequest: R, user: U, rudder: RudderUserDetail, userBuilder: (U, RudderUserDetail) => T): T = {
+  def buildUser(
+      optReg:      Option[RudderClientRegistration],
+      userRequest: R,
+      user:        U,
+      rudder:      RudderUserDetail,
+      userBuilder: (U, RudderUserDetail) => T
+  ): T = {
     val roles = {
-      registrationRepository.registrations.get(userRequest.getClientRegistration.getRegistrationId) match {
+      optReg match {
         case None      =>
           AuthBackendsLogger.trace(
             s"No configuration found for ${protocolName} registration id: ${userRequest.getClientRegistration.getRegistrationId}"
@@ -556,7 +586,8 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
 
 class RudderOidcUserService(
     rudderUserDetailsService:            RudderInMemoryUserDetailsService,
-    override val registrationRepository: RudderClientRegistrationRepository
+    override val registrationRepository: RudderClientRegistrationRepository,
+    userRepository:                      UserRepository
 ) extends OidcUserService with RudderUserServerMapping[OidcUserRequest, OidcUser, RudderUserDetail with OidcUser] {
 
   // we need to use our copy of DefaultOAuth2UserService to log/manage errors
@@ -565,13 +596,14 @@ class RudderOidcUserService(
   override val protocolName = "OIDC"
 
   override def loadUser(userRequest: OidcUserRequest): OidcUser = {
-    mapRudderUser(super.loadUser(_), rudderUserDetailsService, userRequest, new RudderOidcDetails(_, _))
+    mapRudderUser(super.loadUser(_), rudderUserDetailsService, userRepository, userRequest, new RudderOidcDetails(_, _))
   }
 }
 
 class RudderOAuth2UserService(
     rudderUserDetailsService:            RudderInMemoryUserDetailsService,
-    override val registrationRepository: RudderClientRegistrationRepository
+    override val registrationRepository: RudderClientRegistrationRepository,
+    userRepository:                      UserRepository
 ) extends OAuth2UserService[OAuth2UserRequest, OAuth2User]
     with RudderUserServerMapping[OAuth2UserRequest, OAuth2User, RudderUserDetail with OAuth2User] {
   val defaultUserService = new RudderDefaultOAuth2UserService()
@@ -579,7 +611,13 @@ class RudderOAuth2UserService(
   override val protocolName = "OAuth2"
 
   override def loadUser(userRequest: OAuth2UserRequest): OAuth2User = {
-    mapRudderUser(defaultUserService.loadUser(_), rudderUserDetailsService, userRequest, new RudderOauth2Details(_, _))
+    mapRudderUser(
+      defaultUserService.loadUser(_),
+      rudderUserDetailsService,
+      userRepository,
+      userRequest,
+      new RudderOauth2Details(_, _)
+    )
   }
 }
 

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/DataTypes.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/DataTypes.scala
@@ -67,10 +67,8 @@ object AuthBackendsLoggerPure extends NamedZioLogger {
  * This is well beyond the scope of that version.
  */
 final case class JsonAuthConfiguration(
-    declaredProviders: String      // order in config file as it is, without any parsing
-    ,
-    computedProviders: Seq[String] // order after resolution (root admin, plugin status, etc)
-    ,
+    declaredProviders: String,      // order in config file as it is, without any parsing
+    computedProviders: Seq[String], // order after resolution (root admin, plugin status, etc)
     adminConfig:       JsonAdminConfig,
     fileConfig:        JsonFileConfig,
     ldapConfig:        JsonLdapConfig

--- a/user-management/src/main/scala/bootstrap/rudder/plugin/UserManagementConf.scala
+++ b/user-management/src/main/scala/bootstrap/rudder/plugin/UserManagementConf.scala
@@ -43,6 +43,7 @@ import com.normation.plugins.PluginStatus
 import com.normation.plugins.RudderPluginModule
 import com.normation.plugins.usermanagement.CheckRudderPluginEnableImpl
 import com.normation.plugins.usermanagement.UserManagementPluginDef
+import com.normation.plugins.usermanagement.UserManagementService
 import com.normation.plugins.usermanagement.api.UserManagementApiImpl
 
 /*
@@ -63,7 +64,12 @@ object UserManagementConf extends RudderPluginModule {
 
   lazy val pluginDef = new UserManagementPluginDef(UserManagementConf.pluginStatusService)
 
-  lazy val api = new UserManagementApiImpl(RudderConfig.restExtractorService, RudderConfig.rudderUserListProvider)
+  lazy val api = new UserManagementApiImpl(
+    RudderConfig.userRepository,
+    RudderConfig.restExtractorService,
+    RudderConfig.rudderUserListProvider,
+    new UserManagementService(RudderConfig.userRepository)
+  )
 
   RudderConfig.userAuthorisationLevel.overrideLevel(new UserManagementAuthorizationLevel(pluginStatusService))
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/23444

That change needs https://github.com/Normation/rudder/pull/5121.

The changes in `user-management` are just the minimum to make things compile. A big change is still needed: we must use information from database in that plugin, which is not done here. 

The changes in `authentication-backend` add the possibility for `oidc/oauth2` backend to auto-provision users in Rudder if their authentication was successful. 
That possibility is governed by a new IdP propery: `rudder.auth.oauth2.provider.${idp}.enableProvisionning=true`

The logic change is then rather small and mainly in [AuthBackendsConf.scala](https://github.com/Normation/rudder-plugins/pull/603/files#diff-8fe302fecad34e77c8d7fa30f3efdf0110c77048e1f14006e4855dc1c60e73d9): on authentication success, we try to retrieve user from user repository. It it is not here and provisioning is allowed, we create it. 

Further evolution can be done to add more details when the user is provisioned, for now only minimal data is created (login, etc).
