### PR TITLE
Fixes #17809: If tables are missing, the error notification toast disappears almost instantly

### DIFF
--- a/change-validation/src/main/elm/sources/Init.elm
+++ b/change-validation/src/main/elm/sources/Init.elm
@@ -26,7 +26,7 @@ addToast toast conf  m =
 defaultConfig : Toasty.Config Msg
 defaultConfig =
   Toasty.Defaults.config
-    |> Toasty.delay 3.0
+    |> Toasty.delay 30000
     |> Toasty.containerAttrs
         [ style "position" "fixed"
         , style "top" "50px"


### PR DESCRIPTION
https://issues.rudder.io/issues/17809

Documentation says the value is in milliseconds