### PR TITLE
Fixes #23775: Migrate api-authorizations, auth-backends to zio-json

### DIFF
--- a/api-authorizations/src/main/scala/bootstrap/rudder/plugin/ApiAuthorizationsConf.scala
+++ b/api-authorizations/src/main/scala/bootstrap/rudder/plugin/ApiAuthorizationsConf.scala
@@ -61,7 +61,6 @@ object ApiAuthorizationsConf extends RudderPluginModule {
   RudderConfig.apiAuthorizationLevelService.overrideLevel(new AclLevel(pluginStatusService))
 
   lazy val userApi   = new UserApi(
-    RudderConfig.restExtractorService,
     RudderConfig.roApiAccountRepository,
     RudderConfig.woApiAccountRepository,
     RudderConfig.tokenGenerator,

--- a/api-authorizations/src/main/scala/com/normation/plugins/apiauthorizations/UserJsonCodec.scala
+++ b/api-authorizations/src/main/scala/com/normation/plugins/apiauthorizations/UserJsonCodec.scala
@@ -1,0 +1,23 @@
+package com.normation.plugins.apiauthorizations
+
+import com.normation.rudder.api.ApiAccountId
+import com.normation.rudder.api.ApiAccountName
+import com.normation.rudder.api.ApiAccountType
+import com.normation.rudder.api.ApiAuthorizationKind
+import com.normation.rudder.apidata.JsonApiAcl
+import com.normation.utils.DateFormaterService
+import org.joda.time.DateTime
+import zio.json._
+
+trait UserJsonCodec {
+
+  implicit val accountIdEncoder:         JsonEncoder[ApiAccountId]         = JsonEncoder[String].contramap(_.value)
+  implicit val accountNameEncoder:       JsonEncoder[ApiAccountName]       = JsonEncoder[String].contramap(_.value)
+  implicit val dateTimeEncoder:          JsonEncoder[DateTime]             = JsonEncoder[String].contramap(DateFormaterService.serialize)
+  implicit val accountTypeEncoder:       JsonEncoder[ApiAccountType]       = JsonEncoder[String].contramap(_.name)
+  implicit val authorizationTypeEncoder: JsonEncoder[ApiAuthorizationKind] = JsonEncoder[String].contramap(_.name)
+  implicit val aclEncoder:               JsonEncoder[JsonApiAcl]           = DeriveJsonEncoder.gen[JsonApiAcl]
+
+}
+
+object UserJsonCodec extends UserJsonCodec

--- a/api-authorizations/src/main/scala/com/normation/plugins/apiauthorizations/UserTokenApiDefinition.scala
+++ b/api-authorizations/src/main/scala/com/normation/plugins/apiauthorizations/UserTokenApiDefinition.scala
@@ -37,31 +37,30 @@
 
 package com.normation.plugins.apiauthorizations
 
-import com.normation.box._
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.api._
-import com.normation.rudder.apidata.ApiAccountSerialisation._
+import com.normation.rudder.apidata.JsonApiAcl
 import com.normation.rudder.rest._
 import com.normation.rudder.rest.{UserApi => API}
+import com.normation.rudder.rest.implicits.ToLiftResponseOne
 import com.normation.rudder.rest.lift._
+import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGenerator
-import net.liftweb.common.EmptyBox
-import net.liftweb.common.Full
+import io.scalaland.chimney.Transformer
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json._
-import net.liftweb.json.JsonAST.JArray
-import net.liftweb.json.JsonDSL._
 import org.joda.time.DateTime
+import zio.json._
 
 class UserApi(
-    restExtractor:  RestExtractorService,
     readApi:        RoApiAccountRepository,
     writeApi:       WoApiAccountRepository,
     tokenGenerator: TokenGenerator,
     uuidGen:        StringUuidGenerator
 ) extends LiftApiModuleProvider[API] {
   api =>
+
+  import UserApi._
 
   def schemas = API
 
@@ -85,34 +84,18 @@ class UserApi(
    */
 
   object GetApiToken extends LiftApiModule0 {
-    val schema        = API.GetApiToken
-    val restExtractor = api.restExtractor
+    val schema = API.GetApiToken
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      readApi.getById(ApiAccountId(authzToken.actor.name)).toBox match {
-        case Full(Some(account)) =>
-          val filtered = account.copy(token = if (account.token.isHashed) {
-            // Don't send hashes
-            ApiToken("")
-          } else {
-            account.token
-          })
-          val accounts: JValue = ("accounts" -> JArray(List(filtered.toJson)))
-          RestUtils.toJsonResponse(None, accounts)(schema.name, true)
-
-        case Full(None) =>
-          val accounts: JValue = ("accounts" -> JArray(Nil))
-          RestUtils.toJsonResponse(None, accounts)(schema.name, true)
-
-        case eb: EmptyBox =>
-          val e = eb ?~! s"Error when trying to get user '${authzToken.actor.name}' API token"
-          RestUtils.toJsonError(None, e.messageChain)(schema.name, true)
-      }
+      readApi
+        .getById(ApiAccountId(authzToken.actor.name))
+        .map(RestAccountsResponse.fromRedacted(_))
+        .chainError(s"Error when trying to get user '${authzToken.actor.name}' API token")
+        .toLiftResponseOne(params, schema, None)
     }
   }
 
   object CreateApiToken extends LiftApiModule0 {
-    val schema        = API.CreateApiToken
-    val restExtractor = api.restExtractor
+    val schema = API.CreateApiToken
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
       val now     = DateTime.now
       val secret  = ApiToken.generate_secret(tokenGenerator)
@@ -128,67 +111,178 @@ class UserApi(
         now
       )
 
-      writeApi.save(account, ModificationId(uuidGen.newUuid), authzToken.actor).toBox match {
-        case Full(account) =>
-          val accounts: JValue = ("accounts" -> JArray(
-            List(
-              account
-                .copy(
-                  // Send clear text secret
-                  token = ApiToken(secret)
-                )
-                .toJson
-            )
-          ))
-          RestUtils.toJsonResponse(None, accounts)(schema.name, true)
-
-        case eb: EmptyBox =>
-          val e = eb ?~! s"Error when trying to save user '${authzToken.actor.name}' API token"
-          RestUtils.toJsonError(None, e.messageChain)(schema.name, true)
-      }
+      writeApi
+        .save(account, ModificationId(uuidGen.newUuid), authzToken.actor)
+        .map(RestAccountsResponse.fromUnredacted(_, secret))
+        .chainError(s"Error when trying to save user '${authzToken.actor.name}' API token")
+        .toLiftResponseOne(params, schema, None)
     }
   }
 
   object DeleteApiToken extends LiftApiModule0 {
-    val schema        = API.DeleteApiToken
-    val restExtractor = api.restExtractor
+    val schema = API.DeleteApiToken
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      writeApi.delete(ApiAccountId(authzToken.actor.name), ModificationId(uuidGen.newUuid), authzToken.actor).toBox match {
-        case Full(account) =>
-          val accounts: JValue = ("accounts" -> ("id" -> account.value))
-          RestUtils.toJsonResponse(None, accounts)(schema.name, true)
-
-        case eb: EmptyBox =>
-          val e = eb ?~! s"Error when trying to delete user '${authzToken.actor.name}' API token"
-          RestUtils.toJsonError(None, e.messageChain)(schema.name, true)
-      }
+      writeApi
+        .delete(ApiAccountId(authzToken.actor.name), ModificationId(uuidGen.newUuid), authzToken.actor)
+        .map(RestAccountIdResponse(_))
+        .chainError(s"Error when trying to delete user '${authzToken.actor.name}' API token")
+        .toLiftResponseOne(params, schema, None)
     }
   }
 
   object UpdateApiToken extends LiftApiModule0 {
-    val schema        = API.UpdateApiToken
-    val restExtractor = api.restExtractor
+    val schema = API.UpdateApiToken
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      readApi.getById(ApiAccountId(authzToken.actor.name)).toBox match {
-        case Full(Some(account)) =>
-          val filtered = account.copy(token = if (account.token.isHashed) {
-            // Don't send hashes
-            ApiToken("")
-          } else {
-            account.token
-          })
-          val accounts: JValue = ("accounts" -> JArray(List(filtered.toJson)))
-          RestUtils.toJsonResponse(None, accounts)(schema.name, true)
-
-        case Full(None) =>
-          val accounts: JValue = ("accounts" -> JArray(Nil))
-          RestUtils.toJsonResponse(None, accounts)(schema.name, true)
-
-        case eb: EmptyBox =>
-          val e = eb ?~! s"Error when trying to get user '${authzToken.actor.name}' API token"
-          RestUtils.toJsonError(None, e.messageChain)(schema.name, true)
-      }
+      readApi
+        .getById(ApiAccountId(authzToken.actor.name))
+        .map(RestAccountsResponse.fromRedacted(_))
+        .chainError(s"Error when trying to get user '${authzToken.actor.name}' API token")
+        .toLiftResponseOne(params, schema, None)
     }
+  }
+
+}
+
+object UserApi {
+
+  /**
+    * The value that will be displayed in the API response for the token.
+    */
+  final case class ClearTextToken(value: String) extends AnyVal
+
+  object ClearTextToken {
+
+    implicit val transformer: Transformer[ApiToken, ClearTextToken] = Transformer
+      .define[ApiToken, ClearTextToken]
+      .withFieldComputed(_.value, token => if (token.isHashed) "" else token.value)
+      .buildTransformer
+
+    implicit val encoder: JsonEncoder[ClearTextToken] = JsonEncoder[String].contramap(_.value)
+  }
+
+  final case class RestApiAccount(
+      id:                              ApiAccountId,
+      name:                            ApiAccountName,
+      token:                           ClearTextToken,
+      tokenGenerationDate:             DateTime,
+      kind:                            ApiAccountType,
+      description:                     String,
+      creationDate:                    DateTime,
+      @jsonField("enabled") isEnabled: Boolean,
+      expirationDate:                  Option[String],
+      expirationDateDefined:           Boolean,
+      authorizationType:               Option[ApiAuthorizationKind],
+      acl:                             Option[List[JsonApiAcl]]
+  )
+
+  object RestApiAccount extends UserJsonCodec {
+    implicit class ApiAccountOps(val account: ApiAccount) extends AnyVal {
+      import ApiAccountKind._
+      import io.scalaland.chimney.syntax._
+      def expirationDate: Option[String] = {
+        account.kind match {
+          case PublicApi(_, expirationDate) => expirationDate.map(DateFormaterService.getDisplayDateTimePicker)
+          case User | System                => None
+        }
+      }
+
+      def expirationDateDefined: Boolean = expirationDate.isDefined
+
+      def authzType: Option[ApiAuthorizationKind] = {
+        account.kind match {
+          case PublicApi(authz, _) => Some(authz.kind)
+          case User | System       => None
+        }
+      }
+
+      def acl: Option[List[JsonApiAcl]] = {
+        import ApiAuthorization._
+        account.kind match {
+          case PublicApi(authz, expirationDate) =>
+            authz match {
+              case None | RO | RW => Option.empty
+              case ACL(acls)      => Some(acls.flatMap(x => x.actions.map(a => JsonApiAcl(x.path.value, a.name))))
+            }
+          case User | System                    => Option.empty
+        }
+      }
+
+      /**
+        * Always hides any hashed token, and displays any clear-text token
+        */
+      def toRest = account.transformInto[RestApiAccount]
+
+      /**
+        * Always displays the passed secret token
+        */
+      def toRestWithSecret(secret: ClearTextToken) = account.transformInto[RestApiAccount].copy(token = secret)
+    }
+
+    implicit val transformer: Transformer[ApiAccount, RestApiAccount] = Transformer
+      .define[ApiAccount, RestApiAccount]
+      .withFieldComputed(_.kind, _.kind.kind)
+      .withFieldComputed(_.acl, _.acl)
+      .withFieldComputed(_.expirationDate, _.expirationDate)
+      .withFieldComputed(_.expirationDateDefined, _.expirationDateDefined)
+      .withFieldComputed(
+        _.authorizationType,
+        _.authzType
+      )
+      .buildTransformer
+
+    implicit val publicTokenEncoder: JsonEncoder[ApiToken] =
+      JsonEncoder[String].contramap(_.value)
+
+    implicit val encoder: JsonEncoder[RestApiAccount] = DeriveJsonEncoder.gen[RestApiAccount]
+  }
+
+  /**
+    * The format of the API response is a list of accounts (it usually contains a single element or is empty)
+    */
+  final case class RestAccountsResponse private (
+      accounts: List[RestApiAccount]
+  )
+
+  object RestAccountsResponse {
+    import RestApiAccount._
+
+    implicit val encoder: JsonEncoder[RestAccountsResponse] = DeriveJsonEncoder.gen[RestAccountsResponse]
+
+    // The format of the API response is a list of accounts but contains only a single account, the secret is used to replace the token in the account
+    private def apply(accounts: List[ApiAccount], secret: Option[ClearTextToken] = None): RestAccountsResponse = {
+      new RestAccountsResponse(
+        accounts.map(a => secret.map(a.toRestWithSecret(_)).getOrElse(a.toRest))
+      )
+    }
+
+    def empty: RestAccountsResponse = RestAccountsResponse(Nil)
+
+    /**
+      * Displays the provided clear-text or hashed token for the api account 
+      */
+    def fromUnredacted(account: ApiAccount, secret: String): RestAccountsResponse = {
+      apply(List(account), Some(ClearTextToken(secret)))
+    }
+
+    /**
+      * Hides the hashed token and displays the clear-text token
+      */
+    def fromRedacted(account: Option[ApiAccount]): RestAccountsResponse = {
+      // Don't send hashes in response
+      apply(account.toList)
+    }
+  }
+
+  final case class RestAccountId(id: ApiAccountId)
+  final case class RestAccountIdResponse private (
+      accounts: RestAccountId
+  )
+
+  object RestAccountIdResponse extends UserJsonCodec {
+    implicit val accountIdResponseEncoder: JsonEncoder[RestAccountId]         = DeriveJsonEncoder.gen[RestAccountId]
+    implicit val encoder:                  JsonEncoder[RestAccountIdResponse] = DeriveJsonEncoder.gen[RestAccountIdResponse]
+
+    def apply(account: ApiAccountId): RestAccountIdResponse = new RestAccountIdResponse(RestAccountId(account))
   }
 
 }

--- a/api-authorizations/src/test/resources/authorizations_api/api_users.yml
+++ b/api-authorizations/src/test/resources/authorizations_api/api_users.yml
@@ -1,0 +1,110 @@
+description: Get information about user personal UserApi token
+method: GET
+url: /secure/api/user/api/token
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 200
+  content: >-
+    {
+     "action" : "getApiToken",
+     "result" : "success",
+     "data" : {
+       "accounts" : [
+          {
+            "id" : "user1",
+            "name" : "user1",
+            "token" : "",
+            "tokenGenerationDate" : "2023-10-10T10:10:10Z",
+            "kind" : "system",
+            "description" : "number one user",
+            "creationDate" : "2023-10-10T10:10:10Z",
+            "enabled" : true,
+            "expirationDateDefined" : false
+          }
+        ]
+      }
+    }
+---
+description: Update user personal UserApi token
+method: POST
+url: /secure/api/user/api/token
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "updateApiToken",
+      "result" : "success",
+      "data" : {
+        "accounts" : [
+          {
+            "id" : "user1",
+            "name" : "user1",
+            "token" : "",
+            "tokenGenerationDate" : "2023-10-10T10:10:10Z",
+            "kind" : "system",
+            "description" : "number one user",
+            "creationDate" : "2023-10-10T10:10:10Z",
+            "enabled" : true,
+            "expirationDateDefined" : false
+          }
+        ]
+      }
+    }
+---
+description: Create user personal UserApi token
+method: PUT
+url: /secure/api/user/api/token
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "name": "user1",
+    "description": "number one user"
+  }
+response:
+  code: 200
+  content: >-
+    {
+     "action" : "createApiToken",
+     "result" : "success",
+     "data" : {
+       "accounts" : [
+          {
+            "id" : "user1",
+            "name" : "user1",
+            "token" : "generated-test-token",
+            "tokenGenerationDate" : "2023-12-12T13:12:12+01:00",
+            "kind" : "user",
+            "description" : "API token for user 'user1'",
+            "creationDate" : "2023-12-12T13:12:12+01:00",
+            "enabled" : true,
+            "expirationDateDefined" : false
+          }
+        ]
+      }
+    }
+---
+description: Delete user personal UserApi token
+method: DELETE
+url: /secure/api/user/api/token
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "name": "user1"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "deleteApiToken",
+      "result" : "success",
+      "data" : {
+        "accounts" : {
+          "id" : "user1"
+        }
+      }
+    }

--- a/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/MockServices.scala
+++ b/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/MockServices.scala
@@ -1,0 +1,37 @@
+package com.normation.plugins.apiauthorizations
+
+import com.normation.errors.IOResult
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountId
+import com.normation.rudder.api.ApiToken
+import com.normation.rudder.api.RoApiAccountRepository
+import com.normation.rudder.api.TokenGenerator
+import com.normation.rudder.api.WoApiAccountRepository
+import zio.syntax._
+
+class MockServices(newToken: String, accounts: Map[ApiAccountId, ApiAccount] = Map.empty) { self =>
+
+  object apiAccountRepository extends RoApiAccountRepository with WoApiAccountRepository {
+    override def getById(id: ApiAccountId): IOResult[Option[ApiAccount]] = {
+      accounts.get(id).succeed
+    }
+
+    override def save(principal: ApiAccount, modId: ModificationId, actor: EventActor): IOResult[ApiAccount] = {
+      principal.succeed
+    }
+
+    override def delete(id: ApiAccountId, modId: ModificationId, actor: EventActor): IOResult[ApiAccountId] = {
+      id.succeed
+    }
+
+    override def getAllStandardAccounts:      IOResult[Seq[ApiAccount]]    = ???
+    override def getByToken(token: ApiToken): IOResult[Option[ApiAccount]] = ???
+    override def getSystemAccount:            ApiAccount                   = ???
+  }
+
+  object tokenGenerator extends TokenGenerator {
+    override def newToken(size: Int): String = self.newToken
+  }
+}

--- a/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/api/UserApiTest.scala
+++ b/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/api/UserApiTest.scala
@@ -1,0 +1,97 @@
+package com.normation.plugins.apiauthorizations
+
+import better.files._
+import com.normation.rudder.AuthorizationType
+import com.normation.rudder.RudderAccount
+import com.normation.rudder.User
+import com.normation.rudder.UserService
+import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountId
+import com.normation.rudder.api.ApiAccountKind
+import com.normation.rudder.api.ApiAccountName
+import com.normation.rudder.api.ApiAuthorization
+import com.normation.rudder.api.ApiToken
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.rest.TraitTestApiFromYamlFiles
+import java.nio.file.Files
+import net.liftweb.common.Loggable
+import org.joda.time.DateTime
+import org.joda.time.DateTimeUtils
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.BeforeAfterAll
+
+@RunWith(classOf[JUnitRunner])
+class UserApiTest extends Specification with TraitTestApiFromYamlFiles with Loggable with BeforeAfterAll {
+
+  sequential
+
+  val restTestSetUp = RestTestSetUp.newEnv
+
+  val tmpDir: File = File(Files.createTempDirectory("rudder-test-"))
+  override def yamlSourceDirectory  = "authorizations_api"
+  override def yamlDestTmpDirectory = tmpDir / "templates"
+
+  // date used when `DateTime.now` is called e.g. when creating a new token
+  val fixedDate = DateTime.parse("2023-12-12T12:12:12.000Z")
+
+  val accountCreationDate = DateTime.parse("2023-10-10T10:10:10.000Z")
+  val accounts            = Map(
+    ApiAccountId("user1") -> ApiAccount(
+      ApiAccountId("user1"),
+      ApiAccountKind.System, // so that we have access to the plugin endpoints
+      ApiAccountName("user1"),
+      ApiToken("v2:some-hashed-token"),
+      "number one user",
+      isEnabled = true,
+      creationDate = accountCreationDate,
+      tokenGenerationDate = accountCreationDate
+    )
+  )
+
+  val mockServices = new MockServices(newToken = "generated-test-token", accounts = accounts)
+
+  val userService: UserService = new UserService {
+    // use an user that has access to the api, we do not test authorization checks in this file
+    val user1          = new User {
+      val account                              = RudderAccount.Api(accounts(ApiAccountId("user1")))
+      def checkRights(auth: AuthorizationType) = true
+      def getApiAuthz                          = ApiAuthorization.RW
+    }
+    val getCurrentUser = user1
+  }
+
+  val modules = List(
+    new UserApi(
+      mockServices.apiAccountRepository,
+      mockServices.apiAccountRepository,
+      mockServices.tokenGenerator,
+      restTestSetUp.uuidGen
+    )
+  )
+
+  val apiVersions            = ApiVersion(13, true) :: ApiVersion(14, false) :: Nil
+  val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(modules, apiVersions, Some(userService))
+
+  override def transformations: Map[String, String => String] = Map()
+
+  // we are testing error cases, so we don't want to output error log for them
+  org.slf4j.LoggerFactory
+    .getLogger("com.normation.rudder.rest.RestUtils")
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.OFF)
+
+  override def beforeAll(): Unit = {
+    // set current time to the fixed date so that we can test dates in yaml files
+    DateTimeUtils.setCurrentMillisFixed(fixedDate.getMillis)
+  }
+
+  override def afterAll(): Unit = {
+    tmpDir.delete()
+  }
+
+  doTest(semanticJson = true)
+
+}

--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -46,7 +46,7 @@ import com.normation.plugins.RudderPluginModule
 import com.normation.plugins.authbackends.AuthBackendsLogger
 import com.normation.plugins.authbackends.AuthBackendsLoggerPure
 import com.normation.plugins.authbackends.AuthBackendsPluginDef
-import com.normation.plugins.authbackends.AuthBackendsRepository
+import com.normation.plugins.authbackends.AuthBackendsRepositoryImpl
 import com.normation.plugins.authbackends.CheckRudderPluginEnableImpl
 import com.normation.plugins.authbackends.LoginFormRendering
 import com.normation.plugins.authbackends.RudderClientRegistration
@@ -167,8 +167,7 @@ object AuthBackendsConf extends RudderPluginModule {
   lazy val pluginDef = new AuthBackendsPluginDef(AuthBackendsConf.pluginStatusService)
 
   lazy val api = new AuthBackendsApiImpl(
-    RudderConfig.restExtractorService,
-    new AuthBackendsRepository(RudderConfig.authenticationProviders, RudderProperties.config)
+    new AuthBackendsRepositoryImpl(RudderConfig.authenticationProviders, RudderProperties.config)
   )
 
   lazy val loginFormRendering: LoginFormRendering = {

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/AuthBackendsRepository.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/AuthBackendsRepository.scala
@@ -43,21 +43,30 @@ import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.config.ConfigValueType
 
+trait AuthBackendsRepository {
+
+  /**
+    * Attempt to get the configuration for the authentication backends
+    */
+  def getConfigOption(): JsonAuthConfiguration
+
+}
+
 /*
  * This class handle the translation between configuration files
  * for authentication and information that can be presented to the
  * user.
  */
-class AuthBackendsRepository(
+class AuthBackendsRepositoryImpl(
     authService:      AuthBackendProvidersManager,
     configParameters: Config
-) {
+) extends AuthBackendsRepository {
 
   /**
    * Get all information about the currently configured back-ends in a
    * format that can be understood by client side.
    */
-  def getConfigOption(): Either[Exception, JsonAuthConfiguration] = {
+  def getConfigOption(): JsonAuthConfiguration = {
 
     // utility method which look in "config" for the key and
     // return an ConfigOption for the value, with an empty value
@@ -161,8 +170,6 @@ class AuthBackendsRepository(
 
     val usedOrder = authService.getConfiguredProviders().map(_.name)
 
-    Right(
-      JsonAuthConfiguration(configuredOrder, usedOrder, rootAdmin, file, ldap)
-    )
+    JsonAuthConfiguration(configuredOrder, usedOrder, rootAdmin, file, ldap)
   }
 }

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/DataTypes.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/DataTypes.scala
@@ -39,11 +39,8 @@ package com.normation.plugins.authbackends
 
 import com.normation.NamedZioLogger
 import net.liftweb.common.Logger
-import net.liftweb.json.Extraction
-import net.liftweb.json.Formats
-import net.liftweb.json.JsonAST.JValue
-import net.liftweb.json.NoTypeHints
 import org.slf4j.LoggerFactory
+import zio.json._
 
 /**
  * Applicative log of interest for Rudder ops.
@@ -112,14 +109,11 @@ final case class JsonLdapConfig(
 )
 
 final object JsonSerialization {
-
-  implicit val formats: Formats = net.liftweb.json.Serialization.formats(NoTypeHints)
-
-  implicit class ConfigOptionToJson(config: JsonAuthConfiguration) {
-    def toJson(): JValue = {
-      Extraction.decompose(config)
-    }
-  }
+  implicit val configOptionEncoder:    JsonEncoder[ConfigOption]          = DeriveJsonEncoder.gen[ConfigOption]
+  implicit val jsonAdminConfigEncoder: JsonEncoder[JsonAdminConfig]       = DeriveJsonEncoder.gen[JsonAdminConfig]
+  implicit val jsonFileConfigEncoder:  JsonEncoder[JsonFileConfig]        = DeriveJsonEncoder.gen[JsonFileConfig]
+  implicit val jsonLdapConfigEncoder:  JsonEncoder[JsonLdapConfig]        = DeriveJsonEncoder.gen[JsonLdapConfig]
+  implicit val jsonAuthConfigEncoder:  JsonEncoder[JsonAuthConfiguration] = DeriveJsonEncoder.gen[JsonAuthConfiguration]
 }
 
 /*

--- a/auth-backends/src/test/resources/authbackends_api/api_authbackends.yml
+++ b/auth-backends/src/test/resources/authbackends_api/api_authbackends.yml
@@ -1,0 +1,65 @@
+description: Get information about current authentication configuration
+method: GET
+url: /secure/api/authbackends/current-configuration
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getAuthenticationInformation",
+      "result" : "success",
+      "data" : {
+        "declaredProviders" : "provider1, provider2",
+        "computedProviders" : [
+          "provider1",
+          "provider2"
+        ],
+        "adminConfig" : {
+          "description" : "Admin configuration",
+          "login" : {
+            "description" : "Login description",
+            "key" : "loginKey",
+            "value" : "loginValue"
+          },
+          "password" : {
+            "description" : "Password description",
+            "key" : "passwordKey",
+            "value" : "passwordValue"
+          },
+          "enabled" : true
+        },
+        "fileConfig" : {
+          "providerId" : "fileProvider",
+          "description" : "File configuration",
+          "filePath" : "/path/to/file"
+        },
+        "ldapConfig" : {
+          "providerId" : "ldapProvider",
+          "description" : "LDAP configuration",
+          "ldapUrl" : {
+            "description" : "LDAP URL description",
+            "key" : "ldapUrlKey",
+            "value" : "ldapUrlValue"
+          },
+          "bindDn" : {
+            "description" : "Bind DN description",
+            "key" : "bindDnKey",
+            "value" : "bindDnValue"
+          },
+          "bindPassword" : {
+            "description" : "Bind password description",
+            "key" : "bindPasswordKey",
+            "value" : "bindPasswordValue"
+          },
+          "searchBase" : {
+            "description" : "Search base description",
+            "key" : "searchBaseKey",
+            "value" : "searchBaseValue"
+          },
+          "ldapFilter" : {
+            "description" : "LDAP filter description",
+            "key" : "ldapFilterKey",
+            "value" : "ldapFilterValue"
+          }
+        }
+      }
+    }

--- a/auth-backends/src/test/scala/com/normation/plugins/authbackends/api/AuthBackendsApiTest.scala
+++ b/auth-backends/src/test/scala/com/normation/plugins/authbackends/api/AuthBackendsApiTest.scala
@@ -1,0 +1,72 @@
+package com.normation.plugins.authbackends
+package api
+
+import better.files.File
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.rest.TraitTestApiFromYamlFiles
+import java.nio.file.Files
+import net.liftweb.common.Loggable
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+
+class AuthBackendsApiTest extends Specification with Loggable with TraitTestApiFromYamlFiles with AfterAll {
+  sequential
+
+  val restTestSetUp = RestTestSetUp.newEnv
+
+  val tmpDir: File = File(Files.createTempDirectory("rudder-test-"))
+  override def yamlSourceDirectory  = "authbackends_api"
+  override def yamlDestTmpDirectory = tmpDir / "templates"
+
+  val fakeJsonAuthConfiguration = JsonAuthConfiguration(
+    declaredProviders = "provider1, provider2",
+    computedProviders = Seq("provider1", "provider2"),
+    adminConfig = JsonAdminConfig(
+      description = "Admin configuration",
+      login = ConfigOption("Login description", "loginKey", "loginValue"),
+      password = ConfigOption("Password description", "passwordKey", "passwordValue"),
+      enabled = true
+    ),
+    fileConfig = JsonFileConfig(
+      providerId = "fileProvider",
+      description = "File configuration",
+      filePath = "/path/to/file"
+    ),
+    ldapConfig = JsonLdapConfig(
+      providerId = "ldapProvider",
+      description = "LDAP configuration",
+      ldapUrl = ConfigOption("LDAP URL description", "ldapUrlKey", "ldapUrlValue"),
+      bindDn = ConfigOption("Bind DN description", "bindDnKey", "bindDnValue"),
+      bindPassword = ConfigOption("Bind password description", "bindPasswordKey", "bindPasswordValue"),
+      searchBase = ConfigOption("Search base description", "searchBaseKey", "searchBaseValue"),
+      ldapFilter = ConfigOption("LDAP filter description", "ldapFilterKey", "ldapFilterValue")
+    )
+  )
+
+  val mockAuthBackendsRepository = new AuthBackendsRepository {
+    override def getConfigOption(): JsonAuthConfiguration = fakeJsonAuthConfiguration
+  }
+  val modules                    = List(
+    new AuthBackendsApiImpl(
+      mockAuthBackendsRepository
+    )
+  )
+
+  val apiVersions            = ApiVersion(13, true) :: ApiVersion(14, false) :: Nil
+  val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(modules, apiVersions, None)
+
+  override def transformations: Map[String, String => String] = Map()
+
+  // we are testing error cases, so we don't want to output error log for them
+  org.slf4j.LoggerFactory
+    .getLogger("com.normation.rudder.rest.RestUtils")
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.OFF)
+
+  override def afterAll(): Unit = {
+    tmpDir.delete()
+  }
+
+  doTest(semanticJson = true)
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/23775

Migrating api-authorizations, there needed to be a rewrite of [the lift-json serializer](https://github.com/Normation/rudder/blob/master/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala#L669) into a data transfer case class and the added tests ensures that the display/hiding of the token value is the same after migrating to zio-json...

