### PR TITLE
Fixes #23760: Migrate branding, openscap, scale-out-relay to zio-json

### DIFF
--- a/branding/pom-template.xml
+++ b/branding/pom-template.xml
@@ -43,6 +43,12 @@
 
   <dependencies>
     <!-- Add other plugin specific dependencies -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <!-- Below is an horrible if/then/else in maven. You shouldn't have anything to change here -->

--- a/branding/src/main/scala/bootstrap/rudder/plugin/BrandingPluginConf.scala
+++ b/branding/src/main/scala/bootstrap/rudder/plugin/BrandingPluginConf.scala
@@ -59,7 +59,7 @@ object BrandingPluginConf extends RudderPluginModule {
   val brandingConfService: BrandingConfService = new BrandingConfService(BrandingConfService.defaultConfigFilePath)
   val brandingApiService:  BrandingApiService  = new BrandingApiService(brandingConfService)
   val brandingApi:         BrandingApi         =
-    new BrandingApi(brandingApiService, RudderConfig.restExtractorService, RudderConfig.stringUuidGenerator)
+    new BrandingApi(brandingApiService, RudderConfig.stringUuidGenerator)
 
   RudderConfig.rudderApi.addModules(brandingApi.getLiftEndpoints())
   RudderConfig.snippetExtensionRegister.register(new CommonBranding(pluginStatusService))

--- a/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
@@ -42,7 +42,7 @@ import com.normation.plugins.PluginExtensionPoint
 import com.normation.plugins.PluginStatus
 import com.normation.plugins.PluginVersion
 import com.normation.rudder.web.snippet.Login
-import net.liftweb.common.Full
+import com.normation.zio.UnsafeRun
 import net.liftweb.common.Loggable
 import net.liftweb.util.Helpers._
 import scala.reflect.ClassTag
@@ -57,18 +57,18 @@ class LoginBranding(val status: PluginStatus, version: PluginVersion)(implicit v
 
   private[this] val confRepo = BrandingPluginConf.brandingConfService
   def display(xml: NodeSeq)  = {
-    val data                      = confRepo.getConf
+    val data                      = confRepo.getConf.either.runNow
     val bar                       = data match {
-      case Full(d) if (d.displayBarLogin) =>
+      case Right(d) if (d.displayBarLogin) =>
         <div id="headerBar">
           <div class="background">
             <span>{if (d.displayLabel) d.labelText}</span>
           </div>
         </div>
-      case _                              => NodeSeq.Empty
+      case _                               => NodeSeq.Empty
     }
     var (customLogo, brandingCss) = data match {
-      case Full(d) =>
+      case Right(d) =>
         (
           d.wideLogo.loginLogo,
           <style>
@@ -90,7 +90,7 @@ class LoginBranding(val status: PluginStatus, version: PluginVersion)(implicit v
           }}
           </style>
         )
-      case _       => (<img src="/images/logo-rudder-white.svg" data-lift="with-cached-resource" alt="Rudder"/>, NodeSeq.Empty)
+      case _        => (<img src="/images/logo-rudder-white.svg" data-lift="with-cached-resource" alt="Rudder"/>, NodeSeq.Empty)
     }
     val logoContainer             = {
       <div>
@@ -106,9 +106,9 @@ class LoginBranding(val status: PluginStatus, version: PluginVersion)(implicit v
       </div>
     }
     val motd                      = data match {
-      case Full(data) if (data.displayMotd) =>
+      case Right(data) if (data.displayMotd) =>
         <div class="motd enabled" style="margin-bottom: 20px; text-align: center;">{data.motd}</div>
-      case _                                => <div class="motd"></div>
+      case _                                 => <div class="motd"></div>
     }
     (".logo-container" #> logoContainer &
     ".plugin-info" #> bar &

--- a/branding/src/main/scala/com/normation/rudder/rest/BrandingApiSchema.scala
+++ b/branding/src/main/scala/com/normation/rudder/rest/BrandingApiSchema.scala
@@ -37,9 +37,8 @@
 
 package com.normation.rudder.rest
 
-import com.normation.rudder.api.HttpAction._
 import com.normation.rudder.AuthorizationType
-
+import com.normation.rudder.api.HttpAction._
 import sourcecode.Line
 
 /*
@@ -55,7 +54,7 @@ object BrandingApiEndpoints extends ApiModuleProvider[BrandingApiSchema] {
     val z              = implicitly[Line].value
     val description    = "Get branding plugin configuration"
     val (action, path) = GET / "branding"
-    val dataContainer: Option[String] = None
+    val dataContainer:  Option[String]          = None
     override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 

--- a/branding/src/test/resources/branding_api/api_branding.yml
+++ b/branding/src/test/resources/branding_api/api_branding.yml
@@ -1,0 +1,262 @@
+description: Get branding plugin configuration
+method: GET
+url: /api/latest/branding
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getBrandingConf",
+      "result" : "success",
+      "data" : {
+        "branding" : {
+          "displayBar" : true,
+          "barColor" : {
+            "red" : 0.0,
+            "green" : 0.0,
+            "blue" : 0.0,
+            "alpha" : 0.0
+          },
+          "displayLabel" : true,
+          "labelText" : "Sample Text",
+          "labelColor" : {
+            "red" : 1.0,
+            "green" : 1.0,
+            "blue" : 1.0,
+            "alpha" : 1.0
+          },
+          "wideLogo" : {
+            "enable" : true,
+            "name" : "logo.png",
+            "data" : "base64encodeddata"
+          },
+          "smallLogo" : {
+            "enable" : true,
+            "name" : "logo.png",
+            "data" : "base64encodeddata"
+          },
+          "displayBarLogin" : false,
+          "displayMotd" : true,
+          "motd" : "Welcome to our application"
+        }
+      }
+    }
+---
+description: Update branding plugin configuration with V5.0 payload format, removing logo name and data
+method: POST
+url: /api/latest/branding
+headers: 
+  - "Content-Type: application/json"
+body: >-
+  {
+    "displayBar": true,
+    "barColor": {
+        "red": 0.5,
+        "green": 0.5,
+        "blue": 0.5,
+        "alpha": 1.0
+    },
+    "displayLabel": true,
+    "labelText": "Test Label",
+    "labelColor": {
+        "red": 0.2,
+        "green": 0.8,
+        "blue": 0.4,
+        "alpha": 1.0
+    },
+    "enableLogo": true,
+    "displayFavIcon": true,
+    "displaySmallLogo": false,
+    "displayBigLogo": false,
+    "displayBarLogin": true,
+    "displayLoginLogo": true,
+    "displayMotd": true,
+    "motd": "Test MOTD"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "updateBRandingConf",
+      "result" : "success",
+      "data": {
+        "branding": {
+          "displayBar": true,
+          "barColor": {
+              "red": 0.5,
+              "green": 0.5,
+              "blue": 0.5,
+              "alpha": 1.0
+          },
+          "displayLabel": true,
+          "labelText": "Test Label",
+          "labelColor": {
+              "red": 0.2,
+              "green": 0.8,
+              "blue": 0.4,
+              "alpha": 1.0
+          },
+          "wideLogo": {
+              "enable": false
+          },
+          "smallLogo": {
+              "enable": false
+          },
+          "displayBarLogin": true,
+          "displayMotd": true,
+          "motd": "Test MOTD"
+        }
+      }
+    }
+---
+description: Update branding plugin configuration
+method: POST
+url: /api/latest/branding
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "displayBar": true,
+    "barColor": {
+        "red": 0.5,
+        "green": 0.5,
+        "blue": 0.5,
+        "alpha": 1.0
+    },
+    "displayLabel": true,
+    "labelText": "Test Label",
+    "labelColor": {
+        "red": 0.2,
+        "green": 0.8,
+        "blue": 0.4,
+        "alpha": 1.0
+    },
+    "wideLogo": {
+        "enable": false,
+        "name": "wide_logo.png"
+    },
+    "smallLogo": {
+        "enable": false,
+        "name": "small_logo.png"
+    },
+    "displayBarLogin": true,
+    "displayMotd": true,
+    "motd": "Test MOTD"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "updateBRandingConf",
+      "result" : "success",
+      "data": {
+        "branding": {
+          "displayBar": true,
+          "barColor": {
+              "red": 0.5,
+              "green": 0.5,
+              "blue": 0.5,
+              "alpha": 1.0
+          },
+          "displayLabel": true,
+          "labelText": "Test Label",
+          "labelColor": {
+              "red": 0.2,
+              "green": 0.8,
+              "blue": 0.4,
+              "alpha": 1.0
+          },
+          "wideLogo": {
+              "enable": false,
+              "name": "wide_logo.png"
+          },
+          "smallLogo": {
+              "enable": false,
+              "name": "small_logo.png"
+          },
+          "displayBarLogin": true,
+          "displayMotd": true,
+          "motd": "Test MOTD"
+        }
+      }
+    }
+---
+description: Fail to update branding plugin configuration with invalid payload
+method: POST
+url: /api/latest/branding
+headers: 
+  - "Content-Type: application/json"
+body: >-
+  {
+    "displayBar": true,
+    "barColor": {
+        "red": 0.5,
+        "green": 0.5,
+        "blue": 0.5,
+        "alpha": 1.0
+    },
+    "displayLabel": true,
+    "labelText": "Test Label",
+    "labelColor": {
+        "red": 0.2,
+        "green": 0.8,
+        "blue": 0.4,
+        "alpha": 1.0
+    },
+    "enableLogo": true,
+    "displayFavIcon": true,
+    "displayBarLogin": true,
+    "displayLoginLogo": true,
+    "displayMotd": true,
+    "motd": "Test MOTD"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "updateBRandingConf",
+      "result" : "error",
+      "errorDetails" : "Could not update Branding plugin configuration; cause was: Unexpected: .wideLogo(missing)"
+    }
+---
+description: Reload branding plugin configuration from config file
+method: POST
+url: /api/latest/branding/reload
+headers: 
+  - "Content-Type: application/json"
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getBrandingConf",
+      "result" : "success",
+      "data": {
+        "branding": {
+          "displayBar": true,
+          "barColor": {
+              "red": 0.5,
+              "green": 0.5,
+              "blue": 0.5,
+              "alpha": 1.0
+          },
+          "displayLabel": true,
+          "labelText": "Test Label",
+          "labelColor": {
+              "red": 0.2,
+              "green": 0.8,
+              "blue": 0.4,
+              "alpha": 1.0
+          },
+          "wideLogo": {
+              "enable": false,
+              "name": "wide_logo.png"
+          },
+          "smallLogo": {
+              "enable": false,
+              "name": "small_logo.png"
+          },
+          "displayBarLogin": true,
+          "displayMotd": true,
+          "motd": "Test MOTD"
+        }
+      }
+    }

--- a/branding/src/test/scala/com/normation/plugins/branding/BrandingConfServiceTest.scala
+++ b/branding/src/test/scala/com/normation/plugins/branding/BrandingConfServiceTest.scala
@@ -1,0 +1,132 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.plugins.branding
+
+import better.files._
+import com.normation.plugins.branding.BrandingConf
+import com.normation.plugins.branding.BrandingConfService
+import com.normation.zio.UnsafeRun
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+import zio.json._
+
+@RunWith(classOf[JUnitRunner])
+class BrandingConfServiceTest extends Specification with AfterAll {
+  sequential
+
+  val fakeBrandingConf: BrandingConf = BrandingConf(
+    displayBar = true,
+    barColor = JsonColor(0.5, 0.5, 0.5, 1.0),
+    displayLabel = true,
+    labelText = "Test Label",
+    labelColor = JsonColor(0.2, 0.8, 0.4, 1.0),
+    wideLogo = Logo(enable = true, name = Some("wide_logo.png"), data = None),
+    smallLogo = Logo(enable = true, name = Some("small_logo.png"), data = None),
+    displayBarLogin = true,
+    displayMotd = true,
+    motd = "Test MOTD"
+  )
+  val fakeBrandingConfJson = s"""
+    {
+      "displayBar": true,
+      "barColor": {
+          "red": 0.5,
+          "green": 0.5,
+          "blue": 0.5,
+          "alpha": 1.0
+      },
+      "displayLabel": true,
+      "labelText": "Test Label",
+      "labelColor": {
+          "red": 0.2,
+          "green": 0.8,
+          "blue": 0.4,
+          "alpha": 1.0
+      },
+      "wideLogo": {
+          "enable": true,
+          "name": "wide_logo.png",
+          "data": null
+      },
+      "smallLogo": {
+          "enable": true,
+          "name": "small_logo.png",
+          "data": null
+      },
+      "displayBarLogin": true,
+      "displayMotd": true,
+      "motd": "Test MOTD"
+    }"""
+  val tempFile: File                = File.newTemporaryFile("rudder", "branding-config.json").overwrite(fakeBrandingConfJson)
+  val service:  BrandingConfService = new BrandingConfService(tempFile.pathAsString)
+  service.reloadCache.runNow
+
+  "BrandingConfService" should {
+
+    "get the branding configuration" in {
+      service.getConf.runNow must beEqualTo(fakeBrandingConf)
+    }
+
+    "update the branding configuration" in {
+      val updatedConf = BrandingConf(
+        displayBar = false,
+        barColor = JsonColor(0.1, 0.1, 0.1, 1.0),
+        displayLabel = false,
+        labelText = "Updated Label",
+        labelColor = JsonColor(0.9, 0.9, 0.9, 1.0),
+        wideLogo = Logo(enable = false, name = Some("updated_wide_logo.png"), data = None),
+        smallLogo = Logo(enable = false, name = Some("updated_small_logo.png"), data = None),
+        displayBarLogin = false,
+        displayMotd = false,
+        motd = "Updated MOTD"
+      )
+      service.updateConf(updatedConf).runNow must beEqualTo(updatedConf)
+
+      val updatedConfFromFile = tempFile.contentAsString.fromJson[BrandingConf]
+      updatedConfFromFile must beEqualTo(Right(updatedConf))
+
+      service.getConf.runNow must beEqualTo(updatedConf)
+    }
+
+  }
+
+  override def afterAll(): Unit = {
+    tempFile.delete()
+  }
+}

--- a/branding/src/test/scala/com/normation/plugins/branding/api/BrandingApiTest.scala
+++ b/branding/src/test/scala/com/normation/plugins/branding/api/BrandingApiTest.scala
@@ -1,0 +1,87 @@
+package com.normation.plugins.branding
+
+import better.files._
+import com.normation.plugins.branding.api.BrandingApi
+import com.normation.plugins.branding.api.BrandingApiService
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.rest.TraitTestApiFromYamlFiles
+import java.nio.file.Files
+import net.liftweb.common.Loggable
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+
+@RunWith(classOf[JUnitRunner])
+class BrandingApiTest extends Specification with TraitTestApiFromYamlFiles with Loggable with AfterAll {
+  sequential
+
+  val restTestSetUp = RestTestSetUp.newEnv
+
+  val tmpDir: File = File(Files.createTempDirectory("rudder-test-"))
+  override def yamlSourceDirectory  = "branding_api"
+  override def yamlDestTmpDirectory = tmpDir / "templates"
+
+  val fakeBrandingConf: String = s"""
+    {
+      "displayBar": true,
+      "barColor": {
+        "red": 0.0,
+        "green": 0.0,
+        "blue": 0.0,
+        "alpha": 0.0
+      },
+      "displayLabel": true,
+      "labelText": "Sample Text",
+      "labelColor": {
+        "red": 1.0,
+        "green": 1.0,
+        "blue": 1.0,
+        "alpha": 1.0
+      },
+      "wideLogo": {
+        "enable": true,
+        "name": "logo.png",
+        "data": "base64encodeddata"
+      },
+      "smallLogo": {
+        "enable": true,
+        "name": "logo.png",
+        "data": "base64encodeddata"
+      },
+      "displayBarLogin": false,
+      "displayMotd": true,
+      "motd": "Welcome to our application"
+    }"""
+
+  // file with overrwriten config
+  val brandingConfFile: File = tmpDir.createChild("config.json").overwrite(fakeBrandingConf)
+
+  val modules = List(
+    new BrandingApi(
+      new BrandingApiService(
+        new BrandingConfService(brandingConfFile.pathAsString)
+      ),
+      restTestSetUp.uuidGen
+    )
+  )
+
+  val apiVersions            = ApiVersion(13, true) :: ApiVersion(14, false) :: Nil
+  val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(modules, apiVersions, None)
+
+  override def transformations: Map[String, String => String] = Map()
+
+  // we are testing error cases, so we don't want to output error log for them
+  org.slf4j.LoggerFactory
+    .getLogger("com.normation.rudder.rest.RestUtils")
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.OFF)
+
+  override def afterAll(): Unit = {
+    tmpDir.delete()
+  }
+
+  doTest(semanticJson = true)
+
+}

--- a/openscap/pom-template.xml
+++ b/openscap/pom-template.xml
@@ -73,6 +73,12 @@
             </exclusion>
         </exclusions>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <!-- Below is an horrible if/then/else in maven. You shouldn't have anything to change here -->

--- a/openscap/src/main/scala/bootstrap/rudder/plugin/OpenscapPoliciesConf.scala
+++ b/openscap/src/main/scala/bootstrap/rudder/plugin/OpenscapPoliciesConf.scala
@@ -109,10 +109,11 @@ object OpenscapPoliciesConf extends RudderPluginModule {
     RudderConfig.nodeInfoService,
     RudderConfig.roDirectiveRepository,
     getActiveTechniqueIds,
-    RudderConfig.findExpectedReportRepository
+    RudderConfig.findExpectedReportRepository,
+    openScapReportDirPath = "/var/rudder/shared-files/root/files/"
   )
 
-  lazy val openScapApiImpl = new OpenScapApiImpl(RudderConfig.restExtractorService, openScapReportReader, reportSanitizer)
+  lazy val openScapApiImpl = new OpenScapApiImpl(openScapReportReader, reportSanitizer)
   // other service instantiation / initialization
   RudderConfig.snippetExtensionRegister.register(
     new OpenScapNodeDetailsExtension(pluginStatusService, openScapReportReader, reportSanitizer)

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/api/OpenScapApi.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/api/OpenScapApi.scala
@@ -22,9 +22,6 @@ import net.liftweb.common.Full
 import net.liftweb.http.InMemoryResponse
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json.Formats
-import net.liftweb.json.JValue
-import net.liftweb.json.NoTypeHints
 import sourcecode.Line
 
 sealed trait OpenScapApi extends EndpointSchema with GeneralApi with SortIndex
@@ -35,7 +32,7 @@ object OpenScapApi       extends ApiModuleProvider[OpenScapApi] {
     val description    = "Get OpenSCAP report for a node"
     val (action, path) = GET / "openscap" / "report" / "{id}"
 
-    override def dataContainer: Option[String] = Some("openscap")
+    override def dataContainer: Option[String] = None
   }
 
   final case object GetSanitizedOpenScapReport extends OpenScapApi with OneParam with StartsAtVersion12 {
@@ -43,22 +40,19 @@ object OpenScapApi       extends ApiModuleProvider[OpenScapApi] {
     val description    = "Get sanitized OpenSCAP report for a node"
     val (action, path) = GET / "openscap" / "sanitized" / "{id}"
 
-    override def dataContainer: Option[String] = Some("openscap")
+    override def dataContainer: Option[String] = None
   }
 
   def endpoints = ca.mrvisser.sealerate.values[OpenScapApi].toList.sortBy(_.z)
 }
 
 class OpenScapApiImpl(
-    restExtractorService: RestExtractorService,
     openScapReportReader: OpenScapReportReader,
     reportSanitizer:      ReportSanitizer
 ) extends LiftApiModuleProvider[OpenScapApi] {
   api =>
 
   val logger = OpenscapPoliciesLogger
-
-  implicit val formats: Formats = net.liftweb.json.Serialization.formats(NoTypeHints)
 
   def schemas = OpenScapApi
 
@@ -72,15 +66,8 @@ class OpenScapApiImpl(
     }.toList
   }
 
-  def response(function: Box[JValue], req: Req, errorMessage: String, id: Option[String], dataName: String)(implicit
-      action:            String
-  ): LiftResponse = {
-    RestUtils.response(restExtractorService, dataName, id)(function, req, errorMessage)
-  }
-
   object GetOpenScapReport extends LiftApiModule {
-    val schema        = OpenScapApi.GetOpenScapReport
-    val restExtractor = api.restExtractorService
+    val schema = OpenScapApi.GetOpenScapReport
 
     def process(
         version:    ApiVersion,
@@ -123,8 +110,7 @@ class OpenScapApiImpl(
   }
 
   object GetSanitizedOpenScapReport extends LiftApiModule {
-    val schema        = OpenScapApi.GetSanitizedOpenScapReport
-    val restExtractor = api.restExtractorService
+    val schema = OpenScapApi.GetSanitizedOpenScapReport
 
     def process(
         version:    ApiVersion,

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/services/OpenScapReportReader.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/services/OpenScapReportReader.scala
@@ -20,17 +20,17 @@ class OpenScapReportReader(
     nodeInfoService:              NodeInfoService,
     directiveRepository:          RoDirectiveRepository,
     pluginDirectiveRepository:    GetActiveTechniqueIds,
-    findExpectedReportRepository: FindExpectedReportRepository
+    findExpectedReportRepository: FindExpectedReportRepository,
+    openScapReportDirPath:        String
 ) {
+  import OpenScapReportReader._
 
-  val OPENSCAP_REPORT_FILENAME = "openscap_report.html"
-  val OPENSCAP_REPORT_PATH     = "/var/rudder/shared-files/root/files/"
+  val openScapReportPath = File(openScapReportDirPath)
 
-  val OPENSCAP_TECHNIQUE_ID = "plugin_openscap_policies"
-  val logger                = OpenscapPoliciesLogger
+  val logger = OpenscapPoliciesLogger
 
   private[this] def computePathFromNodeId(nodeId: NodeId): String = {
-    OPENSCAP_REPORT_PATH + nodeId.value + "/" + OPENSCAP_REPORT_FILENAME
+    (openScapReportPath / nodeId.value / OPENSCAP_REPORT_FILENAME).pathAsString
   }
 
   def checkifOpenScapApplied(nodeId: NodeId): Box[Boolean] = {
@@ -156,4 +156,11 @@ class OpenScapReportReader(
       result
     }
   }
+}
+
+object OpenScapReportReader {
+
+  val OPENSCAP_REPORT_FILENAME = "openscap_report.html"
+  val OPENSCAP_TECHNIQUE_ID    = "plugin_openscap_policies"
+
 }

--- a/openscap/src/test/resources/openscap_api/api_openscap.yml
+++ b/openscap/src/test/resources/openscap_api/api_openscap.yml
@@ -1,0 +1,31 @@
+description: Get OpenSCAP report for a node
+method: GET
+url: /api/latest/openscap/report/node1
+response:
+  code: 200
+  type: text
+  content: <html><head><title>OpenSCAP Report example</title></head><body><h1>OpenSCAP Report</h1></body></html>
+---
+description: Get OpenSCAP report for a non-existing node
+method: GET
+url: /api/latest/openscap/report/node_void123
+response:
+  code: 404
+  type: text
+  content: Could not get the OpenSCAP report for node ${nodeId} <- Node with id node_void123 not found
+---
+description: Get sanitized OpenSCAP report for a node
+method: GET
+url: /api/latest/openscap/sanitized/node2
+response:
+  code: 200
+  type: text
+  content: <a rel="nofollow" href="https://example.com"/>
+---
+description: Get sanitized OpenSCAP report for a non-existing node
+method: GET
+url: /api/latest/openscap/sanitized/node_void123
+response:
+  code: 404
+  type: text
+  content: <div class="error">Could not get the sanitized OpenSCAP report for node ${nodeId} &lt;- Cannot get OpenSCAP report for node node_void123 &lt;- Node with id node_void123 not found</div>

--- a/openscap/src/test/scala/com/normation/plugins/openscappolicies/api/OpenScapApiTest.scala
+++ b/openscap/src/test/scala/com/normation/plugins/openscappolicies/api/OpenScapApiTest.scala
@@ -1,0 +1,76 @@
+package com.normation.plugins.openscappolicies.api
+
+import better.files._
+import com.normation.plugins.openscappolicies.services.OpenScapReportReader
+import com.normation.plugins.openscappolicies.services.ReportSanitizer
+import com.normation.rudder.MockNodes
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.rest.TraitTestApiFromYamlFiles
+import java.nio.file.Files
+import net.liftweb.common.Loggable
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+
+@RunWith(classOf[JUnitRunner])
+class OpenScapApiTest extends Specification with TraitTestApiFromYamlFiles with Loggable with AfterAll {
+  sequential
+
+  val restTestSetUp = RestTestSetUp.newEnv
+
+  val tmpDir: File = File(Files.createTempDirectory("rudder-test-"))
+  override def yamlSourceDirectory  = "openscap_api"
+  override def yamlDestTmpDirectory = tmpDir / "templates"
+
+  val policySanitizationFile = better.files.Resource
+    .url("antisamy.xml")
+    .map(_.getPath().toString)
+    .getOrElse("non_existing_file")
+  val reportSanitizer        = new ReportSanitizer(policySanitizationFile)
+
+  val openScapReportDir = tmpDir
+  val node1ReportFile   = openScapReportDir
+    .createChild("node1/", asDirectory = true)
+    .createChild(OpenScapReportReader.OPENSCAP_REPORT_FILENAME)
+    .overwrite("<html><head><title>OpenSCAP Report example</title></head><body><h1>OpenSCAP Report</h1></body></html>")
+  val node2ReportFile   = openScapReportDir
+    .createChild("node2/", asDirectory = true)
+    .createChild(OpenScapReportReader.OPENSCAP_REPORT_FILENAME)
+    .overwrite("""<a href="https://example.com">""") // upon sanitization, should have rel="nofollow" added
+
+  val mockNodes            = new MockNodes()
+  val openScapReportReader = new OpenScapReportReader(
+    mockNodes.nodeInfoService,
+    restTestSetUp.mockDirectives.directiveRepo,
+    null,
+    null,
+    openScapReportDirPath = openScapReportDir.pathAsString
+  )
+
+  val modules = List(
+    new OpenScapApiImpl(
+      openScapReportReader,
+      reportSanitizer
+    )
+  )
+
+  val apiVersions            = ApiVersion(13, true) :: ApiVersion(14, false) :: Nil
+  val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(modules, apiVersions, None)
+
+  override def transformations: Map[String, String => String] = Map()
+
+  // we are testing error cases, so we don't want to output error log for them
+  org.slf4j.LoggerFactory
+    .getLogger("com.normation.rudder.rest.RestUtils")
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.OFF)
+
+  override def afterAll(): Unit = {
+    tmpDir.delete()
+  }
+
+  doTest()
+
+}

--- a/scale-out-relay/pom-template.xml
+++ b/scale-out-relay/pom-template.xml
@@ -44,6 +44,12 @@
 
   <dependencies>
     <!-- Add other plugin specific dependencies -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <!-- Below is an horrible if/then/else in maven. You shouldn't have anything to change here -->

--- a/scale-out-relay/src/main/scala/bootstrap/rudder/plugin/ScaleOutRelayConf.scala
+++ b/scale-out-relay/src/main/scala/bootstrap/rudder/plugin/ScaleOutRelayConf.scala
@@ -55,7 +55,7 @@ object ScalaOutRelayConf extends RudderPluginModule {
 
   lazy val pluginDef = new ScalaOutRelayPluginDef(ScalaOutRelayConf.pluginStatusService)
 
-  lazy val api = new ScaleOutRelayApiImpl(RudderConfig.restExtractorService, scaleOutRelayService)
+  lazy val api = new ScaleOutRelayApiImpl(scaleOutRelayService)
 
   lazy val scaleOutRelayService = new ScaleOutRelayService(
     RudderConfig.nodeInfoService,

--- a/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApi.scala
+++ b/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApi.scala
@@ -1,6 +1,5 @@
 package com.normation.plugins.scaleoutrelay.api
 
-import com.normation.box._
 import com.normation.eventlog.EventActor
 import com.normation.inventory.domain.NodeId
 import com.normation.plugins.scaleoutrelay.ScaleOutRelayService
@@ -8,20 +7,12 @@ import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction.POST
 import com.normation.rudder.rest._
 import com.normation.rudder.rest.EndpointSchema.syntax._
-import com.normation.rudder.rest.RestUtils.toJsonError
-import com.normation.rudder.rest.RestUtils.toJsonResponse
+import com.normation.rudder.rest.implicits._
 import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
-import net.liftweb.common.Box
-import net.liftweb.common.EmptyBox
-import net.liftweb.common.Full
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json.Formats
-import net.liftweb.json.JsonAST.JValue
-import net.liftweb.json.JsonDSL._
-import net.liftweb.json.NoTypeHints
 import sourcecode.Line
 
 sealed trait ScaleOutRelayApi extends EndpointSchema with GeneralApi with SortIndex {
@@ -45,13 +36,9 @@ object ScaleOutRelayApi       extends ApiModuleProvider[ScaleOutRelayApi]       
 }
 
 class ScaleOutRelayApiImpl(
-    restExtractorService: RestExtractorService,
     scaleOutRelayService: ScaleOutRelayService
 ) extends LiftApiModuleProvider[ScaleOutRelayApi] {
 
-  api =>
-
-  implicit val formats: Formats = net.liftweb.json.Serialization.formats((NoTypeHints))
   override def schemas = ScaleOutRelayApi
 
   override def getLiftEndpoints(): List[LiftApiModule] = {
@@ -61,15 +48,8 @@ class ScaleOutRelayApiImpl(
     }.toList
   }
 
-  def response(function: Box[JValue], req: Req, errorMessage: String, id: Option[String], dataName: String)(implicit
-      action:            String
-  ): LiftResponse = {
-    RestUtils.response(restExtractorService, dataName, id)(function, req, errorMessage)
-  }
-
   object PromoteToRelay extends LiftApiModule {
-    val schema        = ScaleOutRelayApi.PromoteToRelay
-    val restExtractor = api.restExtractorService
+    val schema = ScaleOutRelayApi.PromoteToRelay
 
     def process(
         version: ApiVersion,
@@ -81,18 +61,13 @@ class ScaleOutRelayApiImpl(
     ): LiftResponse = {
       scaleOutRelayService
         .promoteNodeToRelay(NodeId(nodeId), EventActor("rudder"), Some(s"Promote node ${nodeId} to relay"))
-        .toBox match {
-        case Full(node) =>
-          toJsonResponse(None, nodeId)("promoteToRelay", true)
-        case eb: EmptyBox =>
-          val message = (eb ?~ (s"Error when trying to promote mode $nodeId")).msg
-          toJsonError(None, message)("promoteToRelay", true)
-      }
+        .chainError(s"Error when trying to promote mode $nodeId")
+        .as(nodeId)
+        .toLiftResponseOne(params, schema, None)
     }
   }
   object DemoteToNode   extends LiftApiModule {
-    val schema        = ScaleOutRelayApi.DemoteToNode
-    val restExtractor = api.restExtractorService
+    val schema = ScaleOutRelayApi.DemoteToNode
 
     def process(
         version: ApiVersion,
@@ -104,13 +79,9 @@ class ScaleOutRelayApiImpl(
     ): LiftResponse = {
       scaleOutRelayService
         .demoteRelayToNode(NodeId(nodeId), EventActor("rudder"), Some(s"Demote relay ${nodeId} to node"))
-        .toBox match {
-        case Full(node) =>
-          toJsonResponse(None, nodeId)("demoteToNode", true)
-        case eb: EmptyBox =>
-          val message = (eb ?~ (s"Error when trying to demote mode $nodeId")).msg
-          toJsonError(None, message)("demoteToNode", true)
-      }
+        .chainError(s"Error when trying to demote mode $nodeId")
+        .as(nodeId)
+        .toLiftResponseOne(params, schema, None)
     }
   }
 }

--- a/scale-out-relay/src/test/resources/scaleoutrelay_api/api_scaleoutrelay.yml
+++ b/scale-out-relay/src/test/resources/scaleoutrelay_api/api_scaleoutrelay.yml
@@ -1,0 +1,59 @@
+description: Promote a node to relay
+method: POST
+url: /api/latest/scaleoutrelay/promote/node1
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 200
+  type: json
+  content: >-
+    {
+      "action": "promoteToRelay",
+      "result": "success",
+      "data": "node1"
+    }
+---
+description: Fail to promote a node to relay when the node does not exist
+method: POST
+url: /api/latest/scaleoutrelay/promote/node_void123
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 500
+  type: json
+  content: >-
+    {
+      "action": "promoteToRelay",
+      "result": "error",
+      "errorDetails": "Error when trying to promote mode node_void123; cause was: Inconsistency: Node with UUID node_void123 is missing and can not be upgraded to relay"
+    }
+---
+description: Demote a relay to a simple node
+method: POST
+url: /api/latest/scaleoutrelay/demote/node1
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 200
+  type: json
+  content: >-
+    {
+      "action": "demoteToNode",
+      "result": "success",
+      "data": "node1"
+    }
+---
+description: Fail to demote a relay to a simple node when the node does not exist
+method: POST
+url: /api/latest/scaleoutrelay/demote/node_void123
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 500
+  type: json
+  content: >-
+    {
+      "action": "demoteToNode",
+      "result": "error",
+      "errorDetails": "Error when trying to demote mode node_void123; cause was: Inconsistency: Relay with UUID node_void123 is missing and can not be demoted to node"
+    }

--- a/scale-out-relay/src/test/scala/com/normation/plugins/scaleoutrelay/MockServices.scala
+++ b/scale-out-relay/src/test/scala/com/normation/plugins/scaleoutrelay/MockServices.scala
@@ -1,0 +1,260 @@
+package com.normation.plugins.scaleoutrelay
+
+import com.normation.errors._
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.EventLog
+import com.normation.eventlog.EventLogFilter
+import com.normation.eventlog.ModificationId
+import com.normation.inventory.domain.KeyStatus
+import com.normation.inventory.domain.NodeId
+import com.normation.inventory.domain.SecurityToken
+import com.normation.ldap.ldif.LDIFNoopChangeRecord
+import com.normation.rudder.domain.nodes.AddNodeGroupDiff
+import com.normation.rudder.domain.nodes.DeleteNodeGroupDiff
+import com.normation.rudder.domain.nodes.ModifyNodeGroupDiff
+import com.normation.rudder.domain.nodes.Node
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupCategory
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeInfo
+import com.normation.rudder.domain.policies.PolicyServerTarget
+import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.repository.EventLogRepository
+import com.normation.rudder.repository.WoNodeGroupRepository
+import com.normation.rudder.repository.WoNodeRepository
+import com.normation.rudder.services.eventlog.EventLogFactory
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.rudder.services.servers.PolicyServer
+import com.normation.rudder.services.servers.PolicyServerManagementService
+import com.normation.rudder.services.servers.PolicyServers
+import com.normation.rudder.services.servers.PolicyServersUpdateCommand
+import com.normation.zio.UnsafeRun
+import com.unboundid.ldap.sdk.DN
+import com.unboundid.ldif.LDIFChangeRecord
+import doobie.Fragment
+import zio.Ref
+import zio.ZIO
+import zio.syntax._
+
+class MockServices(nodeInfos: Map[NodeId, NodeInfo], nodeGroups: Map[NodeGroupId, NodeGroup]) {
+
+  private val (nodesRef, nodeGroupsRef): (Ref[Map[NodeId, NodeInfo]], Ref[Map[NodeGroupId, NodeGroup]]) = {
+    (Ref.Synchronized.make(nodeInfos)
+    <*> Ref.Synchronized.make(nodeGroups)).runNow
+  }
+
+  object nodeInfoService extends NodeInfoService with WoNodeRepository {
+    override def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = {
+      nodesRef.get.map(_.get(nodeId))
+    }
+
+    override def createNode(
+        node:   Node,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[Node] = {
+      nodeInfos
+        .get(node.id)
+        .notOptional("Cannot create node in mock without associated node info")
+        .flatMap(nodeInfo => nodesRef.update(_ + (node.id -> nodeInfo)))
+        .as(node)
+    }
+
+    override def deleteNode(
+        node:   Node,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[Node] = {
+      nodesRef.update(_ - node.id).map(_ => node)
+    }
+
+    override def getNodeInfos(nodeIds: Set[NodeId]):                                                       IOResult[Set[NodeInfo]]         = ???
+    override def getNodeInfosSeq(nodeIds: Seq[NodeId]):                                                    IOResult[Seq[NodeInfo]]         = ???
+    override def getNumberOfManagedNodes:                                                                  Int                             = ???
+    override def getAll():                                                                                 IOResult[Map[NodeId, NodeInfo]] = ???
+    override def getAllNodesIds():                                                                         IOResult[Set[NodeId]]           = ???
+    override def getAllNodes():                                                                            IOResult[Map[NodeId, Node]]     = ???
+    override def getAllNodeInfos():                                                                        IOResult[Seq[NodeInfo]]         = ???
+    override def getAllSystemNodeIds():                                                                    IOResult[Seq[NodeId]]           = ???
+    override def getPendingNodeInfos():                                                                    IOResult[Map[NodeId, NodeInfo]] = ???
+    override def getPendingNodeInfo(nodeId: NodeId):                                                       IOResult[Option[NodeInfo]]      = ???
+    override def getDeletedNodeInfos():                                                                    IOResult[Map[NodeId, NodeInfo]] = ???
+    override def getDeletedNodeInfo(nodeId: NodeId):                                                       IOResult[Option[NodeInfo]]      = ???
+    override def updateNode(node: Node, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Node]                  =
+      ???
+    override def updateNodeKeyInfo(
+        nodeId:         NodeId,
+        agentKey:       Option[SecurityToken],
+        agentKeyStatus: Option[KeyStatus],
+        modId:          ModificationId,
+        actor:          EventActor,
+        reason:         Option[String]
+    ): IOResult[Unit] = ???
+
+  }
+
+  object woLDAPNodeGroupRepository extends WoNodeGroupRepository {
+
+    override def create(
+        group: NodeGroup,
+        into:  NodeGroupCategoryId,
+        modId: ModificationId,
+        actor: EventActor,
+        why:   Option[String]
+    ): IOResult[AddNodeGroupDiff] = {
+      nodeGroupsRef.update(_ + (group.id -> group)).as(AddNodeGroupDiff(group))
+    }
+
+    override def createPolicyServerTarget(
+        target: PolicyServerTarget,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[LDIFChangeRecord] = {
+      LDIFNoopChangeRecord(DN.NULL_DN).succeed
+    }
+
+    override def delete(
+        id:             NodeGroupId,
+        modId:          ModificationId,
+        actor:          EventActor,
+        whyDescription: Option[String]
+    ): IOResult[DeleteNodeGroupDiff] = {
+      nodeGroupsRef.get
+        .map(_.get(id))
+        .flatMap(_.notOptional(s"Cannot delete node group $id because it was not created in mock"))
+        .map(DeleteNodeGroupDiff(_))
+    }
+
+    override def deletePolicyServerTarget(policyServer: PolicyServerTarget): IOResult[PolicyServerTarget] = {
+      policyServer.succeed
+    }
+
+    override def update(
+        group:          NodeGroup,
+        modId:          ModificationId,
+        actor:          EventActor,
+        whyDescription: Option[String]
+    ): IOResult[Option[ModifyNodeGroupDiff]] = ???
+    override def updateDiffNodes(
+        group:          NodeGroupId,
+        add:            List[NodeId],
+        delete:         List[NodeId],
+        modId:          ModificationId,
+        actor:          EventActor,
+        whyDescription: Option[String]
+    ): IOResult[Option[ModifyNodeGroupDiff]] = ???
+    override def updateSystemGroup(
+        group:  NodeGroup,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[Option[ModifyNodeGroupDiff]] = ???
+    override def updateDynGroupNodes(
+        group:          NodeGroup,
+        modId:          ModificationId,
+        actor:          EventActor,
+        whyDescription: Option[String]
+    ): IOResult[Option[ModifyNodeGroupDiff]] = ???
+    override def move(
+        group:          NodeGroupId,
+        containerId:    NodeGroupCategoryId,
+        modId:          ModificationId,
+        actor:          EventActor,
+        whyDescription: Option[String]
+    ): IOResult[Option[ModifyNodeGroupDiff]] = ???
+    override def addGroupCategorytoCategory(
+        that:           NodeGroupCategory,
+        into:           NodeGroupCategoryId,
+        modificationId: ModificationId,
+        actor:          EventActor,
+        reason:         Option[String]
+    ): IOResult[NodeGroupCategory] = ???
+    override def saveGroupCategory(
+        category:       NodeGroupCategory,
+        modificationId: ModificationId,
+        actor:          EventActor,
+        reason:         Option[String]
+    ): IOResult[NodeGroupCategory] = ???
+    override def saveGroupCategory(
+        category:       NodeGroupCategory,
+        containerId:    NodeGroupCategoryId,
+        modificationId: ModificationId,
+        actor:          EventActor,
+        reason:         Option[String]
+    ): IOResult[NodeGroupCategory] = ???
+    override def delete(
+        id:             NodeGroupCategoryId,
+        modificationId: ModificationId,
+        actor:          EventActor,
+        reason:         Option[String],
+        checkEmpty:     Boolean
+    ): IOResult[NodeGroupCategoryId] = ???
+  }
+
+  object policyServerManagementService extends PolicyServerManagementService {
+    private val fakePolicyServers = PolicyServers(PolicyServer(NodeId("root"), List.empty), List.empty)
+    override def savePolicyServers(policyServers: PolicyServers): IOResult[PolicyServers] = {
+      fakePolicyServers.succeed
+    }
+
+    override def getPolicyServers():                               IOResult[PolicyServers] = {
+      fakePolicyServers.succeed
+    }
+
+    override def updatePolicyServers(
+        commands: List[PolicyServersUpdateCommand],
+        modId:    ModificationId,
+        actor:    EventActor
+    ): IOResult[PolicyServers] = ???
+    override def deleteRelaySystemObjects(policyServerId: NodeId): IOResult[Unit]          = ???
+
+  }
+
+  object eventLogRepo extends EventLogRepository {
+
+    override def savePromoteToRelay(
+        modId:        ModificationId,
+        principal:    EventActor,
+        promotedNode: NodeInfo,
+        reason:       Option[String]
+    ): IOResult[EventLog] = {
+      ZIO.succeed(null)
+    }
+
+    override def saveDemoteToNode(
+        modId:        ModificationId,
+        principal:    EventActor,
+        demotedRelay: NodeInfo,
+        reason:       Option[String]
+    ): IOResult[EventLog] = {
+      ZIO.succeed(null)
+    }
+
+    override def eventLogFactory:                                                                EventLogFactory                                       = ???
+    override def getLastEventByChangeRequest(
+        xpath:           String,
+        eventTypeFilter: List[EventLogFilter]
+    ): IOResult[Map[ChangeRequestId, EventLog]] = ???
+    override def saveEventLog(modId: ModificationId, eventLog: EventLog):                        IOResult[EventLog]                                    = ???
+    override def getEventLogByCriteria(
+        criteria:       Option[Fragment],
+        limit:          Option[Int],
+        orderBy:        List[Fragment],
+        extendedFilter: Option[Fragment]
+    ): IOResult[Seq[EventLog]] = ???
+    override def getEventLogById(id: Long):                                                      IOResult[EventLog]                                    = ???
+    override def getEventLogCount(criteria: Option[Fragment], extendedFilter: Option[Fragment]): IOResult[Long]                                        = ???
+    override def getEventLogByChangeRequest(
+        changeRequest:   ChangeRequestId,
+        xpath:           String,
+        optLimit:        Option[Int],
+        orderBy:         Option[String],
+        eventTypeFilter: List[EventLogFilter]
+    ): IOResult[Vector[EventLog]] = ???
+    override def getEventLogWithChangeRequest(id: Int):                                          IOResult[Option[(EventLog, Option[ChangeRequestId])]] = ???
+  }
+}

--- a/scale-out-relay/src/test/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApiTest.scala
+++ b/scale-out-relay/src/test/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApiTest.scala
@@ -1,0 +1,61 @@
+package com.normation.plugins.scaleoutrelay.api
+
+import better.files._
+import com.normation.plugins.scaleoutrelay.MockServices
+import com.normation.plugins.scaleoutrelay.ScaleOutRelayService
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.rest.TraitTestApiFromYamlFiles
+import java.nio.file.Files
+import net.liftweb.common.Loggable
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+
+@RunWith(classOf[JUnitRunner])
+class ScaleOutRelayApiTest extends Specification with TraitTestApiFromYamlFiles with Loggable with AfterAll {
+  sequential
+  isolated
+
+  val restTestSetUp = RestTestSetUp.newEnv
+
+  val tmpDir: File = File(Files.createTempDirectory("rudder-test-"))
+  override def yamlSourceDirectory  = "scaleoutrelay_api"
+  override def yamlDestTmpDirectory = tmpDir / "templates"
+
+  val mockServices = new MockServices(restTestSetUp.mockNodes.allNodesInfo, Map.empty)
+  val modules      = List(
+    new ScaleOutRelayApiImpl(
+      new ScaleOutRelayService(
+        mockServices.nodeInfoService,
+        mockServices.woLDAPNodeGroupRepository,
+        mockServices.nodeInfoService,
+        restTestSetUp.mockDirectives.directiveRepo,
+        restTestSetUp.mockRules.ruleRepo,
+        restTestSetUp.uuidGen,
+        mockServices.policyServerManagementService,
+        mockServices.eventLogRepo,
+        restTestSetUp.asyncDeploymentAgent
+      )
+    )
+  )
+
+  val apiVersions            = ApiVersion(13, true) :: ApiVersion(14, false) :: Nil
+  val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(modules, apiVersions, None)
+
+  override def transformations: Map[String, String => String] = Map()
+
+  // we are testing error cases, so we don't want to output error log for them
+  org.slf4j.LoggerFactory
+    .getLogger("com.normation.rudder.rest.RestUtils")
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.OFF)
+
+  override def afterAll(): Unit = {
+    tmpDir.delete()
+  }
+
+  doTest(semanticJson = true)
+
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/23760

Removing any occurrence of lift-json in the three plugins : branding, openscap, scale-out-relay.

In the branding plugin there is an outdated serial format (from the v5.0 of rudder), which should be removed later. The openscap plugin has only unused imports from lift-json, I took the opportunity to add yaml tests for the API