### PR TITLE
Fixes #23805: Migrate datasource plugin to zio-json

### DIFF
--- a/datasources/src/main/scala/bootstrap/rudder/plugin/DataSourcesConf.scala
+++ b/datasources/src/main/scala/bootstrap/rudder/plugin/DataSourcesConf.scala
@@ -114,7 +114,6 @@ object DatasourcesConf extends RudderPluginModule {
 
   val dataSourceApi9 = new DataSourceApiImpl(
     Cfg.restExtractorService,
-    Cfg.restDataSerializer,
     dataSourceRepository,
     Cfg.nodeInfoService,
     Cfg.woNodeRepository,

--- a/datasources/src/main/scala/com/normation/plugins/datasources/DataTypes.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/DataTypes.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.typesafe.config.ConfigValue
 import net.liftweb.common.Logger
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 import zio._
 
@@ -191,33 +190,6 @@ final case class DataSourceRunParameters(
     onNewNode:    Boolean
 )
 
-final case class DataSourceStatus(
-    lastRunDate: Option[DateTime],
-    nodesStatus: Map[NodeId, DataSourceUpdateStatus]
-)
-
-sealed trait DataSourceUpdateStatus {
-  def state:       String
-  def lastRunDate: DateTime
-}
-
-final case object DataSourceUpdateStatus {
-
-  final case class Success(
-      lastRunDate: DateTime
-  ) extends DataSourceUpdateStatus {
-    val state = "success"
-  }
-
-  final case class Failure(
-      lastRunDate:     DateTime,
-      message:         String,
-      lastSuccessDate: Option[String]
-  ) extends DataSourceUpdateStatus {
-    val state = "failure"
-  }
-}
-
 final case class DataSource(
     id:            DataSourceId,
     name:          DataSourceName,
@@ -226,9 +198,7 @@ final case class DataSource(
     description:   String,
     enabled:       Boolean,
     updateTimeOut: Duration
-) {
-  val scope = "all"
-}
+)
 
 /*
  * A data type to track which nodes were updated and which one were not touched.

--- a/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
@@ -113,7 +113,7 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val description    = "Get the list of all defined datasources"
     val (action, path) = GET / "datasources"
 
-    override def dataContainer: Option[String]          = None
+    override def dataContainer: Option[String]          = Some("datasources")
     override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
@@ -122,7 +122,7 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val description    = "Get information about the given datasource"
     val (action, path) = GET / "datasources" / "{datasourceid}"
 
-    override def dataContainer: Option[String]          = None
+    override def dataContainer: Option[String]          = Some("datasources")
     override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
@@ -131,7 +131,7 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val description    = "Delete given datasource"
     val (action, path) = DELETE / "datasources" / "{datasourceid}"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String] = Some("datasources")
   }
 
   final case object CreateDataSource extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
@@ -139,7 +139,7 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val description    = "Create given datasource"
     val (action, path) = PUT / "datasources"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String] = Some("datasources")
   }
 
   final case object UpdateDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
@@ -147,7 +147,7 @@ object DataSourceApi       extends ApiModuleProvider[DataSourceApi] {
     val description    = "Update information about the given datasource"
     val (action, path) = POST / "datasources" / "{datasourceid}"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String] = Some("datasources")
   }
 
   def endpoints = ca.mrvisser.sealerate.values[DataSourceApi].toList.sortBy(_.z)

--- a/datasources/src/test/resources/datasources_api/api_datasources.yml
+++ b/datasources/src/test/resources/datasources_api/api_datasources.yml
@@ -1,0 +1,804 @@
+description: Get the list of all defined datasources
+method: GET
+url: /api/latest/datasources
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getAllDataSources",
+      "result" : "success",
+      "data" : {
+        "datasources" : [
+          {
+            "name" : "",
+            "id" : "datasource1",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [],
+                "params" : [],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "delete"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          }
+        ]
+      }
+    }
+---
+description: Create given datasource
+method: PUT
+url: /api/latest/datasources
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "name" : "",
+    "id" : "datasource2",
+    "description" : "",
+    "type" : {
+      "name" : "HTTP",
+      "parameters" : {
+        "url" : "",
+        "headers" : [
+          {
+            "name" : "header 1",
+            "value" : "value 1"
+          },
+          {
+            "name" : "header 2",
+            "value" : "value 2"
+          }
+        ],
+        "params" : [
+          {
+            "name" : "param 1",
+            "value" : "value 1"
+          }
+        ],
+        "path" : "",
+        "checkSsl" : false,
+        "maxParallelReq" : 10,
+        "requestTimeout" : 300,
+        "requestMethod" : "GET",
+        "requestMode" : {
+          "name" : "byNode"
+        },
+        "onMissing" : {
+          "name" : "noChange"
+        }
+      }
+    },
+    "runParameters" : {
+      "onGeneration" : false,
+      "onNewNode" : false,
+      "schedule" : {
+        "type" : "notscheduled",
+        "duration" : 300
+      }
+    },
+    "updateTimeout" : 300,
+    "enabled" : false
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "createDataSource",
+      "result" : "success",
+      "data" : {
+        "datasources" : [
+          {
+            "name" : "",
+            "id" : "datasource2",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [
+                  {
+                    "name" : "header 1",
+                    "value" : "value 1"
+                  },
+                  {
+                    "name" : "header 2",
+                    "value" : "value 2"
+                  }
+                ],
+                "params" : [
+                  {
+                    "name" : "param 1",
+                    "value" : "value 1"
+                  }
+                ],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "noChange"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          }
+        ]
+      }
+    }
+---
+description: Create given datasource with query parameters
+method: PUT
+url: /api/latest/datasources
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+params:
+  name: ""
+  id: "datasource3"
+  description: ""
+  type: >-
+    {
+      "name": "HTTP",
+      "parameters": {
+        "url": "",
+        "headers": [],
+        "params": [],
+        "path": "",
+        "checkSsl": false,
+        "maxParallelReq": 10,
+        "requestTimeout": 300,
+        "requestMethod": "GET",
+        "requestMode": {
+          "name": "byNode"
+        }
+      }
+    }
+  runParameters: >-
+    {
+      "onGeneration": false,
+      "onNewNode": false,
+      "schedule": {
+        "type": "notscheduled",
+        "duration": 300
+      }
+    }
+  updateTimeout: "300"
+  enabled: "false"
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "createDataSource",
+      "result" : "success",
+      "data" : {
+        "datasources" : [
+          {
+            "name" : "",
+            "id" : "datasource3",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [],
+                "params" : [],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "delete"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          }
+        ]
+      }
+    }
+---
+description: Get the new list of data sources
+method: GET
+url: /api/latest/datasources
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getAllDataSources",
+      "result" : "success",
+      "data" : {
+        "datasources" : [
+          {
+            "name" : "",
+            "id" : "datasource1",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [],
+                "params" : [],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "delete"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          },
+          {
+            "name" : "",
+            "id" : "datasource2",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [
+                  {
+                    "name" : "header 1",
+                    "value" : "value 1"
+                  },
+                  {
+                    "name" : "header 2",
+                    "value" : "value 2"
+                  }
+                ],
+                "params" : [
+                  {
+                    "name" : "param 1",
+                    "value" : "value 1"
+                  }
+                ],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "noChange"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          },
+          {
+            "name" : "",
+            "id" : "datasource3",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [],
+                "params" : [],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "delete"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          }
+        ]
+      }
+    }
+---
+description: Update information about the given datasource
+method: POST
+url: /api/latest/datasources/datasource2
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "name" : "d2",
+    "id" : "fakedatasource2",
+    "updateTimeout" : 299,
+    "enabled" : true,
+    "type" : {
+      "name" : "HTTP",
+      "parameters" : {
+        "url" : "http://new.url.com",
+        "headers" : [
+          {
+            "name" : "header 1",
+            "value" : "new value 1"
+          },
+          {
+            "name" : "new header 2",
+            "value" : "new value 2"
+          }
+        ],
+        "params" : [
+          {
+            "name" : "new param 2",
+            "value" : "new value 2"
+          }
+        ],
+        "path" : "/new/path",
+        "checkSsl" : true,
+        "maxParallelReq" : 11,
+        "requestTimeout" : 301,
+        "requestMethod" : "POST",
+        "requestMode" : {
+          "name" : "allNodes",
+          "path" : "/some/path",
+          "attribute" : "someAttribute"
+        },
+        "onMissing" : {
+          "name" : "defaultValue",
+          "value" : "toto"
+        }
+      }
+    },
+    "description" : "new description",
+    "runParameters" : {
+      "onGeneration" : true,
+      "onNewNode" : true,
+      "schedule" : {
+        "type" : "scheduled",
+        "duration" : 70
+      }
+    }
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "updateDataSource",
+      "result" : "success",
+      "data" : {
+        "datasources" : [
+          {
+            "name" : "d2",
+            "id" : "datasource2",
+            "description" : "new description",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "http://new.url.com",
+                "headers" : [
+                  {
+                    "name" : "header 1",
+                    "value" : "new value 1"
+                  },
+                  {
+                    "name" : "new header 2",
+                    "value" : "new value 2"
+                  }
+                ],
+                "params" : [
+                  {
+                    "name" : "new param 2",
+                    "value" : "new value 2"
+                  }
+                ],
+                "path" : "/new/path",
+                "checkSsl" : true,
+                "maxParallelReq" : 11,
+                "requestTimeout" : 301,
+                "requestMethod" : "POST",
+                "requestMode" : {
+                  "name" : "allNodes",
+                  "path" : "/some/path",
+                  "attribute" : "someAttribute"
+                },
+                "onMissing" : {
+                  "name" : "defaultValue",
+                  "value" : "toto"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : true,
+              "onNewNode" : true,
+              "schedule" : {
+                "type" : "scheduled",
+                "duration" : 70
+              }
+            },
+            "updateTimeout" : 299,
+            "enabled" : true
+          }
+        ]
+      }
+    }
+---
+description: Get updated data source
+method: GET
+url: /api/latest/datasources
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getAllDataSources",
+      "result" : "success",
+      "data" : {
+        "datasources" : [
+          {
+            "name" : "",
+            "id" : "datasource1",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [],
+                "params" : [],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "delete"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          },
+          {
+            "name" : "d2",
+            "id" : "datasource2",
+            "description" : "new description",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "http://new.url.com",
+                "headers" : [
+                  {
+                    "name" : "header 1",
+                    "value" : "new value 1"
+                  },
+                  {
+                    "name" : "new header 2",
+                    "value" : "new value 2"
+                  }
+                ],
+                "params" : [
+                  {
+                    "name" : "new param 2",
+                    "value" : "new value 2"
+                  }
+                ],
+                "path" : "/new/path",
+                "checkSsl" : true,
+                "maxParallelReq" : 11,
+                "requestTimeout" : 301,
+                "requestMethod" : "POST",
+                "requestMode" : {
+                  "name" : "allNodes",
+                  "path" : "/some/path",
+                  "attribute" : "someAttribute"
+                },
+                "onMissing" : {
+                  "name" : "defaultValue",
+                  "value" : "toto"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : true,
+              "onNewNode" : true,
+              "schedule" : {
+                "type" : "scheduled",
+                "duration" : 70
+              }
+            },
+            "updateTimeout" : 299,
+            "enabled" : true
+          },
+          {
+            "name" : "",
+            "id" : "datasource3",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [],
+                "params" : [],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "delete"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          }
+        ]
+      }
+    }
+---
+description: Delete given datasource
+method: DELETE
+url: /api/latest/datasources/datasource2
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "deleteDataSource",
+      "result" : "success",
+      "data" : {
+        "datasources" : [
+          {
+            "id" : "datasource2",
+            "message" : "Data source datasource2 deleted"
+          }
+        ]
+      }
+    }
+---
+description: Get list of all data sources after deletion
+method: GET
+url: /api/latest/datasources
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getAllDataSources",
+      "result" : "success",
+      "data" : {
+        "datasources" : [
+          {
+            "name" : "",
+            "id" : "datasource1",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [],
+                "params" : [],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "delete"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          },
+          {
+            "name" : "",
+            "id" : "datasource3",
+            "description" : "",
+            "type" : {
+              "name" : "HTTP",
+              "parameters" : {
+                "url" : "",
+                "headers" : [],
+                "params" : [],
+                "path" : "",
+                "checkSsl" : false,
+                "maxParallelReq" : 10,
+                "requestTimeout" : 300,
+                "requestMethod" : "GET",
+                "requestMode" : {
+                  "name" : "byNode"
+                },
+                "onMissing" : {
+                  "name" : "delete"
+                }
+              }
+            },
+            "runParameters" : {
+              "onGeneration" : false,
+              "onNewNode" : false,
+              "schedule" : {
+                "type" : "notscheduled",
+                "duration" : 300
+              }
+            },
+            "updateTimeout" : 300,
+            "enabled" : false
+          }
+        ]
+      }
+    }
+---
+description: Reload all datasources for all nodes
+method: POST
+url: /api/latest/datasources/reload/node
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "reloadAllDatasourcesAllNodes",
+      "result" : "success",
+      "data" : "Data for all nodes, for all configured data sources are going to be updated"
+    }
+---
+description: Reload all datasources for the given node
+method: POST
+url: /api/latest/datasources/reload/node/node1
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "reloadAllDatasourcesOneNode",
+      "result" : "success",
+      "data" : "Data for node 'node1', for all configured data sources, is going to be updated"
+    }
+---
+description: Reload this given datasources for all nodes
+method: POST
+url: /api/latest/datasources/reload/datasource1
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "reloadOneDatasourceAllNodes",
+      "result" : "success",
+      "data" : "Data for all nodes, for data source 'datasource1', are going to be updated"
+    }
+---
+description: Reload the given datasource for the given node
+method: POST
+url: /api/latest/datasources/reload/datasource1/node/node1
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "reloadOneDatasourceOneNode",
+      "result" : "success",
+      "data" : "Data for node 'node1', for data source 'datasource1', is going to be updated"
+    }
+---
+description: Clear node property values on all nodes for given datasource
+method: POST
+url: /api/latest/datasources/clear/datasource1
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "clearValueOneDatasourceAllNodes",
+      "result" : "success",
+      "data" : "Data for all nodes, for data source 'datasource1', cleared"
+    }
+---
+description: Clear node property value set by given datasource on given node
+method: POST
+url: /api/latest/datasources/clear/datasource1/node/node1
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "clearValueOneDatasourceOneNode",
+      "result" : "success",
+      "data" : "Data for node 'node1', for data source 'datasource1', cleared"
+    }

--- a/datasources/src/test/scala/com/normation/plugins/datasources/RepositoryTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/RepositoryTest.scala
@@ -1,0 +1,127 @@
+package com.normation.plugins.datasources
+
+import cats.effect
+import cats.syntax.apply._
+import com.normation.errors.Inconsistency
+import com.normation.rudder.db.DBCommon
+import com.normation.zio.UnsafeRun
+import doobie.Transactor
+import doobie.implicits._
+import doobie.specs2.analysisspec.IOChecker
+import doobie.util.query.Query0
+import doobie.util.update.Update0
+import io.scalaland.chimney.syntax._
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import zio._
+import zio.interop.catz._
+
+@RunWith(classOf[JUnitRunner])
+class RepositoryTest extends Specification with DBCommon with IOChecker {
+  sequential
+
+  override def transactor: Transactor[effect.IO] = doobie.xaio
+
+  override def initDb(): Unit = {
+    // get the resource DDL definition which consist of an function definition and a function call
+    val is      = this.getClass().getClassLoader().getResourceAsStream("datasources-schema.sql")
+    val sqlText = scala.io.Source
+      .fromInputStream(is)
+      .getLines()
+      .toSeq
+      .filterNot { line =>
+        val s = line.trim(); s.isEmpty || s.startsWith("/*") || s.startsWith("*")
+      }
+      .map(s => {
+        s
+          // using toLowerCase is safer, it will always replace create table by a temp one,
+          // but it also mean that we will not know when we won't be strict with ourselves
+          .toLowerCase
+          .replaceAll("create table", "create temp table")
+          .replaceAll("create sequence", "create temp sequence")
+          .replaceAll("alter database rudder", "alter database test")
+      })
+      .mkString("\n")
+    is.close()
+
+    // function declaration is an 'update' operation and function call is a 'select' one
+    val (update, select) = sqlText.splitAt(sqlText.indexOf("select create_datasources()"))
+
+    doobie.transactRunEither(xa => (Update0(update, None).run <* Query0(select).option).transact(xa)) match {
+      case Right(_) => ()
+      case Left(ex) => throw ex
+    }
+  }
+
+  lazy val repo = new DataSourceJdbcRepository(doobie)
+
+  val httpDatasourceTemplate = DataSourceType.HTTP(
+    "CHANGE MY URL",
+    Map(),
+    HttpMethod.GET,
+    Map(),
+    true,
+    "CHANGE MY PATH",
+    DataSourceType.HTTP.defaultMaxParallelRequest,
+    HttpRequestMode.OneRequestByNode,
+    30.second,
+    MissingNodeBehavior.Delete
+  )
+  val fakeDataSource         = DataSource(
+    DataSourceId("test-my-datasource"),
+    DataSourceName("test-my-datasource"),
+    httpDatasourceTemplate,
+    DataSourceRunParameters(
+      DataSourceSchedule.Scheduled(300.seconds),
+      true,
+      true
+    ),
+    "a test datasource to test datasources",
+    true,
+    5.minutes
+  )
+  val compactExpectedJson    =
+    """{"name":"test-my-datasource","id":"test-my-datasource","description":"a test datasource to test datasources","type":{"name":"HTTP","parameters":{"url":"CHANGE MY URL","headers":[],"params":[],"path":"CHANGE MY PATH","checkSsl":true,"maxParallelReq":10,"requestTimeout":30,"requestMethod":"GET","requestMode":{"name":"byNode"},"onMissing":{"name":"delete"}}},"runParameters":{"onGeneration":true,"onNewNode":true,"schedule":{"type":"scheduled","duration":300}},"updateTimeout":300,"enabled":true}"""
+
+  "DataSourceRepository" should {
+
+    "type-check queries" in {
+      check(DataSourceJdbcRepository.insertDataSourceSQL(fakeDataSource.id, fakeDataSource.transformInto[FullDataSource]))
+      check(DataSourceJdbcRepository.updateDataSourceSQL(fakeDataSource.id, fakeDataSource.transformInto[FullDataSource]))
+      check(DataSourceJdbcRepository.getAllSQL)
+      check(DataSourceJdbcRepository.getIdsSQL)
+      check(DataSourceJdbcRepository.getSQL(fakeDataSource.id))
+    }
+
+    "insert datasource" in {
+      repo.save(fakeDataSource).runNow must beEqualTo(fakeDataSource)
+    }
+
+    "get inserted datasource" in {
+      repo.get(fakeDataSource.id).runNow must beSome(fakeDataSource)
+    }
+
+    "have a compact json properties stored" in {
+      doobie.transactRunEither(
+        sql"""select properties from datasources where id=${fakeDataSource.id}""".query[String].unique.transact(_)
+      ) must beRight(compactExpectedJson)
+    }
+
+    "update datasource" in {
+      val updated = fakeDataSource.copy(
+        name = DataSourceName("test-my-datasource-updated"),
+        description = "updated description"
+      )
+      repo.save(updated).runNow must beEqualTo(updated)
+    }
+
+    "not save datasource with a reserved id" in {
+      val reservedId  = DataSource.reservedIds.keys.head
+      val reservedMsg = DataSource.reservedIds(reservedId)
+      repo.save(fakeDataSource.copy(id = reservedId)).either.runNow must beLeft(
+        Inconsistency(s"You can't use the reserved data sources id '${reservedId.value}': ${reservedMsg}")
+      )
+    }
+  }
+}

--- a/datasources/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala
@@ -441,13 +441,6 @@ class UpdateHttpDatasetTest extends Specification with BoxSpecMatcher with Logga
     def toScala = scala.concurrent.duration.FiniteDuration(d.toMillis, "millis")
   }
 
-  // utility to compact render a json string
-  // will throws exceptions if errors
-  def compact(json: String): String = {
-    import net.liftweb.json._
-    compactRender(parse(json))
-  }
-
   implicit class RunNowTimeout[A](effect: ZIO[Annotations with zio.test.Live, RudderError, A]) {
     def runTimeout(d: Duration) =
       effect.timeout(d).notOptional(s"The test timed-out after ${d}").provideLayer(zio.test.testEnvironment).runNow


### PR DESCRIPTION
https://issues.rudder.io/issues/23805

There are two different use cases of deserialization in the plugin, that were in the `OptionalJson` and `CompleteJson`  extractors : 
 * the _complete_ one for representing a whole datasource properties object with **all fields mandatory**
 * the _optional_ one for representing a subset of them, so with **all fields optional** 

We needed to add case classes with **full** representation of a datasource, and derive json codecs accordingly so that the migration keeps the json format and validation constraints.
The previously named "wrappers" classes, with optional fields has been renamed to **patch** classes, as they are used to update a datasource (patch is the operation name as defined by _chimney_ for that use case). These "patch" classes have the same field names as the "full" classes, the types are only wrapped in `Option[_]`.

Added postgresql tests along the way, and rewrote the existing API tests to the yaml format

