### PR TITLE
Fixes #21724: Categories can't be folded in ACL API with authorization plugin

### DIFF
--- a/api-authorizations/src/main/elm/sources/ApiAuthorizations.elm
+++ b/api-authorizations/src/main/elm/sources/ApiAuthorizations.elm
@@ -159,7 +159,9 @@ displayCategory acl cat =
       div [class "acl-category"]
       [ input[type_ "checkbox", id toggleId, class "toggle-checkbox"][]
       , div[class "category-header"]
-        [ i [class "fa fa-caret-down"][]
+        [ label [for toggleId, class "category-toggle-caret"]
+          [ i [class "fa fa-caret-down"][]
+          ]
         , label [for toggleId]
           [ text cat.category
           , span [class ("badge badge-secondary " ++ if nbSelected <= 0 then "empty" else "")][text (String.fromInt nbSelected)]

--- a/api-authorizations/src/main/resources/toserve/apiauthorizations/media.css
+++ b/api-authorizations/src/main/resources/toserve/apiauthorizations/media.css
@@ -68,13 +68,17 @@
 .acl-category .toggle-checkbox:not(:checked) + .category-header{
   margin-bottom: 8px;
 }
+.acl-category .category-header .category-toggle-caret{
+   flex: 0 1 40px;
+   font-size: inherit;
+}
 .acl-category .category-header label{
   margin: 0;
   text-transform: capitalize;
   font-size: 22px;
   font-weight: normal;
   flex: 1;
-  padding: 4px 0 4px 40px;
+  padding: 4px 0;
   cursor: pointer;
 }
 .acl-category .category-header > label .badge.badge-secondary{


### PR DESCRIPTION
https://issues.rudder.io/issues/21724

Instead of the 'category' title having a padding of 40px, the icon has a width of 40px.
The icon is also in a label now, so it allows to do the fold :partying_face: 