### PR TITLE
Fixes #23831: Migrate change request API in change-validation to zio-json

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,8 @@
+# False positive on uuids
+[default]
+extend-ignore-re = [
+    "[0-9a-fA-F]{8}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{12}"
+]
 [default.extend-words]
 monitord = "monitord"
 Ser = "Ser"

--- a/change-validation/pom-template.xml
+++ b/change-validation/pom-template.xml
@@ -69,8 +69,8 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/change-validation/src/main/scala/bootstrap/rudder/plugin/ChangeValidationConf.scala
+++ b/change-validation/src/main/scala/bootstrap/rudder/plugin/ChangeValidationConf.scala
@@ -40,9 +40,6 @@ package bootstrap.rudder.plugin
 import bootstrap.liftweb.RudderConfig
 import bootstrap.liftweb.RudderConfig.commitAndDeployChangeRequest
 import bootstrap.liftweb.RudderConfig.doobie
-import bootstrap.liftweb.RudderConfig.restDataSerializer
-import bootstrap.liftweb.RudderConfig.restExtractorService
-import bootstrap.liftweb.RudderConfig.techniqueRepository
 import bootstrap.liftweb.RudderConfig.workflowLevelService
 import com.normation.box._
 import com.normation.eventlog.EventActor
@@ -53,7 +50,7 @@ import com.normation.plugins.changevalidation.ChangeValidationPluginDef
 import com.normation.plugins.changevalidation.CheckRudderPluginEnableImpl
 import com.normation.plugins.changevalidation.EmailNotificationService
 import com.normation.plugins.changevalidation.NodeGroupValidationNeeded
-import com.normation.plugins.changevalidation.NotificationService
+import com.normation.plugins.changevalidation.NotificationServiceImpl
 import com.normation.plugins.changevalidation.RoChangeRequestJdbcRepository
 import com.normation.plugins.changevalidation.RoChangeRequestRepository
 import com.normation.plugins.changevalidation.RoValidatedUserJdbcRepository
@@ -221,7 +218,7 @@ object ChangeValidationConf extends RudderPluginModule {
 
   lazy val fileUserDetailListProvider = RudderConfig.rudderUserListProvider
 
-  lazy val notificationService = new NotificationService(
+  lazy val notificationService = new NotificationServiceImpl(
     new EmailNotificationService(),
     RudderConfig.linkUtil,
     "/opt/rudder/etc/plugins/change-validation.conf"
@@ -243,6 +240,7 @@ object ChangeValidationConf extends RudderPluginModule {
     roChangeRequestRepository,
     woChangeRequestRepository,
     notificationService,
+    RudderConfig.userService,
     () => Full(RudderConfig.workflowLevelService.workflowEnabled),
     () => RudderConfig.configService.rudder_workflow_self_validation().toBox,
     () => RudderConfig.configService.rudder_workflow_self_deployment().toBox
@@ -305,15 +303,15 @@ object ChangeValidationConf extends RudderPluginModule {
       RudderConfig.roNodeGroupRepository
     )
     val api2 = new ChangeRequestApiImpl(
-      restExtractorService,
+      RudderConfig.diffService,
+      RudderConfig.techniqueRepository,
       roChangeRequestRepository,
       woChangeRequestRepository,
       roWorkflowRepository,
-      woWorkflowRepository,
-      techniqueRepository,
       workflowLevelService,
       commitAndDeployChangeRequest,
-      restDataSerializer
+      RudderConfig.userPropertyService,
+      RudderConfig.userService
     )
     val api3 = new ValidatedUserApiImpl(
       roValidatedUserRepository,

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeRequestJson.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeRequestJson.scala
@@ -1,0 +1,961 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.plugins.changevalidation
+
+import cats.data.NonEmptyList
+import com.normation.cfclerk.domain.SectionSpec
+import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.domain.TechniqueVersion
+import com.normation.errors._
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.apidata.JsonResponseObjects._
+import com.normation.rudder.apidata.implicits._
+import com.normation.rudder.domain.nodes.AddNodeGroupDiff
+import com.normation.rudder.domain.nodes.ChangeRequestNodeGroupDiff
+import com.normation.rudder.domain.nodes.DeleteNodeGroupDiff
+import com.normation.rudder.domain.nodes.ModifyNodeGroupDiff
+import com.normation.rudder.domain.nodes.ModifyToNodeGroupDiff
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.policies.AddDirectiveDiff
+import com.normation.rudder.domain.policies.AddRuleDiff
+import com.normation.rudder.domain.policies.ChangeRequestDirectiveDiff
+import com.normation.rudder.domain.policies.ChangeRequestRuleDiff
+import com.normation.rudder.domain.policies.DeleteDirectiveDiff
+import com.normation.rudder.domain.policies.DeleteRuleDiff
+import com.normation.rudder.domain.policies.Directive
+import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.GroupTarget
+import com.normation.rudder.domain.policies.ModifyDirectiveDiff
+import com.normation.rudder.domain.policies.ModifyRuleDiff
+import com.normation.rudder.domain.policies.ModifyToDirectiveDiff
+import com.normation.rudder.domain.policies.ModifyToRuleDiff
+import com.normation.rudder.domain.policies.Rule
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.domain.policies.SectionVal
+import com.normation.rudder.domain.policies.SimpleDiff
+import com.normation.rudder.domain.properties.AddGlobalParameterDiff
+import com.normation.rudder.domain.properties.ChangeRequestGlobalParameterDiff
+import com.normation.rudder.domain.properties.DeleteGlobalParameterDiff
+import com.normation.rudder.domain.properties.GenericProperty
+import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.domain.properties.GroupProperty
+import com.normation.rudder.domain.properties.InheritMode
+import com.normation.rudder.domain.properties.ModifyGlobalParameterDiff
+import com.normation.rudder.domain.properties.ModifyToGlobalParameterDiff
+import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.domain.workflows.ChangeRequest
+import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.domain.workflows.ConfigurationChangeRequest
+import com.normation.rudder.domain.workflows.DirectiveChange
+import com.normation.rudder.domain.workflows.DirectiveChanges
+import com.normation.rudder.domain.workflows.GlobalParameterChange
+import com.normation.rudder.domain.workflows.GlobalParameterChanges
+import com.normation.rudder.domain.workflows.NodeGroupChange
+import com.normation.rudder.domain.workflows.NodeGroupChanges
+import com.normation.rudder.domain.workflows.RuleChange
+import com.normation.rudder.domain.workflows.RuleChanges
+import com.normation.rudder.domain.workflows.WorkflowNodeId
+import com.normation.rudder.services.modification.DiffService
+import com.typesafe.config.ConfigValue
+import io.scalaland.chimney.PartialTransformer
+import io.scalaland.chimney.Transformer
+import io.scalaland.chimney.partial.Result
+import io.scalaland.chimney.syntax._
+import net.liftweb.common.Empty
+import net.liftweb.common.Failure
+import net.liftweb.common.Full
+import scala.util.Try
+import zio.Chunk
+import zio.NonEmptyChunk
+import zio.json._
+import zio.json.internal.Write
+
+sealed trait SimpleDiffOrValueJson[T] {
+  def map[U](f: T => U): SimpleDiffOrValueJson[U]
+}
+final case class SimpleDiffJson[T](
+    @jsonField("from") oldValue: T,
+    @jsonField("to") newValue:   T
+) extends SimpleDiffOrValueJson[T] {
+  def map[U](f: T => U): SimpleDiffJson[U] = SimpleDiffJson(f(oldValue), f(newValue))
+}
+final case class SimpleValueJson[T](value: T) extends SimpleDiffOrValueJson[T] {
+  def map[U](f: T => U): SimpleValueJson[U] = SimpleValueJson(f(value))
+}
+
+object SimpleDiffOrValueJson {
+  implicit def diffTransformer[T]:                 Transformer[SimpleDiff[T], SimpleDiffJson[T]] =
+    Transformer.derive[SimpleDiff[T], SimpleDiffJson[T]]
+  implicit def simpleValueEncoder[T: JsonEncoder]: JsonEncoder[SimpleValueJson[T]]               =
+    JsonEncoder[T].contramap[SimpleValueJson[T]](_.value)
+  implicit def simpleDiffEncoder[T: JsonEncoder]:  JsonEncoder[SimpleDiffJson[T]]                = DeriveJsonEncoder.gen[SimpleDiffJson[T]]
+
+  // An encoder for both {from, to} json object and raw value json. This is a way to encode both different types of json
+  implicit def encoder[T: JsonEncoder]: JsonEncoder[SimpleDiffOrValueJson[T]] = new JsonEncoder[SimpleDiffOrValueJson[T]] {
+    override def unsafeEncode(a: SimpleDiffOrValueJson[T], indent: Option[Int], out: Write): Unit = {
+      a match {
+        case SimpleDiffJson(from, to) => simpleDiffEncoder[T].unsafeEncode(SimpleDiffJson(from, to), indent, out)
+        case SimpleValueJson(value)   => simpleValueEncoder[T].unsafeEncode(SimpleValueJson(value), indent, out)
+      }
+    }
+  }
+
+  def withDefault[T](diff: Option[SimpleDiff[T]], defaultValue: T): SimpleDiffOrValueJson[T] = {
+    diff match {
+      case Some(SimpleDiff(from, to)) => SimpleDiffJson(from, to)
+      case None                       => SimpleValueJson(defaultValue)
+    }
+  }
+}
+
+final case class ChangeRequestJson(
+    id:                                 ChangeRequestId,
+    displayName:                        String,
+    status:                             WorkflowNodeId,
+    @jsonField("created by") createdBy: String,
+    acceptable:                         Boolean,
+    description:                        String,
+    changes:                            Option[ConfigurationChangeRequestJson]
+)
+
+object ChangeRequestJson {
+  implicit val idEncoder:     JsonEncoder[ChangeRequestId]   = JsonEncoder[Int].contramap[ChangeRequestId](_.value)
+  implicit val statusEncoder: JsonEncoder[WorkflowNodeId]    = JsonEncoder[String].contramap[WorkflowNodeId](_.value)
+  implicit val encoder:       JsonEncoder[ChangeRequestJson] = DeriveJsonEncoder.gen[ChangeRequestJson]
+
+  implicit def transformErrorsToRudderError: Transformer[Result.Errors, RudderError] = {
+    case Result.Errors(errors) =>
+      Accumulated(
+        NonEmptyList
+          .fromListUnsafe(errors.toList) // This is safe because errors is non-empty
+          .map(e => Inconsistency(s"Error while serializing change request at ${e.path.asString} : ${e.message.asString}"))
+      )
+  }
+
+  // Entrypoint to convert the whole tree of ChangeRequest + some context to a serializable object ChangeRequestJson
+  def from(cr:              ChangeRequest, status: WorkflowNodeId, isAcceptable: Boolean)(implicit
+      techniqueByDirective: Map[DirectiveId, Technique],
+      diffService:          DiffService
+  ): PureResult[ChangeRequestJson] = {
+    val changesJson: PureResult[Option[ConfigurationChangeRequestJson]] = cr match {
+      case cr: ConfigurationChangeRequest => {
+        cr.transformIntoPartial[ConfigurationChangeRequestJson].map(Some(_)).asEither.left.map(_.transformInto[RudderError])
+      }
+      case _ => Right(None)
+    }
+
+    changesJson.map(
+      ChangeRequestJson(
+        cr.id,
+        cr.info.name,
+        status,
+        cr.owner,
+        isAcceptable,
+        cr.info.description,
+        _
+      )
+    )
+  }
+}
+
+@jsonDiscriminator("action") sealed trait ActionChangeJson {
+  def name: String = this match {
+    case ActionChangeJson.create => "create"
+    case ActionChangeJson.modify => "modify"
+    case ActionChangeJson.delete => "delete"
+  }
+}
+object ActionChangeJson                                    {
+  case object create extends ActionChangeJson
+  case object modify extends ActionChangeJson
+  case object delete extends ActionChangeJson
+
+  implicit val encoder: JsonEncoder[ActionChangeJson] = JsonEncoder[String].contramap[ActionChangeJson](_.name)
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// DIRECTIVES
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// The discriminator is not needed for serialization so we leave hints as case class names
+@jsonDiscriminator("type") sealed trait DirectiveChangeJson
+object DirectiveChangeJson {
+
+  final case class DirectiveCreateChangeJson(
+      change: JRDirective
+  ) extends DirectiveChangeJson
+
+  final case class DirectiveDeleteChangeJson(
+      change: JRDirective
+  ) extends DirectiveChangeJson
+
+  final case class DirectiveModifyChangeJson(
+      change: ModifyDirectiveJson
+  ) extends DirectiveChangeJson
+
+  final case class SectionValJson(
+      section: SectionValContentJson
+  )
+  final case class SectionValContentJson(
+      name:     String = SectionVal.ROOT_SECTION_NAME,
+      vars:     Option[NonEmptyChunk[SectionVarJson]],
+      sections: Option[NonEmptyChunk[SectionValContentJson]]
+  )
+  object SectionValContentJson {
+    implicit val sectionNameValueEncoder: JsonEncoder[SectionNameValueJson]  = DeriveJsonEncoder.gen[SectionNameValueJson]
+    implicit val sectionVarEncoder:       JsonEncoder[SectionVarJson]        = DeriveJsonEncoder.gen[SectionVarJson]
+    implicit lazy val encoder:            JsonEncoder[SectionValContentJson] = DeriveJsonEncoder.gen[SectionValContentJson]
+  }
+  final case class SectionVarJson(
+      `var`: SectionNameValueJson
+  )
+  final case class SectionNameValueJson(
+      name:  String,
+      value: String
+  )
+
+  object SectionValJson {
+    implicit val transformer: Transformer[SectionVal, SectionValJson] = sv => {
+      def serializeSectionVal(sv: SectionVal, sectionName: String = SectionVal.ROOT_SECTION_NAME): SectionValContentJson = {
+        val variables = {
+          sv.variables.toSeq.sortBy(_._1).map {
+            case (variable, value) =>
+              SectionVarJson(SectionNameValueJson(variable, value))
+          }
+        }
+        val sections  = {
+          sv.sections.toSeq.sortBy(_._1).flatMap {
+            case (sectionName, sectionIterations) =>
+              sectionIterations.map(sectionValue => serializeSectionVal(sectionValue, sectionName))
+          }
+        }
+        SectionValContentJson(
+          sectionName,
+          NonEmptyChunk.fromIterableOption(variables),
+          NonEmptyChunk.fromIterableOption(sections)
+        )
+      }
+      SectionValJson(serializeSectionVal(sv))
+    }
+
+    implicit val encoder: JsonEncoder[SectionValJson] = DeriveJsonEncoder.gen[SectionValJson]
+  }
+
+  final case class ModifyDirectiveJson(
+      id:                                                 DirectiveId,
+      @jsonField("displayName") modName:                  SimpleDiffOrValueJson[String],
+      @jsonField("shortDescription") modShortDescription: SimpleDiffOrValueJson[String],
+      @jsonField("longDescription") modLongDescription:   SimpleDiffOrValueJson[String],
+      techniqueName:                                      TechniqueName,
+      @jsonField("techniqueVersion") modTechniqueVersion: SimpleDiffOrValueJson[TechniqueVersion],
+      @jsonField("parameters") modParameters:             SimpleDiffOrValueJson[SectionValJson],
+      @jsonField("priority") modPriority:                 SimpleDiffOrValueJson[Int],
+      @jsonField("enabled") modIsActivated:               SimpleDiffOrValueJson[Boolean],
+      system:                                             Boolean
+  )
+
+  object ModifyDirectiveJson {
+    // encoders in this nested scope need to be lazy
+    implicit lazy val directiveIdEncoder:      JsonEncoder[DirectiveId]         = JsonEncoder[String].contramap[DirectiveId](_.serialize)
+    implicit lazy val techniqueNameEncoder:    JsonEncoder[TechniqueName]       = JsonEncoder[String].contramap[TechniqueName](_.value)
+    implicit lazy val techniqueVersionEncoder: JsonEncoder[TechniqueVersion]    =
+      JsonEncoder[String].contramap[TechniqueVersion](_.serialize)
+    implicit lazy val encoder:                 JsonEncoder[ModifyDirectiveJson] =
+      DeriveJsonEncoder.gen[ModifyDirectiveJson]
+
+    def from(
+        diff:               ModifyDirectiveDiff,
+        initialState:       Directive,
+        technique:          Technique,
+        initialRootSection: SectionSpec
+    ): Either[String, ModifyDirectiveJson] = {
+      import io.scalaland.chimney.dsl._
+      // This is in a try/catch because directiveValToSectionVal may fail
+      Try(
+        ModifyDirectiveJson(
+          initialState.id,
+          SimpleDiffOrValueJson.withDefault(diff.modName, initialState.name),
+          SimpleDiffOrValueJson.withDefault(diff.modShortDescription, initialState.shortDescription),
+          SimpleDiffOrValueJson.withDefault(diff.modLongDescription, initialState.longDescription),
+          technique.id.name,
+          SimpleDiffOrValueJson.withDefault(diff.modTechniqueVersion, initialState.techniqueVersion),
+          SimpleDiffOrValueJson
+            .withDefault(
+              diff.modParameters.map(_.transformInto[SimpleDiff[SectionValJson]]),
+              SectionVal
+                .directiveValToSectionVal(initialRootSection, initialState.parameters)
+                .transformInto[SectionValJson]
+            ),
+          SimpleDiffOrValueJson.withDefault(diff.modPriority, initialState.priority),
+          SimpleDiffOrValueJson.withDefault(diff.modIsActivated, initialState.isEnabled),
+          initialState.isSystem
+        )
+      ).toEither.left.map(e => s"Error in directive sections : ${e.getMessage}")
+    }
+  }
+
+  implicit def createTransformer(implicit
+      technique: Technique
+  ): Transformer[AddDirectiveDiff, DirectiveCreateChangeJson] = {
+    case AddDirectiveDiff(techniqueName, directive) =>
+      DirectiveCreateChangeJson(JRDirective.fromDirective(technique, directive, None))
+  }
+
+  implicit def deleteTransformer(implicit
+      technique: Technique
+  ): Transformer[DeleteDirectiveDiff, DirectiveDeleteChangeJson] = {
+    case DeleteDirectiveDiff(_, directive) =>
+      DirectiveDeleteChangeJson(JRDirective.fromDirective(technique, directive, None))
+  }
+
+  // Technique is needed to put default values when there is no diff in any given directive field
+  // This return an error result when no technique is passed
+  implicit def modifyTransformer(implicit
+      change:      DirectiveChange,
+      technique:   Technique,
+      diffService: DiffService
+  ): PartialTransformer[ModifyToDirectiveDiff, DirectiveModifyChangeJson] = {
+    case (ModifyToDirectiveDiff(techniqueName, directive, rootSection), _) =>
+      val result = change.initialState match {
+        case Some((techniqueName, initialState, section @ Some(initialRootSection))) =>
+          val diff = diffService.diffDirective(initialState, section, directive, rootSection, techniqueName)
+
+          ModifyDirectiveJson
+            .from(diff, initialState, technique, initialRootSection)
+            .map(DirectiveModifyChangeJson(_))
+
+        case _ => Left(s"Error while fetching initial state of change request.")
+      }
+
+      Result.fromEitherString(result)
+  }
+
+  implicit def transformDirectiveDiff(implicit
+      change:      DirectiveChange,
+      technique:   Technique,
+      diffService: DiffService
+  ): PartialTransformer[ChangeRequestDirectiveDiff, DirectiveChangeJson] = {
+    PartialTransformer
+      .define[ChangeRequestDirectiveDiff, DirectiveChangeJson]
+      .withCoproductInstance[AddDirectiveDiff](_.transformInto[DirectiveCreateChangeJson])
+      .withCoproductInstance[DeleteDirectiveDiff](_.transformInto[DirectiveDeleteChangeJson])
+      .withCoproductInstancePartial[ModifyToDirectiveDiff](_.transformIntoPartial[DirectiveModifyChangeJson])
+      .buildTransformer
+  }
+
+  // We need to remove the wrapping when serializing to directly serialize the directive or directive diff
+  implicit val createEncoder: JsonEncoder[DirectiveCreateChangeJson] =
+    JsonEncoder[JRDirective].contramap[DirectiveCreateChangeJson](_.change)
+  implicit val deleteEncoder: JsonEncoder[DirectiveDeleteChangeJson] =
+    JsonEncoder[JRDirective].contramap[DirectiveDeleteChangeJson](_.change)
+  implicit val modifyEncoder: JsonEncoder[DirectiveModifyChangeJson] =
+    JsonEncoder[ModifyDirectiveJson].contramap[DirectiveModifyChangeJson](_.change)
+  implicit val encoder:       JsonEncoder[DirectiveChangeJson]       = DeriveJsonEncoder.gen[DirectiveChangeJson]
+
+}
+
+final case class DirectiveChangeActionJson(
+    action: ActionChangeJson,
+    change: DirectiveChangeJson
+)
+object DirectiveChangeActionJson {
+  import DirectiveChangeJson._
+
+  implicit def transformer(implicit
+      technique:   Technique,
+      diffService: DiffService
+  ): PartialTransformer[DirectiveChange, DirectiveChangeActionJson] = {
+    case (source, _) =>
+      implicit val change = source
+      source.change
+        .map(_.diff)
+        .map(_.transformIntoPartial[DirectiveChangeJson].map {
+          case d: DirectiveCreateChangeJson => DirectiveChangeActionJson(ActionChangeJson.create, d)
+          case d: DirectiveDeleteChangeJson => DirectiveChangeActionJson(ActionChangeJson.delete, d)
+          case d: DirectiveModifyChangeJson => DirectiveChangeActionJson(ActionChangeJson.modify, d)
+        }) match {
+        case Empty                          =>
+          Result.fromErrorString(s"Error while serializing directives from CR ${change.firstChange.diff.directive.id.serialize}")
+        case Failure(msg, exception, chain) => Result.fromErrorString(msg)
+        case Full(value)                    => value
+      }
+  }
+
+  implicit val encoder: JsonEncoder[DirectiveChangeActionJson] = DeriveJsonEncoder.gen[DirectiveChangeActionJson]
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// RULES
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@jsonDiscriminator("type") sealed trait RuleChangeJson
+object RuleChangeJson {
+
+  final case class RuleCreateChangeJson(
+      rule: JRRule
+  ) extends RuleChangeJson
+
+  final case class RuleDeleteChangeJson(
+      rule: JRRule
+  ) extends RuleChangeJson
+
+  final case class RuleModifyChangeJson(
+      change: ModifyRuleJson
+  ) extends RuleChangeJson
+
+  final case class ModifyRuleJson(
+      id:                                                 RuleId,
+      @jsonField("displayName") modName:                  SimpleDiffOrValueJson[String],
+      @jsonField("shortDescription") modShortDescription: SimpleDiffOrValueJson[String],
+      @jsonField("longDescription") modLongDescription:   SimpleDiffOrValueJson[String],
+      @jsonField("directives") modDirectiveIds:           SimpleDiffOrValueJson[Set[DirectiveId]],
+      @jsonField("targets") modTarget:                    SimpleDiffOrValueJson[Set[RuleTarget]],
+      @jsonField("enabled") modIsActivatedStatus:         SimpleDiffOrValueJson[Boolean]
+  )
+
+  object ModifyRuleJson {
+    implicit lazy val ruleIdEncoder:      JsonEncoder[RuleId]         = JsonEncoder[String].contramap[RuleId](_.serialize)
+    implicit lazy val directiveIdEncoder: JsonEncoder[DirectiveId]    = JsonEncoder[String].contramap[DirectiveId](_.serialize)
+    implicit lazy val ruleTargetEncoder:  JsonEncoder[RuleTarget]     = JsonEncoder[String].contramap[RuleTarget](_.target)
+    implicit lazy val encoder:            JsonEncoder[ModifyRuleJson] =
+      DeriveJsonEncoder.gen[ModifyRuleJson]
+
+    def from(
+        modifyRuleDiff: ModifyRuleDiff,
+        initialState:   Rule
+    ): ModifyRuleJson = {
+      ModifyRuleJson(
+        modifyRuleDiff.id,
+        SimpleDiffOrValueJson.withDefault(modifyRuleDiff.modName, initialState.name),
+        SimpleDiffOrValueJson.withDefault(modifyRuleDiff.modShortDescription, initialState.shortDescription),
+        SimpleDiffOrValueJson.withDefault(modifyRuleDiff.modLongDescription, initialState.longDescription),
+        SimpleDiffOrValueJson.withDefault(modifyRuleDiff.modDirectiveIds, initialState.directiveIds),
+        SimpleDiffOrValueJson.withDefault(modifyRuleDiff.modTarget, initialState.targets),
+        SimpleDiffOrValueJson.withDefault(modifyRuleDiff.modIsActivatedStatus, initialState.isEnabledStatus)
+      )
+    }
+  }
+  implicit val jrRuleTransformer: Transformer[Rule, JRRule] = Transformer
+    .define[Rule, JRRule]
+    .enableBeanGetters
+    .withFieldComputed(_.id, _.id.serialize)
+    .withFieldRenamed(_.name, _.displayName)
+    .withFieldComputed(_.categoryId, _.categoryId.value)
+    .withFieldComputed(_.directives, _.directiveIds.map(_.serialize).toList.sorted)
+    .withFieldComputed(_.targets, _.targets.toList.sortBy(_.target).map(t => JRRuleTarget(t)))
+    .withFieldRenamed(_.isEnabledStatus, _.enabled)
+    .withFieldComputed(_.tags, x => JRTags.fromTags(x.tags))
+    .withFieldConst(_.policyMode, None)      // not needed
+    .withFieldConst(_.status, None)          // not needed
+    .withFieldConst(_.changeRequestId, None) // not needed
+    .buildTransformer
+  implicit val createTransformer: Transformer[AddRuleDiff, RuleCreateChangeJson]    =
+    Transformer.derive[AddRuleDiff, RuleCreateChangeJson]
+  implicit val deleteTransformer: Transformer[DeleteRuleDiff, RuleDeleteChangeJson] =
+    Transformer.derive[DeleteRuleDiff, RuleDeleteChangeJson]
+  implicit def modifyTransformer(implicit
+      change:      RuleChange,
+      diffService: DiffService
+  ): PartialTransformer[ModifyToRuleDiff, RuleModifyChangeJson] = {
+    case (ModifyToRuleDiff(rule), _) =>
+      val result = change.initialState match {
+        case Some(init) =>
+          val diff = diffService.diffRule(init, rule)
+          Right(RuleModifyChangeJson(ModifyRuleJson.from(diff, init)))
+        case _          => Left(s"Error while fetching initial state of change request.")
+      }
+      Result.fromEitherString(result)
+  }
+
+  implicit def transformer(implicit
+      change:      RuleChange,
+      diffService: DiffService
+  ): PartialTransformer[ChangeRequestRuleDiff, RuleChangeJson] = {
+    PartialTransformer
+      .define[ChangeRequestRuleDiff, RuleChangeJson]
+      .withCoproductInstance[AddRuleDiff](_.transformInto[RuleCreateChangeJson])
+      .withCoproductInstance[DeleteRuleDiff](_.transformInto[RuleDeleteChangeJson])
+      .withCoproductInstancePartial[ModifyToRuleDiff](_.transformIntoPartial[RuleModifyChangeJson])
+      .buildTransformer
+  }
+
+  implicit val createEncoder: JsonEncoder[RuleCreateChangeJson] = JsonEncoder[JRRule].contramap[RuleCreateChangeJson](_.rule)
+  implicit val deleteEncoder: JsonEncoder[RuleDeleteChangeJson] = JsonEncoder[JRRule].contramap[RuleDeleteChangeJson](_.rule)
+  implicit val modifyEncoder: JsonEncoder[RuleModifyChangeJson] =
+    JsonEncoder[ModifyRuleJson].contramap[RuleModifyChangeJson](_.change)
+  implicit val encoder:       JsonEncoder[RuleChangeJson]       = DeriveJsonEncoder.gen[RuleChangeJson]
+}
+
+final case class RuleChangeActionJson(
+    action: ActionChangeJson,
+    change: RuleChangeJson
+)
+object RuleChangeActionJson {
+  import RuleChangeJson._
+
+  implicit def transformer(implicit
+      diffService: DiffService
+  ): PartialTransformer[RuleChange, RuleChangeActionJson] = {
+    case (source, _) =>
+      implicit val change = source
+      source.change
+        .map(_.diff)
+        .map(_.transformIntoPartial[RuleChangeJson].map {
+          case d: RuleCreateChangeJson => RuleChangeActionJson(ActionChangeJson.create, d)
+          case d: RuleDeleteChangeJson => RuleChangeActionJson(ActionChangeJson.delete, d)
+          case d: RuleModifyChangeJson => RuleChangeActionJson(ActionChangeJson.modify, d)
+        }) match {
+        case Empty                          =>
+          Result.fromErrorString(s"Error while serializing rules from CR ${change.firstChange.diff.rule.id.serialize}")
+        case Failure(msg, exception, chain) => Result.fromErrorString(msg)
+        case Full(value)                    => value
+      }
+  }
+
+  implicit val encoder: JsonEncoder[RuleChangeActionJson] = DeriveJsonEncoder.gen[RuleChangeActionJson]
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// GROUPS
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@jsonDiscriminator("type") sealed trait GroupChangeJson
+object GroupChangeJson {
+
+  // Group json representation for creating or deleting a group
+  final case class GroupJson(
+      id:                               NodeGroupId,
+      @jsonField("displayName") name:   String,
+      description:                      String,
+      query:                            Option[JRQuery],
+      @jsonField("nodeIds") serverList: Set[NodeId],
+      dynamic:                          Boolean,
+      enabled:                          Boolean,
+      groupClass:                       List[String],
+      properties:                       PropertiesJson,
+      target:                           GroupTarget,
+      @jsonField("system") isSystem:    Boolean
+  )
+
+  object GroupJson {
+    implicit val nodeGroupIdEncoder: JsonEncoder[NodeGroupId] = JsonEncoder[String].contramap[NodeGroupId](_.serialize)
+    implicit val serverListEncoder:  JsonEncoder[Set[NodeId]] =
+      JsonEncoder[List[String]].contramap[Set[NodeId]](_.toList.map(_.value).sorted)
+    implicit val targetEncoder:      JsonEncoder[GroupTarget] = JsonEncoder[String].contramap[GroupTarget](_.target)
+    implicit val encoder:            JsonEncoder[GroupJson]   = DeriveJsonEncoder.gen[GroupJson]
+  }
+
+  final case class PropertiesJson( // we sort the properties by name on serialization
+      value: List[JRProperty]
+  ) extends AnyVal
+
+  object PropertiesJson      {
+    implicit val propertyTransformer: Transformer[GroupProperty, JRProperty]           = JRProperty.fromGroupProp _
+    implicit val transformer:         Transformer[List[GroupProperty], PropertiesJson] =
+      Transformer.derive[List[GroupProperty], PropertiesJson]
+
+    implicit val encoder: JsonEncoder[PropertiesJson] =
+      JsonEncoder[List[JRProperty]].contramap[PropertiesJson](_.value.sortBy(_.name))
+  }
+
+  final case class GroupCreateChangeJson(
+      group: GroupJson
+  ) extends GroupChangeJson
+
+  final case class GroupDeleteChangeJson(
+      group: GroupJson
+  ) extends GroupChangeJson
+
+  final case class GroupModifyChangeJson(
+      change: ModifyGroupJson
+  ) extends GroupChangeJson
+
+  final case class GroupPropertyJson(
+      name:        String,
+      value:       ConfigValue,
+      provider:    Option[PropertyProvider],
+      inheritMode: Option[InheritMode]
+  )
+  final case class GroupPropertiesJson(
+      value: List[GroupPropertyJson]
+  ) extends AnyVal {
+    def sorted: GroupPropertiesJson = GroupPropertiesJson(value.sortBy(_.name))
+  }
+  object GroupPropertyJson   {
+    implicit val transformer: Transformer[GroupProperty, GroupPropertyJson] = property => {
+      GroupPropertyJson( // chimney does not like this kind of inheritance
+        property.name,
+        property.value,
+        property.provider,
+        property.inheritMode
+      )
+    }
+
+    implicit val propertyProviderEncoder: JsonEncoder[PropertyProvider]  = JsonEncoder[String].contramap[PropertyProvider](_.value)
+    implicit val inheritModeEncoder:      JsonEncoder[InheritMode]       = JsonEncoder[String].contramap[InheritMode](_.value)
+    implicit val encoder:                 JsonEncoder[GroupPropertyJson] = DeriveJsonEncoder.gen[GroupPropertyJson]
+  }
+  object GroupPropertiesJson {
+    // We avoid using automatic derivation because we want to sort the properties by name so we define explicitly the transformers required elsewhere
+    implicit val transformer:               Transformer[List[GroupProperty], GroupPropertiesJson]                         =
+      Transformer.derive[List[GroupProperty], GroupPropertiesJson]
+    implicit val simpleDiffListTransformer: Transformer[SimpleDiff[List[GroupProperty]], SimpleDiff[GroupPropertiesJson]] =
+      Transformer.derive[SimpleDiff[List[GroupProperty]], SimpleDiff[GroupPropertiesJson]]
+
+    implicit val encoder: JsonEncoder[GroupPropertiesJson] = {
+      JsonEncoder[List[GroupPropertyJson]].contramap(g => g.value.sortBy(_.name))
+    }
+  }
+  final case class ModifyGroupJson(
+      id:                                       NodeGroupId,
+      @jsonField("displayName") modName:        SimpleDiffOrValueJson[String],
+      @jsonField("description") modDescription: SimpleDiffOrValueJson[String],
+      @jsonField("category") modCategory:       Option[SimpleDiffJson[NodeGroupCategoryId]], // category is optional
+      @jsonField("query") modQuery:             SimpleDiffOrValueJson[Option[Query]],
+      @jsonField("properties") modProperties:   SimpleDiffOrValueJson[GroupPropertiesJson],
+      @jsonField("nodeIds") modNodeList:        SimpleDiffOrValueJson[Set[NodeId]],
+      @jsonField("dynamic") modIsDynamic:       SimpleDiffOrValueJson[Boolean],
+      @jsonField("enabled") modIsActivated:     SimpleDiffOrValueJson[Boolean]
+  )
+
+  object ModifyGroupJson {
+    implicit lazy val nodeGroupIdEncoder:         JsonEncoder[NodeGroupId]         = JsonEncoder[String].contramap[NodeGroupId](_.serialize)
+    implicit lazy val nodeGroupCategoryIdEncoder: JsonEncoder[NodeGroupCategoryId] =
+      JsonEncoder[String].contramap[NodeGroupCategoryId](_.value)
+    implicit lazy val nodeIdEncoder:              JsonEncoder[NodeId]              = JsonEncoder[String].contramap[NodeId](_.value)
+    implicit lazy val queryEncoder:               JsonEncoder[Query]               = JsonEncoder[String].contramap[Query](_.toString)
+    implicit lazy val encoder:                    JsonEncoder[ModifyGroupJson]     =
+      DeriveJsonEncoder.gen[ModifyGroupJson]
+
+    def from(
+        modifyGroupDiff: ModifyNodeGroupDiff,
+        initialState:    NodeGroup
+    ): ModifyGroupJson = {
+      ModifyGroupJson(
+        modifyGroupDiff.id,
+        SimpleDiffOrValueJson.withDefault(modifyGroupDiff.modName, initialState.name),
+        SimpleDiffOrValueJson.withDefault(modifyGroupDiff.modDescription, initialState.description),
+        modifyGroupDiff.modCategory.map(_.transformInto[SimpleDiffJson[NodeGroupCategoryId]]),
+        SimpleDiffOrValueJson.withDefault(modifyGroupDiff.modQuery, initialState.query),
+        SimpleDiffOrValueJson.withDefault(
+          modifyGroupDiff.modProperties.map(_.transformInto[SimpleDiff[GroupPropertiesJson]]),
+          initialState.properties.transformInto[GroupPropertiesJson]
+        ),
+        SimpleDiffOrValueJson.withDefault(modifyGroupDiff.modNodeList, initialState.serverList),
+        SimpleDiffOrValueJson.withDefault(modifyGroupDiff.modIsDynamic, initialState.isDynamic),
+        SimpleDiffOrValueJson.withDefault(modifyGroupDiff.modIsActivated, initialState.isEnabled)
+      )
+    }
+  }
+
+  implicit val jrGroupTransformer: Transformer[NodeGroup, GroupJson]                       = Transformer
+    .define[NodeGroup, GroupJson]
+    .enableBeanGetters
+    .withFieldComputed(_.query, _.query.map(JRQuery.fromQuery(_)))
+    .withFieldComputed(_.groupClass, x => List(x.id.serialize, x.name).map(RuleTarget.toCFEngineClassName _).sorted)
+    .withFieldComputed(_.target, x => GroupTarget(x.id))
+    .buildTransformer
+  implicit val createTransformer:  Transformer[AddNodeGroupDiff, GroupCreateChangeJson]    =
+    Transformer.derive[AddNodeGroupDiff, GroupCreateChangeJson]
+  implicit val deleteTransformer:  Transformer[DeleteNodeGroupDiff, GroupDeleteChangeJson] =
+    Transformer.derive[DeleteNodeGroupDiff, GroupDeleteChangeJson]
+  implicit def modifyTransformer(implicit
+      change:      NodeGroupChange,
+      diffService: DiffService
+  ): PartialTransformer[ModifyToNodeGroupDiff, GroupModifyChangeJson] = {
+    case (ModifyToNodeGroupDiff(group), _) =>
+      val result = change.initialState match {
+        case Some(init) =>
+          val diff = diffService.diffNodeGroup(init, group)
+          Right(GroupModifyChangeJson(ModifyGroupJson.from(diff, init)))
+        case _          => Left(s"Error while fetching initial state of change request.")
+      }
+      Result.fromEitherString(result)
+  }
+
+  implicit def transformer(implicit
+      change:      NodeGroupChange,
+      diffService: DiffService
+  ): PartialTransformer[ChangeRequestNodeGroupDiff, GroupChangeJson] = {
+    PartialTransformer
+      .define[ChangeRequestNodeGroupDiff, GroupChangeJson]
+      .withCoproductInstance[AddNodeGroupDiff](_.transformInto[GroupCreateChangeJson])
+      .withCoproductInstance[DeleteNodeGroupDiff](_.transformInto[GroupDeleteChangeJson])
+      .withCoproductInstancePartial[ModifyToNodeGroupDiff](_.transformIntoPartial[GroupModifyChangeJson])
+      .buildTransformer
+  }
+
+  implicit val createEncoder: JsonEncoder[GroupCreateChangeJson] =
+    JsonEncoder[GroupJson].contramap[GroupCreateChangeJson](_.group)
+  implicit val deleteEncoder: JsonEncoder[GroupDeleteChangeJson] =
+    JsonEncoder[GroupJson].contramap[GroupDeleteChangeJson](_.group)
+  implicit val modifyEncoder: JsonEncoder[GroupModifyChangeJson] =
+    JsonEncoder[ModifyGroupJson].contramap[GroupModifyChangeJson](_.change)
+  implicit val encoder:       JsonEncoder[GroupChangeJson]       = DeriveJsonEncoder.gen[GroupChangeJson]
+}
+
+final case class GroupChangeActionJson(
+    action: ActionChangeJson,
+    change: GroupChangeJson
+)
+object GroupChangeActionJson {
+  import GroupChangeJson._
+
+  implicit def transformer(implicit
+      diffService: DiffService
+  ): PartialTransformer[NodeGroupChange, GroupChangeActionJson] = {
+    case (source, _) =>
+      implicit val change = source
+      source.change
+        .map(_.diff)
+        .map(_.transformIntoPartial[GroupChangeJson].map {
+          case d: GroupCreateChangeJson => GroupChangeActionJson(ActionChangeJson.create, d)
+          case d: GroupDeleteChangeJson => GroupChangeActionJson(ActionChangeJson.delete, d)
+          case d: GroupModifyChangeJson => GroupChangeActionJson(ActionChangeJson.modify, d)
+        }) match {
+        case Empty                          =>
+          Result.fromErrorString(s"Error while serializing group from CR ${change.firstChange.diff.group.id.serialize}")
+        case Failure(msg, exception, chain) => Result.fromErrorString(msg)
+        case Full(value)                    => value
+      }
+  }
+
+  implicit val encoder: JsonEncoder[GroupChangeActionJson] = DeriveJsonEncoder.gen[GroupChangeActionJson]
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// GLOBAL PARAMETER
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@jsonDiscriminator("type") sealed trait GlobalParameterChangeJson
+object GlobalParameterChangeJson {
+
+  final case class GlobalParameterCreateChangeJson(
+      parameter: JRGlobalParameter
+  ) extends GlobalParameterChangeJson
+
+  final case class GlobalParameterDeleteChangeJson(
+      parameter: JRGlobalParameter
+  ) extends GlobalParameterChangeJson
+
+  final case class GlobalParameterModifyChangeJson(
+      change: ModifyGlobalParameterJson
+  ) extends GlobalParameterChangeJson
+
+  final case class ModifyGlobalParameterJson(
+      name:        String,
+      description: SimpleDiffOrValueJson[String],
+      value:       SimpleDiffOrValueJson[String]
+  )
+
+  object ModifyGlobalParameterJson {
+    implicit lazy val encoder: JsonEncoder[ModifyGlobalParameterJson] =
+      DeriveJsonEncoder.gen[ModifyGlobalParameterJson]
+
+    def from(
+        modifyGlobalParameterDiff: ModifyGlobalParameterDiff,
+        initialState:              GlobalParameter
+    ): ModifyGlobalParameterJson = {
+      ModifyGlobalParameterJson(
+        modifyGlobalParameterDiff.name,
+        SimpleDiffOrValueJson.withDefault(modifyGlobalParameterDiff.modDescription, initialState.description),
+        SimpleDiffOrValueJson
+          .withDefault(modifyGlobalParameterDiff.modValue, initialState.value)
+          .map(GenericProperty.serializeToHocon)
+      )
+    }
+  }
+
+  implicit val jrGlobalParameterTransformer: Transformer[GlobalParameter, JRGlobalParameter]                         =
+    JRGlobalParameter.fromGlobalParameter(_, None)
+  implicit val createTransformer:            Transformer[AddGlobalParameterDiff, GlobalParameterCreateChangeJson]    =
+    Transformer.derive[AddGlobalParameterDiff, GlobalParameterCreateChangeJson]
+  implicit val deleteTransformer:            Transformer[DeleteGlobalParameterDiff, GlobalParameterDeleteChangeJson] =
+    Transformer.derive[DeleteGlobalParameterDiff, GlobalParameterDeleteChangeJson]
+  implicit def modifyTransformer(implicit
+      change:      GlobalParameterChange,
+      diffService: DiffService
+  ): PartialTransformer[ModifyToGlobalParameterDiff, GlobalParameterModifyChangeJson] = {
+    case (ModifyToGlobalParameterDiff(parameter), _) =>
+      val result = change.initialState match {
+        case Some(init) =>
+          val diff = diffService.diffGlobalParameter(init, parameter)
+          Right(GlobalParameterModifyChangeJson(ModifyGlobalParameterJson.from(diff, init)))
+        case _          => Left(s"Error while fetching initial state of change request.")
+      }
+      Result.fromEitherString(result)
+  }
+
+  implicit def transformer(implicit
+      change:      GlobalParameterChange,
+      diffService: DiffService
+  ): PartialTransformer[ChangeRequestGlobalParameterDiff, GlobalParameterChangeJson] = {
+    PartialTransformer
+      .define[ChangeRequestGlobalParameterDiff, GlobalParameterChangeJson]
+      .withCoproductInstance[AddGlobalParameterDiff](_.transformInto[GlobalParameterCreateChangeJson])
+      .withCoproductInstance[DeleteGlobalParameterDiff](_.transformInto[GlobalParameterDeleteChangeJson])
+      .withCoproductInstancePartial[ModifyToGlobalParameterDiff](_.transformIntoPartial[GlobalParameterModifyChangeJson])
+      .buildTransformer
+  }
+
+  implicit val createEncoder: JsonEncoder[GlobalParameterCreateChangeJson] =
+    JsonEncoder[JRGlobalParameter].contramap[GlobalParameterCreateChangeJson](_.parameter)
+  implicit val deleteEncoder: JsonEncoder[GlobalParameterDeleteChangeJson] =
+    JsonEncoder[JRGlobalParameter].contramap[GlobalParameterDeleteChangeJson](_.parameter)
+  implicit val modifyEncoder: JsonEncoder[GlobalParameterModifyChangeJson] =
+    JsonEncoder[ModifyGlobalParameterJson].contramap[GlobalParameterModifyChangeJson](_.change)
+  implicit val encoder:       JsonEncoder[GlobalParameterChangeJson]       = DeriveJsonEncoder.gen[GlobalParameterChangeJson]
+}
+
+final case class GlobalParameterChangeActionJson(
+    action: ActionChangeJson,
+    change: GlobalParameterChangeJson
+)
+
+object GlobalParameterChangeActionJson {
+  import GlobalParameterChangeJson._
+
+  implicit def transformer(implicit
+      diffService: DiffService
+  ): PartialTransformer[GlobalParameterChange, GlobalParameterChangeActionJson] = {
+    case (source, _) =>
+      implicit val change = source
+      source.change
+        .map(_.diff)
+        .map(_.transformIntoPartial[GlobalParameterChangeJson].map {
+          case d: GlobalParameterCreateChangeJson => GlobalParameterChangeActionJson(ActionChangeJson.create, d)
+          case d: GlobalParameterDeleteChangeJson => GlobalParameterChangeActionJson(ActionChangeJson.delete, d)
+          case d: GlobalParameterModifyChangeJson => GlobalParameterChangeActionJson(ActionChangeJson.modify, d)
+        }) match {
+        case Empty                          =>
+          Result.fromErrorString(s"Error while serializing global parameter from CR ${change.firstChange.diff.parameter.name}")
+        case Failure(msg, exception, chain) => Result.fromErrorString(msg)
+        case Full(value)                    => value
+      }
+  }
+
+  implicit val encoder: JsonEncoder[GlobalParameterChangeActionJson] = DeriveJsonEncoder.gen[GlobalParameterChangeActionJson]
+}
+
+final case class ConfigurationChangeRequestJson(
+    directives: Chunk[DirectiveChangeActionJson],
+    rules:      Chunk[RuleChangeActionJson],
+    groups:     Chunk[GroupChangeActionJson],
+    parameters: Chunk[GlobalParameterChangeActionJson]
+)
+
+object ConfigurationChangeRequestJson {
+  implicit def transformer(implicit
+      techniqueByDirective: Map[DirectiveId, Technique],
+      diffService:          DiffService
+  ): PartialTransformer[ConfigurationChangeRequest, ConfigurationChangeRequestJson] = {
+    PartialTransformer
+      .define[ConfigurationChangeRequest, ConfigurationChangeRequestJson]
+      .withFieldComputedPartial(
+        _.directives,
+        cr => {
+          Result.traverse[Chunk[DirectiveChangeActionJson], (DirectiveId, DirectiveChanges), DirectiveChangeActionJson](
+            cr.directives.iterator,
+            {
+              case (directiveId, changes) =>
+                for {
+                  technique <- Result.fromOptionOrString(
+                                 techniqueByDirective.get(directiveId),
+                                 s"Error while fetching technique for directive ${directiveId}"
+                               )
+                  res       <- {
+                    implicit val foundTechnique = technique
+                    changes.changes.transformIntoPartial[DirectiveChangeActionJson]
+                  }
+
+                } yield res
+            },
+            failFast = false
+          )
+        }
+      )
+      .withFieldComputedPartial(
+        _.rules,
+        cr => {
+          Result.traverse[Chunk[RuleChangeActionJson], (RuleId, RuleChanges), RuleChangeActionJson](
+            cr.rules.iterator,
+            {
+              case (directiveId, changes) =>
+                changes.changes.transformIntoPartial[RuleChangeActionJson]
+            },
+            failFast = false
+          )
+        }
+      )
+      .withFieldComputedPartial(
+        _.groups,
+        cr => {
+          Result.traverse[Chunk[GroupChangeActionJson], (NodeGroupId, NodeGroupChanges), GroupChangeActionJson](
+            cr.nodeGroups.iterator,
+            {
+              case (groupId, changes) =>
+                changes.changes.transformIntoPartial[GroupChangeActionJson]
+            },
+            failFast = false
+          )
+        }
+      )
+      .withFieldComputedPartial(
+        _.parameters,
+        cr => {
+          Result
+            .traverse[Chunk[GlobalParameterChangeActionJson], (String, GlobalParameterChanges), GlobalParameterChangeActionJson](
+              cr.globalParams.iterator,
+              {
+                case (parameterName, changes) =>
+                  changes.changes.transformIntoPartial[GlobalParameterChangeActionJson]
+              },
+              failFast = false
+            )
+        }
+      )
+      .buildTransformer
+  }
+
+  implicit val encoder: JsonEncoder[ConfigurationChangeRequestJson] = DeriveJsonEncoder.gen[ConfigurationChangeRequestJson]
+}

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/NotificationService.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/NotificationService.scala
@@ -113,11 +113,15 @@ class EmailNotificationService {
   }
 }
 
-class NotificationService(
+trait NotificationService {
+  def sendNotification(step: WorkflowNode, cr: ChangeRequest): IOResult[Unit]
+}
+
+class NotificationServiceImpl(
     emailService:   EmailNotificationService,
     linkUtil:       LinkUtil,
     configMailPath: String
-) {
+) extends NotificationService {
 
   // we want all our string to be trimmed
   implicit class ConfigExtension(config: Config) {
@@ -154,7 +158,7 @@ class NotificationService(
 
   val logger = NamedZioLogger("plugin.change-validation")
 
-  def sendNotification(step: WorkflowNode, cr: ChangeRequest): IOResult[Unit] = {
+  override def sendNotification(step: WorkflowNode, cr: ChangeRequest): IOResult[Unit] = {
     for {
       serverConfig <- getSMTPConf(configMailPath)
       _            <- ZIO.when(serverConfig.smtpHostServer.nonEmpty) {

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ChangeRequestApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ChangeRequestApi.scala
@@ -38,24 +38,28 @@
 package com.normation.plugins.changevalidation.api
 
 import com.normation.box._
+import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.services.TechniqueRepository
+import com.normation.errors._
 import com.normation.plugins.changevalidation.ChangeRequestFilter
+import com.normation.plugins.changevalidation.ChangeRequestJson
 import com.normation.plugins.changevalidation.RoChangeRequestRepository
 import com.normation.plugins.changevalidation.RoWorkflowRepository
-import com.normation.plugins.changevalidation.TwoValidationStepsWorkflowServiceImpl
+import com.normation.plugins.changevalidation.TwoValidationStepsWorkflowServiceImpl._
 import com.normation.plugins.changevalidation.WoChangeRequestRepository
-import com.normation.plugins.changevalidation.WoWorkflowRepository
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction.DELETE
 import com.normation.rudder.api.HttpAction.GET
 import com.normation.rudder.api.HttpAction.POST
-import com.normation.rudder.apidata.RestDataSerializer
 import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.workflows.ChangeRequest
 import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.domain.workflows.ConfigurationChangeRequest
 import com.normation.rudder.domain.workflows.WorkflowNodeId
 import com.normation.rudder.rest.ApiModuleProvider
 import com.normation.rudder.rest.ApiPath
@@ -64,31 +68,28 @@ import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.EndpointSchema.syntax._
 import com.normation.rudder.rest.GeneralApi
 import com.normation.rudder.rest.OneParam
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.rest.RestUtils._
-import com.normation.rudder.rest.RestUtils.toJsonError
 import com.normation.rudder.rest.SortIndex
 import com.normation.rudder.rest.StartsAtVersion3
 import com.normation.rudder.rest.ZeroParam
+import com.normation.rudder.rest.data.APIChangeRequestInfo
+import com.normation.rudder.rest.implicits._
 import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModule0
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
+import com.normation.rudder.services.modification.DiffService
 import com.normation.rudder.services.workflows.CommitAndDeployChangeRequestService
 import com.normation.rudder.services.workflows.WorkflowLevelService
-import com.normation.rudder.users.CurrentUser
+import com.normation.rudder.users.UserService
+import com.normation.rudder.web.services.ReasonBehavior
+import com.normation.rudder.web.services.UserPropertyService
 import net.liftweb.common.Box
-import net.liftweb.common.EmptyBox
-import net.liftweb.common.Failure
-import net.liftweb.common.Full
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json.JsonAST.JArray
-import net.liftweb.json.JsonAST.JValue
-import net.liftweb.json.JsonDSL._
-import net.liftweb.json.JString
 import sourcecode.Line
-import zio.NonEmptyChunk
+import zio._
+import zio.json._
+import zio.syntax._
 
 sealed trait ChangeRequestApi extends EndpointSchema with GeneralApi with SortIndex
 object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
@@ -107,7 +108,8 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
     val (action, path) = GET / "changeRequests" / "{id}"
 
     override def authz:         List[AuthorizationType] = List(AuthorizationType.Deployer.Read, AuthorizationType.Validator.Read)
-    override def dataContainer: Option[String]          = None
+    override def dataContainer: Option[String]          = Some("changeRequests")
+    override def name:          String                  = "changeRequestDetails"
   }
   final case object DeclineRequestsDetails extends ChangeRequestApi with OneParam with StartsAtVersion3 with SortIndex  {
     val z              = implicitly[Line].value
@@ -120,7 +122,8 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
       AuthorizationType.Validator.Write,
       AuthorizationType.Validator.Edit
     )
-    override def dataContainer: Option[String]          = None
+    override def dataContainer: Option[String]          = Some("changeRequests")
+    override def name:          String                  = "declineChangeRequest"
   }
   final case object AcceptRequestsDetails  extends ChangeRequestApi with OneParam with StartsAtVersion3 with SortIndex  {
     val z              = implicitly[Line].value
@@ -133,7 +136,8 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
       AuthorizationType.Validator.Write,
       AuthorizationType.Validator.Edit
     )
-    override def dataContainer: Option[String]          = None
+    override def dataContainer: Option[String]          = Some("changeRequests")
+    override def name:          String                  = "acceptChangeRequest"
   }
   final case object UpdateRequestsDetails  extends ChangeRequestApi with OneParam with StartsAtVersion3 with SortIndex  {
     val z              = implicitly[Line].value
@@ -146,54 +150,43 @@ object ChangeRequestApi       extends ApiModuleProvider[ChangeRequestApi] {
       AuthorizationType.Validator.Write,
       AuthorizationType.Validator.Edit
     )
-    override def dataContainer: Option[String]          = None
+    override def dataContainer: Option[String]          = Some("changeRequests")
+    override def name:          String                  = "updateChangeRequest"
   }
 
   def endpoints = ca.mrvisser.sealerate.values[ChangeRequestApi].toList.sortBy(_.z)
 }
 
 class ChangeRequestApiImpl(
-    restExtractorService: RestExtractorService,
+    diffService:          DiffService,
+    readTechnique:        TechniqueRepository,
     readChangeRequest:    RoChangeRequestRepository,
     writeChangeRequest:   WoChangeRequestRepository,
     readWorkflow:         RoWorkflowRepository,
-    writeWorkflow:        WoWorkflowRepository,
-    readTechnique:        TechniqueRepository,
     workflowLevelService: WorkflowLevelService,
     commitRepository:     CommitAndDeployChangeRequestService,
-    restDataSerializer:   RestDataSerializer
+    userPropertyService:  UserPropertyService,
+    userService:          UserService
 ) extends LiftApiModuleProvider[ChangeRequestApi] {
-
   import com.normation.plugins.changevalidation.api.{ChangeRequestApi => API}
+  implicit private val diffServiceImpl: DiffService = diffService
 
   override def schemas: ApiModuleProvider[ChangeRequestApi] = API
 
-  def checkWorkflow = {
-    if (workflowLevelService.getWorkflowService().needExternalValidation())
-      Full("Ok")
-    else
-      Failure("workflow disabled")
+  // Checks if we need external validation
+  def checkWorkflow: Boolean = {
+    workflowLevelService.getWorkflowService().needExternalValidation()
   }
 
-  def serialize(cr: ChangeRequest, status: WorkflowNodeId, version: ApiVersion) = {
+  def serialize(cr:         ChangeRequest, status: WorkflowNodeId)(implicit
+      techniqueByDirective: Map[DirectiveId, Technique]
+  ): PureResult[ChangeRequestJson] = {
     val isAcceptable = commitRepository.isMergeable(cr)
-    restDataSerializer.serializeCR(cr, status, isAcceptable, version)
-  }
-  private[this] def unboxAnswer(actionName: String, id: ChangeRequestId, boxedAnswer: Box[LiftResponse])(implicit
-      action:                               String,
-      prettify:                             Boolean
-  ) = {
-    boxedAnswer match {
-      case Full(response) => response
-      case eb: EmptyBox =>
-        val fail    = eb ?~! (s"Could not $actionName ChangeRequest ${id}")
-        val message = s"Could not $actionName ChangeRequest ${id} details cause is: ${fail.messageChain}."
-        toJsonError(Some(id.value.toString), message)
-    }
+    ChangeRequestJson.from(cr, status, isAcceptable)
   }
 
-  private[this] def disabledWorkflowAnswer(crId: Option[String])(implicit action: String, prettify: Boolean) = {
-    toJsonError(crId, "Workflow are disabled in Rudder, change request API is not available")
+  private[this] def disabledWorkflowAnswer[T]: IOResult[T] = {
+    Inconsistency("Workflow are disabled in Rudder, change request API is not available").fail
   }
 
   // While there is no authorisation on API, they got all rights.
@@ -213,79 +206,56 @@ class ChangeRequestApiImpl(
       .toList
   }
 
-  def checkUserAction(workflowNodeId: WorkflowNodeId, target: WorkflowNodeId): Box[String] = {
-    if (workflowNodeId == TwoValidationStepsWorkflowServiceImpl.Validation.id) {
-      if (!CurrentUser.checkRights(AuthorizationType.Validator.Write)) {
-        Failure(s"User is not authorized to update a 'pending validation' change")
-      } else if (
-        target == TwoValidationStepsWorkflowServiceImpl.Deployed.id && !CurrentUser.checkRights(AuthorizationType.Deployer.Write)
-      ) {
-        Failure(s"User is not authorized to update a 'pending validation' change to 'deployed' state")
+  def checkUserAction(workflowNodeId: WorkflowNodeId, target: WorkflowNodeId): PureResult[String] = {
+    if (workflowNodeId == Validation.id) {
+      if (!userService.getCurrentUser.checkRights(AuthorizationType.Validator.Write)) {
+        Left(Inconsistency(s"User is not authorized to update a 'pending validation' change"))
+      } else if (target == Deployed.id && !userService.getCurrentUser.checkRights(AuthorizationType.Deployer.Write)) {
+        Left(Inconsistency(s"User is not authorized to update a 'pending validation' change to 'deployed' state"))
       } else {
-        Full("user is authorized to do step")
+        Right("user is authorized to do step")
       }
     } else if (
-      workflowNodeId == TwoValidationStepsWorkflowServiceImpl.Deployment.id && !CurrentUser.checkRights(
+      workflowNodeId == Deployment.id && !userService.getCurrentUser.checkRights(
         AuthorizationType.Deployer.Write
       )
     ) {
-      Failure(s"User is not authorized to update a 'pending deployment' change")
+      Left(Inconsistency("User is not authorized to update a 'pending deployment' change"))
     } else {
-      Full("user is authorized to do step")
+      Right("user is authorized to do step")
     }
   }
 
   object ListChangeRequests extends LiftApiModule0 {
-    val schema        = API.ListChangeRequests
-    val restExtractor = restExtractorService
+    val schema = API.ListChangeRequests
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      extractFilters(req.params) match {
-        case Full(filter) =>
-          implicit val action   = "listChangeRequests"
-          implicit val prettify = restExtractor.extractPrettify(req.params)
 
-          def listChangeRequestsByFilter(filter: ChangeRequestFilter) = {
-            for {
-              crs <- readChangeRequest.getByFilter(filter).toBox ?~ ("Could not fetch ChangeRequests")
-            } yield {
-              val result = JArray(crs.map { case (cr, status) => serialize(cr, status, version) }.toList)
-              Full(result)
-            }
-          }
-          def concatenateJArray(a: JArray, b: JArray): JArray = {
-            JArray(a.arr ++ b.arr)
-          }
-
-          checkWorkflow match {
-            case Full(_) =>
-              (for {
-                results <- listChangeRequestsByFilter(filter) ?~ ("Could not fetch ChangeRequests")
-              } yield {
-                val res: JValue = (results foldRight JArray(List()))(concatenateJArray)
-                toJsonResponse(None, res)
-              }) match {
-                case Full(response) =>
-                  response
-                case eb: EmptyBox =>
-                  val fail = eb ?~ ("Could not fetch ChangeRequests")
-                  toJsonError(None, fail.messageChain)
-              }
-            case eb: EmptyBox =>
-              disabledWorkflowAnswer(None)
-          }
-
-        case eb: EmptyBox =>
-          toJsonError(None, JString("No parameter 'status' sent"))(
-            "listChangeRequests",
-            restExtractor.extractPrettify(req.params)
-          )
+      def listChangeRequestsByFilter(filter: ChangeRequestFilter): IOResult[Seq[ChangeRequestJson]] = {
+        for {
+          crsWithStatus <- readChangeRequest.getByFilter(filter)
+          serialized    <- crsWithStatus.sortBy(_._1.id.value).accumulate {
+                             case (cr, status) => getDirectiveTechniques(cr).flatMap(serialize(cr, status)(_).toIO)
+                           }
+        } yield {
+          serialized
+        }
       }
+
+      (for {
+        filter <- extractFilters(req.params).toIO
+        res    <- checkWorkflow match {
+                    case true  => listChangeRequestsByFilter(filter).chainError("Could not fetch ChangeRequests")
+                    case false => disabledWorkflowAnswer
+                  }
+      } yield {
+        res
+      }).toLiftResponseList(params, schema)
+
     }
   }
 
   object ChangeRequestsDetails extends LiftApiModule {
-    val schema        = API.ChangeRequestsDetails
-    val restExtractor = restExtractorService
+    val schema = API.ChangeRequestsDetails
     def process(
         version:    ApiVersion,
         path:       ApiPath,
@@ -294,45 +264,14 @@ class ChangeRequestApiImpl(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      try {
-        implicit val action   = "changeRequestDetails"
-        implicit val prettify = restExtractor.extractPrettify(req.params)
-
-        val id = ChangeRequestId(sid.toInt)
-
-        checkWorkflow match {
-
-          case Full(_) =>
-            val answer = for {
-              optCr         <- readChangeRequest.get(id) ?~! (s"Could not find ChangeRequest ${id}")
-              changeRequest <-
-                optCr
-                  .map(Full(_))
-                  .getOrElse(
-                    Failure(s"Could not get ChangeRequest ${id} details cause is: change request with id ${id} does not exist.")
-                  )
-              status        <- readWorkflow.getStateOfChangeRequest(id) ?~! (s"Could not find ChangeRequest ${id} status")
-            } yield {
-              val jsonChangeRequest = List(serialize(changeRequest, status, version))
-              toJsonResponse(Some(id.value.toString), ("changeRequests" -> JArray(jsonChangeRequest)))
-            }
-            unboxAnswer("find", id, answer)
-          case eb: EmptyBox =>
-            disabledWorkflowAnswer(None)
-        }
-      } catch {
-        case e: Exception =>
-          toJsonError(None, JString(s"'${sid}' is not a valid change request id (need to be an integer)"))(
-            "changeRequestDetails",
-            restExtractor.extractPrettify(req.params)
-          )
-      }
+      withChangeRequestContext(sid, params, schema, "find")((changeRequest, status, techniqueByDirective) =>
+        serialize(changeRequest, status)(techniqueByDirective).toIO
+      ).toLiftResponseOne(params, schema, Some(sid))
     }
   }
 
   object DeclineRequestsDetails extends LiftApiModule {
-    val schema        = API.DeclineRequestsDetails
-    val restExtractor = restExtractorService
+    val schema = API.DeclineRequestsDetails
     def process(
         version:    ApiVersion,
         path:       ApiPath,
@@ -341,72 +280,34 @@ class ChangeRequestApiImpl(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      implicit val action   = "declineChangeRequest"
-      implicit val prettify = restExtractor.extractPrettify(req.params)
-
       // we need to check rights for validator/deployer here, API level is not sufficient.
-
-      try {
-        val crId                                                             = ChangeRequestId(id.toInt)
-        def actualRefuse(changeRequest: ChangeRequest, step: WorkflowNodeId) = {
-          val backSteps = workflowLevelService.getWorkflowService().findBackSteps(apiUserRights, step, false)
-          val optStep   = backSteps.find(_._1 == WorkflowNodeId("Cancelled"))
-          val answer    = for {
-            (_, func) <-
-              optStep
-                .map(Full(_))
-                .getOrElse(
-                  Failure(
-                    s"Could not decline ChangeRequest ${id} details cause is: could not decline ChangeRequest ${id}, because status '${step.value}' cannot be cancelled."
-                  )
-                )
-            reason    <- restExtractor.extractReason(req) ?~ "There was an error while extracting reason message"
-            result    <- func(crId, authzToken.qc.actor, reason) ?~! (s"Could not decline ChangeRequest ${id}")
-          } yield {
-            val jsonChangeRequest = List(serialize(changeRequest, result, version))
-            toJsonResponse(Some(id.toString), ("changeRequests" -> JArray(jsonChangeRequest)))
-          }
-          unboxAnswer("decline", crId, answer)
+      def actualRefuse(changeRequest: ChangeRequest, step: WorkflowNodeId)(implicit
+          techniqueByDirective:       Map[DirectiveId, Technique]
+      ): IOResult[ChangeRequestJson] = {
+        for {
+          backSteps  <- workflowLevelService.getWorkflowService().findBackSteps(apiUserRights, step, false).succeed
+          optStep     = backSteps.find(_._1 == WorkflowNodeId("Cancelled"))
+          stepFunc   <-
+            optStep.notOptional(
+              s"Could not decline ChangeRequest ${id} details cause is: could not decline ChangeRequest ${id}, because status '${step.value}' cannot be cancelled."
+            )
+          (_, func)   = stepFunc
+          reason     <- extractReason(req)
+          result     <- func(changeRequest.id, authzToken.qc.actor, reason).toIO
+          serialized <- serialize(changeRequest, result)(techniqueByDirective).toIO
+        } yield {
+          serialized
         }
-
-        checkWorkflow match {
-          case Full(_) =>
-            val answer = {
-              for {
-                optCR         <- readChangeRequest.get(crId) ?~! (s"Could not find ChangeRequest ${id}")
-                changeRequest <-
-                  optCR
-                    .map(Full(_))
-                    .getOrElse(
-                      Failure(
-                        s"Could not decline ChangeRequest ${id} details cause is: change request with id ${id} does not exist."
-                      )
-                    )
-                currentState  <-
-                  readWorkflow.getStateOfChangeRequest(crId) ?~! (s"Could not find actual state of ChangeRequest ${id}")
-                authzOk       <- checkUserAction(currentState, TwoValidationStepsWorkflowServiceImpl.Cancelled.id)
-              } yield {
-                actualRefuse(changeRequest, currentState)
-              }
-            }
-            unboxAnswer("decline", crId, answer)
-
-          case eb: EmptyBox =>
-            disabledWorkflowAnswer(None)
-        }
-      } catch {
-        case e: Exception =>
-          toJsonError(None, JString(s"${id} is not a valid change request id (need to be an integer)"))(
-            "declineChangeRequest",
-            restExtractor.extractPrettify(req.params)
-          )
       }
+
+      withChangeRequestContext(id, params, schema, "decline")((changeRequest, status, techniqueByDirective) =>
+        actualRefuse(changeRequest, status)(techniqueByDirective.toMap)
+      ).toLiftResponseOne(params, schema, Some(id))
     }
   }
 
   object AcceptRequestsDetails extends LiftApiModule {
-    val schema        = API.AcceptRequestsDetails
-    val restExtractor = restExtractorService
+    val schema = API.AcceptRequestsDetails
     def process(
         version:    ApiVersion,
         path:       ApiPath,
@@ -415,90 +316,59 @@ class ChangeRequestApiImpl(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      implicit val action   = "acceptChangeRequest"
-      implicit val prettify = restExtractor.extractPrettify(req.params)
-      restExtractor.extractWorkflowTargetStatus(req.params) match {
-        case Full(targetStep) =>
-          try {
-            val crId                                                             = ChangeRequestId(id.toInt)
-            def actualAccept(changeRequest: ChangeRequest, step: WorkflowNodeId) = {
-              val nextSteps = workflowLevelService.getWorkflowService().findNextSteps(apiUserRights, step, false)
-              val optStep   = nextSteps.actions.find(_._1 == targetStep)
-              val answer    = for {
-                (_, func) <-
-                  optStep
-                    .map(Full(_))
-                    .getOrElse(
-                      Failure(
-                        s"Could not accept ChangeRequest ${id} details cause is: you could not send Change Request from '${step.value}' to '${targetStep.value}'."
-                      )
-                    )
-                reason    <- restExtractor.extractReason(req) ?~ "There was an error while extracting reason message"
-                result    <- func(crId, authzToken.qc.actor, reason) ?~! (s"Could not accept ChangeRequest ${id}")
-              } yield {
-                val jsonChangeRequest = List(serialize(changeRequest, result, version))
-                toJsonResponse(Some(id), ("changeRequests" -> JArray(jsonChangeRequest)))
-              }
-              unboxAnswer("accept", crId, answer)
-            }
 
-            checkWorkflow match {
-              case Full(_) =>
-                val answer = {
-                  for {
-                    optCR         <- readChangeRequest.get(crId) ?~! (s"Could not find ChangeRequest ${id}")
-                    changeRequest <-
-                      optCR
-                        .map(Full(_))
-                        .getOrElse(
-                          Failure(
-                            s"Could not accedt ChangeRequest ${id} details cause is: change request with id ${id} does not exist."
-                          )
-                        )
-                    currentState  <-
-                      readWorkflow.getStateOfChangeRequest(crId) ?~! (s"Could not find actual state of ChangeRequest ${id}")
-                    authzOk       <- checkUserAction(currentState, targetStep)
-                  } yield {
-                    currentState.value match {
-                      case "Pending validation" =>
-                        actualAccept(changeRequest, currentState)
-                      case "Pending deployment" =>
-                        actualAccept(changeRequest, currentState)
-                      case "Cancelled"          =>
-                        val message =
-                          s"Could not accept ChangeRequest ${id} details cause is: ChangeRequest ${id} has already been cancelled."
-                        toJsonError(Some(id), message)
-                      case "Deployed"           =>
-                        val message =
-                          s"Could not accept ChangeRequest ${id} details cause is: ChangeRequest ${id} has already been deployed."
-                        toJsonError(Some(id), message)
-                    }
-                  }
-                }
-                unboxAnswer("decline", crId, answer)
-              case eb: EmptyBox =>
-                disabledWorkflowAnswer(None)
-            }
-
-          } catch {
-            case e: Exception =>
-              toJsonError(None, JString(s"${id} is not a valid change request id (need to be an integer)"))(
-                "acceptChangeRequest",
-                restExtractor.extractPrettify(req.params)
-              )
-          }
-
-        case eb: EmptyBox =>
-          val fail    = eb ?~ "Not valid 'status' parameter sent"
-          val message = s"Could not accept ChangeRequest ${id} details cause is: ${fail.messageChain}."
-          toJsonError(None, JString(message))("acceptChangeRequest", restExtractor.extractPrettify(req.params))
+      def actualAccept(changeRequest: ChangeRequest, step: WorkflowNodeId, targetStep: WorkflowNodeId)(implicit
+          techniqueByDirective:       Map[DirectiveId, Technique]
+      ): IOResult[ChangeRequestJson] = {
+        for {
+          nextSteps  <- workflowLevelService.getWorkflowService().findNextSteps(apiUserRights, step, false).succeed
+          optStep     = nextSteps.actions.find(_._1 == targetStep)
+          stepFunc   <-
+            optStep.notOptional(
+              s"Could not accept ChangeRequest ${id} details cause is: you could not send Change Request from '${step.value}' to '${targetStep.value}'."
+            )
+          (_, func)   = stepFunc
+          reason     <- extractReason(req)
+          result     <- func(changeRequest.id, authzToken.qc.actor, reason).toIO
+          serialized <- serialize(changeRequest, result)(techniqueByDirective).toIO
+        } yield {
+          serialized
+        }
       }
+
+      (for {
+        targetStep <- extractWorkflowTargetStatus(req.params).toIO
+        res        <- {
+          withChangeRequestContext(id, params, schema, "accept") { (changeRequest, currentState, techniqueByDirective) =>
+            implicit val directiveCtx = techniqueByDirective
+            checkUserAction(currentState, targetStep).toIO *>
+            (currentState match {
+              case Deployment.id | Validation.id =>
+                actualAccept(changeRequest, currentState, targetStep)
+              case Cancelled.id                  =>
+                Inconsistency(
+                  s"Could not accept ChangeRequest ${id} details cause is: ChangeRequest ${id} has already been cancelled."
+                ).fail
+              case Deployed.id                   =>
+                Inconsistency(
+                  s"Could not accept ChangeRequest ${id} details cause is: ChangeRequest ${id} has already been deployed."
+                ).fail
+              case WorkflowNodeId(unknownState)  =>
+                Unexpected(
+                  s"Could not accept ChangeRequest ${id} details cause is: ChangeRequest ${id} is in an unknown state : '${unknownState}'."
+                ).fail
+            })
+          }
+        }
+
+      } yield {
+        res
+      }).toLiftResponseOne(params, schema, Some(id))
     }
   }
 
   object UpdateRequestsDetails extends LiftApiModule {
-    val schema        = API.UpdateRequestsDetails
-    val restExtractor = restExtractorService
+    val schema = API.UpdateRequestsDetails
     def process(
         version:    ApiVersion,
         path:       ApiPath,
@@ -507,63 +377,153 @@ class ChangeRequestApiImpl(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      restExtractor.extractChangeRequestInfo(req.params) match {
-        case Full(apiInfo) =>
-          implicit val action   = "updateChangeRequest"
-          implicit val prettify = restExtractor.extractPrettify(req.params)
 
-          def updateInfo(changeRequest: ChangeRequest, status: WorkflowNodeId) = {
-            val newInfo = apiInfo.updateCrInfo(changeRequest.info)
-            if (changeRequest.info == newInfo) {
-              val message = s"Could not update ChangeRequest ${id} details cause is: No changes to save."
-              toJsonError(Some(id), message)
-            } else {
-              val newCR = ChangeRequest.updateInfo(changeRequest, newInfo)
-              writeChangeRequest.updateChangeRequest(newCR, authzToken.qc.actor, None) match {
-                case Full(cr) =>
-                  val jsonChangeRequest = List(serialize(cr, status, version))
-                  toJsonResponse(Some(id), ("changeRequests" -> JArray(jsonChangeRequest)))
-                case eb: EmptyBox =>
-                  val fail    = eb ?~! (s"Could not update ChangeRequest ${id}")
-                  val message = s"Could not update ChangeRequest ${id} details cause is: ${fail.messageChain}."
-                  toJsonError(Some(id), message)
-              }
-            }
+      def updateInfo(changeRequest: ChangeRequest, status: WorkflowNodeId, apiInfo: APIChangeRequestInfo)(implicit
+          techniqueByDirective:     Map[DirectiveId, Technique]
+      ): IOResult[ChangeRequestJson] = {
+        val newInfo = apiInfo.updateCrInfo(changeRequest.info)
+        if (changeRequest.info == newInfo) {
+          val message = s"Could not update ChangeRequest ${id} details cause is: No changes to save."
+          Inconsistency(message).fail
+        } else {
+          val newCR = ChangeRequest.updateInfo(changeRequest, newInfo)
+          for {
+            updated    <- writeChangeRequest.updateChangeRequest(newCR, authzToken.qc.actor, None).toIO
+            serialized <- serialize(updated, status)(techniqueByDirective).toIO
+          } yield {
+            serialized
           }
-
-          val crId = ChangeRequestId(id.toInt)
-          checkWorkflow match {
-            case Full(_) =>
-              val answer = for {
-                optCr         <- readChangeRequest.get(crId) ?~! (s"Could not find ChangeRequest ${id}")
-                changeRequest <-
-                  optCr
-                    .map(Full(_))
-                    .getOrElse(
-                      Failure(
-                        s"Could not update ChangeRequest ${id} details cause is: change request with id ${id} does not exist."
-                      )
-                    )
-                status        <- readWorkflow.getStateOfChangeRequest(crId) ?~! (s"Could not find ChangeRequest ${id} status")
-              } yield {
-                updateInfo(changeRequest, status)
-              }
-              unboxAnswer("update", crId, answer)
-            case eb: EmptyBox =>
-              disabledWorkflowAnswer(None)
-          }
-        case eb: EmptyBox =>
-          val fail    = eb ?~! (s"No parameters sent to update change request")
-          val message = s"Could not update ChangeRequest ${id} details cause is: ${fail.messageChain}."
-          toJsonError(None, JString(message))("updateChangeRequest", restExtractor.extractPrettify(req.params))
+        }
       }
+
+      withChangeRequestContext(id, params, schema, "update")((changeRequest, status, techniqueByDirective) =>
+        updateInfo(changeRequest, status, extractChangeRequestInfo(req.params))(techniqueByDirective.toMap)
+      ).toLiftResponseOne(params, schema, Some(id))
     }
   }
 
-  private[this] def extractFilters(params: Map[String, List[String]]): Box[ChangeRequestFilter] = {
+  private def withChangeRequestContext[T: JsonEncoder](
+      sid:          String,
+      params:       DefaultParams,
+      schema:       EndpointSchema,
+      actionDetail: String
+  )(
+      block:        (ChangeRequest, WorkflowNodeId, Map[DirectiveId, Technique]) => IOResult[T]
+  ): IOResult[T] = {
+    val id = {
+      // PureResult.attempt(s"'${sid}' is not a valid change request id (need to be an integer)")(ChangeRequestId(sid.toInt))
+      Box(sid.toIntOption.map(ChangeRequestId(_))) ?~ (s"'${sid}' is not a valid change request id (need to be an integer)")
+    }
+
+    checkWorkflow match {
+      case true =>
+        (for {
+          crId          <- id
+          optCr         <- readChangeRequest.get(crId) ?~! (s"Could not find ChangeRequest ${sid}")
+          changeRequest <-
+            Box(optCr) ?~ (s"Could not get ChangeRequest ${sid} details cause is: change request with id ${sid} does not exist.")
+          status        <- readWorkflow.getStateOfChangeRequest(crId) ?~! (s"Could not find ChangeRequest ${sid} status")
+          result        <- getDirectiveTechniques(changeRequest).flatMap(block(changeRequest, status, _)).toBox
+        } yield {
+          result
+        }).toIO
+          .chainError(s"Could not ${actionDetail} ChangeRequest ${sid}")
+
+      case false =>
+        disabledWorkflowAnswer
+    }
+  }
+
+  private def getDirectiveTechniques(changeRequest: ChangeRequest): IOResult[Map[DirectiveId, Technique]] = {
+    (ZIO
+      .foreach(changeRequest match {
+        case cr: ConfigurationChangeRequest => cr.directives.toList
+        case _ => List.empty
+      }) {
+        case (directiveId, changes) =>
+          changes.changes.change.toIO.flatMap(item => {
+            val diff        = item.diff
+            val techniqueId = TechniqueId(diff.techniqueName, diff.directive.techniqueVersion)
+            val technique   = readTechnique.get(techniqueId)
+            technique
+              .map((directiveId, _))
+              .notOptional(s"Could not find technique ${techniqueId.serialize} for directive ${directiveId.serialize}")
+          })
+      })
+      .map(_.toMap)
+  }
+
+  private def extractWorkflowStatus(params: Map[String, List[String]]): PureResult[Seq[WorkflowNodeId]] = {
+    params
+      .get("status")
+      .flatMap(_.headOption)
+      .map(_.toLowerCase())
+      .map {
+        case "open"   => Right(workflowLevelService.getWorkflowService().openSteps)
+        case "closed" => Right(workflowLevelService.getWorkflowService().closedSteps)
+        case "all"    => Right(workflowLevelService.getWorkflowService().stepsValue)
+        case value    =>
+          workflowLevelService.getWorkflowService().stepsValue.find(_.value.equalsIgnoreCase(value)) match {
+            case Some(state) => Right(Seq(state))
+            case None        => Left(Unexpected(s"'${value}' is not a possible state for change requests"))
+          }
+
+      }
+      .getOrElse(
+        Right(workflowLevelService.getWorkflowService().openSteps)
+      )
+  }
+
+  private def extractWorkflowTargetStatus(params: Map[String, List[String]]): PureResult[WorkflowNodeId] = {
+    params
+      .get("status")
+      .flatMap(_.headOption)
+      .notOptionalPure("workflow status should not be empty")
+      .map(_.toLowerCase())
+      .flatMap(value => {
+        val possiblestates = workflowLevelService.getWorkflowService().stepsValue
+        possiblestates.find(_.value.equalsIgnoreCase(value)) match {
+          case Some(state) => Right(state)
+          case None        =>
+            Left(
+              Unexpected(
+                s"'${value}' is not a possible state for change requests, available values are: ${possiblestates.map(_.value).mkString("[ ", ", ", " ]")}"
+              )
+            )
+        }
+      })
+  }
+
+  private def extractChangeRequestInfo(params: Map[String, List[String]]): APIChangeRequestInfo = {
+    APIChangeRequestInfo(
+      params.get("name").flatMap(_.headOption),
+      params.get("description").flatMap(_.headOption)
+    )
+  }
+
+  private def extractReason(req: Req): IOResult[Option[String]] = {
+    import ReasonBehavior._
+    (userPropertyService.reasonsFieldBehavior match {
+      case Disabled => ZIO.none
+      case mode     =>
+        val reason = req.params.get("reason").flatMap(_.headOption)
+        (mode: @unchecked) match {
+          case Mandatory =>
+            reason
+              .notOptional("Reason field is mandatory and should be at least 5 characters long")
+              .reject {
+                case s if s.lengthIs < 5 => Inconsistency("Reason field should be at least 5 characters long")
+              }
+              .map(Some(_))
+          case Optionnal => reason.succeed
+        }
+    }).chainError("There was an error while extracting reason message")
+  }
+
+  private[this] def extractFilters(params: Map[String, List[String]]): PureResult[ChangeRequestFilter] = {
     import ChangeRequestFilter._
     for {
-      status     <- restExtractorService.extractWorkflowStatus(params)
+      status     <- extractWorkflowStatus(params)
       byRule      = params.get("ruleId").flatMap(_.headOption).map(id => ByRule(RuleUid(id)))
       byDirective = params.get("directiveId").flatMap(_.headOption).map(id => ByDirective(DirectiveUid(id)))
       byNodeGroup = params.get("nodeGroupId").flatMap(_.headOption).map(id => ByNodeGroup(NodeGroupUid(id)))

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestChangesForm.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestChangesForm.scala
@@ -181,7 +181,7 @@ class ChangeRequestChangesForm(
     }
 
     def groupChild(groupId: NodeGroupId) = new JsTreeNode {
-      val changes    = changeRequest.nodeGroups(groupId).changes
+      val changes   = changeRequest.nodeGroups(groupId).changes
       val groupName = changes.initialState
         .map(_.name)
         .getOrElse(changes.firstChange.diff match {
@@ -189,7 +189,7 @@ class ChangeRequestChangesForm(
           case d:     DeleteNodeGroupDiff   => d.group.name
           case modTo: ModifyToNodeGroupDiff => modTo.group.name
         })
-      val body       = SHtml.a(
+      val body      = SHtml.a(
         () => SetHtml("history", displayHistory(rootRuleCategory, Nil, List(changes))),
         <span>{groupName}</span>
       )

--- a/change-validation/src/test/resources/changevalidation_api/api_changerequest.yml
+++ b/change-validation/src/test/resources/changevalidation_api/api_changerequest.yml
@@ -1,0 +1,3717 @@
+description: List all change requests
+method: GET
+url: /api/latest/changeRequests
+params:
+  status: all
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "listChangeRequests",
+      "result" : "success",
+      "data" : [
+        {
+          "id" : 1,
+          "displayName" : "first cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive first change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "DirectiveCreateChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "shortDescription" : "",
+                  "longDescription" : "",
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "section" : {
+                      "name" : "sections",
+                      "sections" : [
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "htop"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "jq"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "priority" : 5,
+                  "enabled" : false,
+                  "system" : false,
+                  "policyMode" : "default",
+                  "tags" : []
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 2,
+          "displayName" : "second cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive second change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "DirectiveModifyChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : {
+                    "from" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                    "to" : "pkg_directive_001"
+                  },
+                  "shortDescription" : {
+                    "from" : "",
+                    "to" : "testing directive change"
+                  },
+                  "longDescription" : {
+                    "from" : "",
+                    "to" : "testing directive change"
+                  },
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "from" : {
+                      "section" : {
+                        "name" : "sections",
+                        "vars" : [
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_LIST",
+                              "value" : "htop"
+                            }
+                          },
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_STATE",
+                              "value" : "present"
+                            }
+                          }
+                        ],
+                        "sections" : [
+                          {
+                            "name" : "Package",
+                            "sections" : [
+                              {
+                                "name" : "Package architecture",
+                                "sections" : [
+                                  {
+                                    "name" : "Package architecture",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "sections" : [
+                                          {
+                                            "name" : "PACKAGE_ARCHITECTURE_SPECIFIC"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package manager",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_MANAGER"
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package version",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_VERSION",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Post-modification script",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_POST_HOOK_COMMAND"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "to" : {
+                      "section" : {
+                        "name" : "sections",
+                        "vars" : [
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_LIST",
+                              "value" : "curl"
+                            }
+                          },
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_STATE",
+                              "value" : "present"
+                            }
+                          }
+                        ],
+                        "sections" : [
+                          {
+                            "name" : "Package",
+                            "sections" : [
+                              {
+                                "name" : "Package architecture",
+                                "sections" : [
+                                  {
+                                    "name" : "Package architecture",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "sections" : [
+                                          {
+                                            "name" : "PACKAGE_ARCHITECTURE_SPECIFIC"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package manager",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_MANAGER"
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package version",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_VERSION",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Post-modification script",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_POST_HOOK_COMMAND"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "priority" : {
+                    "from" : 5,
+                    "to" : 1
+                  },
+                  "enabled" : {
+                    "from" : false,
+                    "to" : true
+                  },
+                  "system" : false
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 3,
+          "displayName" : "third cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive third change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "DirectiveDeleteChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "shortDescription" : "",
+                  "longDescription" : "",
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "section" : {
+                      "name" : "sections",
+                      "sections" : [
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "htop"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "jq"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "priority" : 5,
+                  "enabled" : false,
+                  "system" : false,
+                  "policyMode" : "default",
+                  "tags" : []
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 4,
+          "displayName" : "first cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group first change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "GroupCreateChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : "Real nodes",
+                  "description" : "",
+                  "nodeIds" : [
+                    "node1",
+                    "node2",
+                    "root"
+                  ],
+                  "dynamic" : false,
+                  "enabled" : true,
+                  "groupClass" : [
+                    "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                    "group_real_nodes"
+                  ],
+                  "properties" : [
+                    {
+                      "name" : "jsonParam",
+                      "value" : {
+                        "array" : [
+                          5,
+                          6
+                        ],
+                        "group" : "string",
+                        "json" : {
+                          "g1" : "g1"
+                        }
+                      }
+                    },
+                    {
+                      "name" : "stringParam",
+                      "value" : "string",
+                      "inheritMode" : "map",
+                      "provider" : "datasources"
+                    }
+                  ],
+                  "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "system" : false
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 5,
+          "displayName" : "second cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group second change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "GroupModifyChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : {
+                    "from" : "Real nodes",
+                    "to" : "group_002"
+                  },
+                  "description" : {
+                    "from" : "",
+                    "to" : "testing node group change"
+                  },
+                  "query" : {
+                    "to" : "{ returnType:'node' (identity) with 'And' criteria [] }"
+                  },
+                  "properties" : {
+                    "from" : [
+                      {
+                        "name" : "jsonParam",
+                        "value" : {
+                          "array" : [
+                            5,
+                            6
+                          ],
+                          "group" : "string",
+                          "json" : {
+                            "g1" : "g1"
+                          }
+                        }
+                      },
+                      {
+                        "name" : "stringParam",
+                        "value" : "string",
+                        "provider" : "datasources",
+                        "inheritMode" : "map"
+                      }
+                    ],
+                    "to" : [
+                      {
+                        "name" : "stringParam",
+                        "value" : "string",
+                        "provider" : "datasources",
+                        "inheritMode" : "map"
+                      }
+                    ]
+                  },
+                  "nodeIds" : {
+                    "from" : [
+                      "root",
+                      "node1",
+                      "node2"
+                    ],
+                    "to" : [
+                      "root"
+                    ]
+                  },
+                  "dynamic" : {
+                    "from" : false,
+                    "to" : true
+                  },
+                  "enabled" : {
+                    "from" : true,
+                    "to" : false
+                  }
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 6,
+          "displayName" : "third cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group third change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "GroupDeleteChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : "Real nodes",
+                  "description" : "",
+                  "nodeIds" : [
+                    "node1",
+                    "node2",
+                    "root"
+                  ],
+                  "dynamic" : false,
+                  "enabled" : true,
+                  "groupClass" : [
+                    "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                    "group_real_nodes"
+                  ],
+                  "properties" : [
+                    {
+                      "name" : "jsonParam",
+                      "value" : {
+                        "array" : [
+                          5,
+                          6
+                        ],
+                        "group" : "string",
+                        "json" : {
+                          "g1" : "g1"
+                        }
+                      }
+                    },
+                    {
+                      "name" : "stringParam",
+                      "value" : "string",
+                      "inheritMode" : "map",
+                      "provider" : "datasources"
+                    }
+                  ],
+                  "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "system" : false
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 7,
+          "displayName" : "first cr rule",
+          "status" : "Deployed",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My rule first change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "RuleCreateChangeJson",
+                  "id" : "rule2",
+                  "displayName" : "50. Deploy PLOP STACK",
+                  "categoryId" : "rootRuleCategory",
+                  "shortDescription" : "global config for all nodes",
+                  "longDescription" : "",
+                  "directives" : [
+                    "directive2"
+                  ],
+                  "targets" : [
+                    "special:all"
+                  ],
+                  "enabled" : true,
+                  "system" : false,
+                  "tags" : [
+                    {
+                      "key" : "value"
+                    }
+                  ]
+                }
+              }
+            ],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 8,
+          "displayName" : "second cr rule",
+          "status" : "Deployed",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My rule second change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "RuleModifyChangeJson",
+                  "id" : "rule2",
+                  "displayName" : {
+                    "from" : "50. Deploy PLOP STACK",
+                    "to" : "rule_002"
+                  },
+                  "shortDescription" : {
+                    "from" : "global config for all nodes",
+                    "to" : "testing rule change"
+                  },
+                  "longDescription" : {
+                    "from" : "",
+                    "to" : "testing rule change"
+                  },
+                  "directives" : {
+                    "from" : [
+                      "directive2"
+                    ],
+                    "to" : [
+                      "directive1"
+                    ]
+                  },
+                  "targets" : {
+                    "from" : [
+                      "special:all"
+                    ],
+                    "to" : [
+                      "special:all_exceptPolicyServers"
+                    ]
+                  },
+                  "enabled" : {
+                    "from" : true,
+                    "to" : false
+                  }
+                }
+              }
+            ],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 9,
+          "displayName" : "third cr rule",
+          "status" : "Deployed",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My rule third change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "RuleDeleteChangeJson",
+                  "id" : "rule2",
+                  "displayName" : "50. Deploy PLOP STACK",
+                  "categoryId" : "rootRuleCategory",
+                  "shortDescription" : "global config for all nodes",
+                  "longDescription" : "",
+                  "directives" : [
+                    "directive2"
+                  ],
+                  "targets" : [
+                    "special:all"
+                  ],
+                  "enabled" : true,
+                  "system" : false,
+                  "tags" : []
+                }
+              }
+            ],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 10,
+          "displayName" : "first cr global param",
+          "status" : "Cancelled",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My global param first change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "GlobalParameterCreateChangeJson",
+                  "id" : "jsonParam",
+                  "value" : {
+                    "array" : [
+                      1,
+                      3,
+                      2
+                    ],
+                    "json" : {
+                      "var1" : "val1",
+                      "var2" : "val2"
+                    },
+                    "string" : "a string"
+                  },
+                  "description" : "a simple string param"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id" : 11,
+          "displayName" : "second cr global param",
+          "status" : "Cancelled",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My global param second change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "GlobalParameterModifyChangeJson",
+                  "name" : "jsonParam",
+                  "description" : {
+                    "from" : "a simple string param",
+                    "to" : "testing global param change"
+                  },
+                  "value" : {
+                    "from" : "{\"array\":[1,3,2],\"json\":{\"var1\":\"val1\",\"var2\":\"val2\"},\"string\":\"a string\"}",
+                    "to" : "some string"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id" : 12,
+          "displayName" : "third cr global param",
+          "status" : "Cancelled",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My global param third change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "GlobalParameterDeleteChangeJson",
+                  "id" : "jsonParam",
+                  "value" : {
+                    "array" : [
+                      1,
+                      3,
+                      2
+                    ],
+                    "json" : {
+                      "var1" : "val1",
+                      "var2" : "val2"
+                    },
+                    "string" : "a string"
+                  },
+                  "description" : "a simple string param"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+---
+description: List all change requests by open status
+method: GET
+url: /api/latest/changeRequests
+params:
+  status: open
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "listChangeRequests",
+      "result" : "success",
+      "data" : [
+        {
+          "id" : 1,
+          "displayName" : "first cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive first change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "DirectiveCreateChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "shortDescription" : "",
+                  "longDescription" : "",
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "section" : {
+                      "name" : "sections",
+                      "sections" : [
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "htop"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "jq"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "priority" : 5,
+                  "enabled" : false,
+                  "system" : false,
+                  "policyMode" : "default",
+                  "tags" : []
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 2,
+          "displayName" : "second cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive second change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "DirectiveModifyChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : {
+                    "from" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                    "to" : "pkg_directive_001"
+                  },
+                  "shortDescription" : {
+                    "from" : "",
+                    "to" : "testing directive change"
+                  },
+                  "longDescription" : {
+                    "from" : "",
+                    "to" : "testing directive change"
+                  },
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "from" : {
+                      "section" : {
+                        "name" : "sections",
+                        "vars" : [
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_LIST",
+                              "value" : "htop"
+                            }
+                          },
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_STATE",
+                              "value" : "present"
+                            }
+                          }
+                        ],
+                        "sections" : [
+                          {
+                            "name" : "Package",
+                            "sections" : [
+                              {
+                                "name" : "Package architecture",
+                                "sections" : [
+                                  {
+                                    "name" : "Package architecture",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "sections" : [
+                                          {
+                                            "name" : "PACKAGE_ARCHITECTURE_SPECIFIC"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package manager",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_MANAGER"
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package version",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_VERSION",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Post-modification script",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_POST_HOOK_COMMAND"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "to" : {
+                      "section" : {
+                        "name" : "sections",
+                        "vars" : [
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_LIST",
+                              "value" : "curl"
+                            }
+                          },
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_STATE",
+                              "value" : "present"
+                            }
+                          }
+                        ],
+                        "sections" : [
+                          {
+                            "name" : "Package",
+                            "sections" : [
+                              {
+                                "name" : "Package architecture",
+                                "sections" : [
+                                  {
+                                    "name" : "Package architecture",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "sections" : [
+                                          {
+                                            "name" : "PACKAGE_ARCHITECTURE_SPECIFIC"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package manager",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_MANAGER"
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package version",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_VERSION",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Post-modification script",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_POST_HOOK_COMMAND"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "priority" : {
+                    "from" : 5,
+                    "to" : 1
+                  },
+                  "enabled" : {
+                    "from" : false,
+                    "to" : true
+                  },
+                  "system" : false
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 3,
+          "displayName" : "third cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive third change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "DirectiveDeleteChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "shortDescription" : "",
+                  "longDescription" : "",
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "section" : {
+                      "name" : "sections",
+                      "sections" : [
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "htop"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "jq"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "priority" : 5,
+                  "enabled" : false,
+                  "system" : false,
+                  "policyMode" : "default",
+                  "tags" : []
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 4,
+          "displayName" : "first cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group first change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "GroupCreateChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : "Real nodes",
+                  "description" : "",
+                  "nodeIds" : [
+                    "node1",
+                    "node2",
+                    "root"
+                  ],
+                  "dynamic" : false,
+                  "enabled" : true,
+                  "groupClass" : [
+                    "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                    "group_real_nodes"
+                  ],
+                  "properties" : [
+                    {
+                      "name" : "jsonParam",
+                      "value" : {
+                        "array" : [
+                          5,
+                          6
+                        ],
+                        "group" : "string",
+                        "json" : {
+                          "g1" : "g1"
+                        }
+                      }
+                    },
+                    {
+                      "name" : "stringParam",
+                      "value" : "string",
+                      "inheritMode" : "map",
+                      "provider" : "datasources"
+                    }
+                  ],
+                  "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "system" : false
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 5,
+          "displayName" : "second cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group second change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "GroupModifyChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : {
+                    "from" : "Real nodes",
+                    "to" : "group_002"
+                  },
+                  "description" : {
+                    "from" : "",
+                    "to" : "testing node group change"
+                  },
+                  "query" : {
+                    "to" : "{ returnType:'node' (identity) with 'And' criteria [] }"
+                  },
+                  "properties" : {
+                    "from" : [
+                      {
+                        "name" : "jsonParam",
+                        "value" : {
+                          "array" : [
+                            5,
+                            6
+                          ],
+                          "group" : "string",
+                          "json" : {
+                            "g1" : "g1"
+                          }
+                        }
+                      },
+                      {
+                        "name" : "stringParam",
+                        "value" : "string",
+                        "provider" : "datasources",
+                        "inheritMode" : "map"
+                      }
+                    ],
+                    "to" : [
+                      {
+                        "name" : "stringParam",
+                        "value" : "string",
+                        "provider" : "datasources",
+                        "inheritMode" : "map"
+                      }
+                    ]
+                  },
+                  "nodeIds" : {
+                    "from" : [
+                      "root",
+                      "node1",
+                      "node2"
+                    ],
+                    "to" : [
+                      "root"
+                    ]
+                  },
+                  "dynamic" : {
+                    "from" : false,
+                    "to" : true
+                  },
+                  "enabled" : {
+                    "from" : true,
+                    "to" : false
+                  }
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 6,
+          "displayName" : "third cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group third change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "GroupDeleteChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : "Real nodes",
+                  "description" : "",
+                  "nodeIds" : [
+                    "node1",
+                    "node2",
+                    "root"
+                  ],
+                  "dynamic" : false,
+                  "enabled" : true,
+                  "groupClass" : [
+                    "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                    "group_real_nodes"
+                  ],
+                  "properties" : [
+                    {
+                      "name" : "jsonParam",
+                      "value" : {
+                        "array" : [
+                          5,
+                          6
+                        ],
+                        "group" : "string",
+                        "json" : {
+                          "g1" : "g1"
+                        }
+                      }
+                    },
+                    {
+                      "name" : "stringParam",
+                      "value" : "string",
+                      "inheritMode" : "map",
+                      "provider" : "datasources"
+                    }
+                  ],
+                  "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "system" : false
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        }
+      ]
+    }
+---
+description: List all change requests by closed status
+method: GET
+url: /api/latest/changeRequests
+params:
+  status: closed
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "listChangeRequests",
+      "result" : "success",
+      "data" : [
+        {
+          "id" : 7,
+          "displayName" : "first cr rule",
+          "status" : "Deployed",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My rule first change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "RuleCreateChangeJson",
+                  "id" : "rule2",
+                  "displayName" : "50. Deploy PLOP STACK",
+                  "categoryId" : "rootRuleCategory",
+                  "shortDescription" : "global config for all nodes",
+                  "longDescription" : "",
+                  "directives" : [
+                    "directive2"
+                  ],
+                  "targets" : [
+                    "special:all"
+                  ],
+                  "enabled" : true,
+                  "system" : false,
+                  "tags" : [
+                    {
+                      "key" : "value"
+                    }
+                  ]
+                }
+              }
+            ],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 8,
+          "displayName" : "second cr rule",
+          "status" : "Deployed",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My rule second change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "RuleModifyChangeJson",
+                  "id" : "rule2",
+                  "displayName" : {
+                    "from" : "50. Deploy PLOP STACK",
+                    "to" : "rule_002"
+                  },
+                  "shortDescription" : {
+                    "from" : "global config for all nodes",
+                    "to" : "testing rule change"
+                  },
+                  "longDescription" : {
+                    "from" : "",
+                    "to" : "testing rule change"
+                  },
+                  "directives" : {
+                    "from" : [
+                      "directive2"
+                    ],
+                    "to" : [
+                      "directive1"
+                    ]
+                  },
+                  "targets" : {
+                    "from" : [
+                      "special:all"
+                    ],
+                    "to" : [
+                      "special:all_exceptPolicyServers"
+                    ]
+                  },
+                  "enabled" : {
+                    "from" : true,
+                    "to" : false
+                  }
+                }
+              }
+            ],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 9,
+          "displayName" : "third cr rule",
+          "status" : "Deployed",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My rule third change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "RuleDeleteChangeJson",
+                  "id" : "rule2",
+                  "displayName" : "50. Deploy PLOP STACK",
+                  "categoryId" : "rootRuleCategory",
+                  "shortDescription" : "global config for all nodes",
+                  "longDescription" : "",
+                  "directives" : [
+                    "directive2"
+                  ],
+                  "targets" : [
+                    "special:all"
+                  ],
+                  "enabled" : true,
+                  "system" : false,
+                  "tags" : []
+                }
+              }
+            ],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 10,
+          "displayName" : "first cr global param",
+          "status" : "Cancelled",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My global param first change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "GlobalParameterCreateChangeJson",
+                  "id" : "jsonParam",
+                  "value" : {
+                    "array" : [
+                      1,
+                      3,
+                      2
+                    ],
+                    "json" : {
+                      "var1" : "val1",
+                      "var2" : "val2"
+                    },
+                    "string" : "a string"
+                  },
+                  "description" : "a simple string param"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id" : 11,
+          "displayName" : "second cr global param",
+          "status" : "Cancelled",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My global param second change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "GlobalParameterModifyChangeJson",
+                  "name" : "jsonParam",
+                  "description" : {
+                    "from" : "a simple string param",
+                    "to" : "testing global param change"
+                  },
+                  "value" : {
+                    "from" : "{\"array\":[1,3,2],\"json\":{\"var1\":\"val1\",\"var2\":\"val2\"},\"string\":\"a string\"}",
+                    "to" : "some string"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id" : 12,
+          "displayName" : "third cr global param",
+          "status" : "Cancelled",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My global param third change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "GlobalParameterDeleteChangeJson",
+                  "id" : "jsonParam",
+                  "value" : {
+                    "array" : [
+                      1,
+                      3,
+                      2
+                    ],
+                    "json" : {
+                      "var1" : "val1",
+                      "var2" : "val2"
+                    },
+                    "string" : "a string"
+                  },
+                  "description" : "a simple string param"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+---
+description: List all change requests with open status by default
+method: GET
+url: /api/latest/changeRequests
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "listChangeRequests",
+      "result" : "success",
+      "data" : [
+        {
+          "id" : 1,
+          "displayName" : "first cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive first change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "DirectiveCreateChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "shortDescription" : "",
+                  "longDescription" : "",
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "section" : {
+                      "name" : "sections",
+                      "sections" : [
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "htop"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "jq"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "priority" : 5,
+                  "enabled" : false,
+                  "system" : false,
+                  "policyMode" : "default",
+                  "tags" : []
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 2,
+          "displayName" : "second cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive second change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "DirectiveModifyChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : {
+                    "from" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                    "to" : "pkg_directive_001"
+                  },
+                  "shortDescription" : {
+                    "from" : "",
+                    "to" : "testing directive change"
+                  },
+                  "longDescription" : {
+                    "from" : "",
+                    "to" : "testing directive change"
+                  },
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "from" : {
+                      "section" : {
+                        "name" : "sections",
+                        "vars" : [
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_LIST",
+                              "value" : "htop"
+                            }
+                          },
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_STATE",
+                              "value" : "present"
+                            }
+                          }
+                        ],
+                        "sections" : [
+                          {
+                            "name" : "Package",
+                            "sections" : [
+                              {
+                                "name" : "Package architecture",
+                                "sections" : [
+                                  {
+                                    "name" : "Package architecture",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "sections" : [
+                                          {
+                                            "name" : "PACKAGE_ARCHITECTURE_SPECIFIC"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package manager",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_MANAGER"
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package version",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_VERSION",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Post-modification script",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_POST_HOOK_COMMAND"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "to" : {
+                      "section" : {
+                        "name" : "sections",
+                        "vars" : [
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_LIST",
+                              "value" : "curl"
+                            }
+                          },
+                          {
+                            "var" : {
+                              "name" : "PACKAGE_STATE",
+                              "value" : "present"
+                            }
+                          }
+                        ],
+                        "sections" : [
+                          {
+                            "name" : "Package",
+                            "sections" : [
+                              {
+                                "name" : "Package architecture",
+                                "sections" : [
+                                  {
+                                    "name" : "Package architecture",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "sections" : [
+                                          {
+                                            "name" : "PACKAGE_ARCHITECTURE_SPECIFIC"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package manager",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_MANAGER"
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Package version",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_VERSION",
+                                    "sections" : [
+                                      {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "name" : "Post-modification script",
+                                "sections" : [
+                                  {
+                                    "name" : "PACKAGE_POST_HOOK_COMMAND"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "priority" : {
+                    "from" : 5,
+                    "to" : 1
+                  },
+                  "enabled" : {
+                    "from" : false,
+                    "to" : true
+                  },
+                  "system" : false
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 3,
+          "displayName" : "third cr directive",
+          "status" : "Pending validation",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My directive third change",
+          "changes" : {
+            "directives" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "DirectiveDeleteChangeJson",
+                  "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                  "shortDescription" : "",
+                  "longDescription" : "",
+                  "techniqueName" : "packageManagement",
+                  "techniqueVersion" : "1.0",
+                  "parameters" : {
+                    "section" : {
+                      "name" : "sections",
+                      "sections" : [
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "htop"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "section" : {
+                            "name" : "Package",
+                            "vars" : [
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_LIST",
+                                  "value" : "jq"
+                                }
+                              },
+                              {
+                                "var" : {
+                                  "name" : "PACKAGE_STATE",
+                                  "value" : "present"
+                                }
+                              }
+                            ],
+                            "sections" : [
+                              {
+                                "section" : {
+                                  "name" : "Package architecture",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE",
+                                        "value" : "default"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package manager",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_MANAGER",
+                                        "value" : "default"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Package version",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION",
+                                        "value" : "latest"
+                                      }
+                                    },
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_VERSION_SPECIFIC",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "section" : {
+                                  "name" : "Post-modification script",
+                                  "vars" : [
+                                    {
+                                      "var" : {
+                                        "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                        "value" : ""
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "priority" : 5,
+                  "enabled" : false,
+                  "system" : false,
+                  "policyMode" : "default",
+                  "tags" : []
+                }
+              }
+            ],
+            "rules" : [],
+            "groups" : [],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 4,
+          "displayName" : "first cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group first change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "create",
+                "change" : {
+                  "type" : "GroupCreateChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : "Real nodes",
+                  "description" : "",
+                  "nodeIds" : [
+                    "node1",
+                    "node2",
+                    "root"
+                  ],
+                  "dynamic" : false,
+                  "enabled" : true,
+                  "groupClass" : [
+                    "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                    "group_real_nodes"
+                  ],
+                  "properties" : [
+                    {
+                      "name" : "jsonParam",
+                      "value" : {
+                        "array" : [
+                          5,
+                          6
+                        ],
+                        "group" : "string",
+                        "json" : {
+                          "g1" : "g1"
+                        }
+                      }
+                    },
+                    {
+                      "name" : "stringParam",
+                      "value" : "string",
+                      "inheritMode" : "map",
+                      "provider" : "datasources"
+                    }
+                  ],
+                  "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "system" : false
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 5,
+          "displayName" : "second cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group second change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "modify",
+                "change" : {
+                  "type" : "GroupModifyChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : {
+                    "from" : "Real nodes",
+                    "to" : "group_002"
+                  },
+                  "description" : {
+                    "from" : "",
+                    "to" : "testing node group change"
+                  },
+                  "query" : {
+                    "to" : "{ returnType:'node' (identity) with 'And' criteria [] }"
+                  },
+                  "properties" : {
+                    "from" : [
+                      {
+                        "name" : "jsonParam",
+                        "value" : {
+                          "array" : [
+                            5,
+                            6
+                          ],
+                          "group" : "string",
+                          "json" : {
+                            "g1" : "g1"
+                          }
+                        }
+                      },
+                      {
+                        "name" : "stringParam",
+                        "value" : "string",
+                        "provider" : "datasources",
+                        "inheritMode" : "map"
+                      }
+                    ],
+                    "to" : [
+                      {
+                        "name" : "stringParam",
+                        "value" : "string",
+                        "provider" : "datasources",
+                        "inheritMode" : "map"
+                      }
+                    ]
+                  },
+                  "nodeIds" : {
+                    "from" : [
+                      "root",
+                      "node1",
+                      "node2"
+                    ],
+                    "to" : [
+                      "root"
+                    ]
+                  },
+                  "dynamic" : {
+                    "from" : false,
+                    "to" : true
+                  },
+                  "enabled" : {
+                    "from" : true,
+                    "to" : false
+                  }
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        },
+        {
+          "id" : 6,
+          "displayName" : "third cr group",
+          "status" : "Pending deployment",
+          "created by" : "test-user",
+          "acceptable" : true,
+          "description" : "My group third change",
+          "changes" : {
+            "directives" : [],
+            "rules" : [],
+            "groups" : [
+              {
+                "action" : "delete",
+                "change" : {
+                  "type" : "GroupDeleteChangeJson",
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : "Real nodes",
+                  "description" : "",
+                  "nodeIds" : [
+                    "node1",
+                    "node2",
+                    "root"
+                  ],
+                  "dynamic" : false,
+                  "enabled" : true,
+                  "groupClass" : [
+                    "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                    "group_real_nodes"
+                  ],
+                  "properties" : [
+                    {
+                      "name" : "jsonParam",
+                      "value" : {
+                        "array" : [
+                          5,
+                          6
+                        ],
+                        "group" : "string",
+                        "json" : {
+                          "g1" : "g1"
+                        }
+                      }
+                    },
+                    {
+                      "name" : "stringParam",
+                      "value" : "string",
+                      "inheritMode" : "map",
+                      "provider" : "datasources"
+                    }
+                  ],
+                  "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "system" : false
+                }
+              }
+            ],
+            "parameters" : []
+          }
+        }
+      ]
+    }
+---
+description: List all change requests when status is unknown
+method: GET
+url: /api/latest/changeRequests
+params:
+  status: unknown
+response:
+  code: 500
+  content: >-
+    {
+      "action": "listChangeRequests",
+      "result": "error",
+      "errorDetails": "Unexpected: 'unknown' is not a possible state for change requests"
+    }
+---
+description: Get information about given change request
+method: GET
+url: /api/latest/changeRequests/12
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "changeRequestDetails",
+      "id" : "12",
+      "result" : "success",
+      "data" : {
+        "changeRequests" : [
+          {
+            "id" : 12,
+            "displayName" : "third cr global param",
+            "status" : "Cancelled",
+            "created by" : "test-user",
+            "acceptable" : true,
+            "description" : "My global param third change",
+            "changes" : {
+              "directives" : [],
+              "rules" : [],
+              "groups" : [],
+              "parameters" : [
+                {
+                  "action" : "delete",
+                  "change" : {
+                    "id" : "jsonParam",
+                    "value" : {
+                      "array" : [
+                        1,
+                        3,
+                        2
+                      ],
+                      "json" : {
+                        "var1" : "val1",
+                        "var2" : "val2"
+                      },
+                      "string" : "a string"
+                    },
+                    "description" : "a simple string param",
+                    "type": "GlobalParameterDeleteChangeJson"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+---
+description: Get information about given change request when id is unknown
+method: GET
+url: /api/latest/changeRequests/999
+response:
+  code: 500
+  content: >-
+    {
+      "action": "changeRequestDetails",
+      "id": "999",
+      "result": "error",
+      "errorDetails": "Could not find ChangeRequest 999; cause was: Unexpected: Could not get ChangeRequest 999 details cause is: change request with id 999 does not exist."
+    }
+---
+description: Get information about given change request when id is not a number
+method: GET
+url: /api/latest/changeRequests/aaa
+response:
+  code: 500
+  content: >-
+    {
+      "action": "changeRequestDetails",
+      "id": "aaa",
+      "result": "error",
+      "errorDetails": "Could not find ChangeRequest aaa; cause was: Unexpected: 'aaa' is not a valid change request id (need to be an integer)"
+    }
+---
+description: Decline given change request
+method: DELETE
+url: /api/latest/changeRequests/1
+response:
+  code: 200
+  content: >-
+    {
+      "action": "declineChangeRequest",
+      "id": "1",
+      "result": "success",
+      "data": {
+        "changeRequests": [
+          {
+            "id" : 1,
+            "displayName" : "first cr directive",
+            "status" : "Cancelled",
+            "created by" : "test-user",
+            "acceptable" : true,
+            "description" : "My directive first change",
+            "changes" : {
+              "directives" : [
+                {
+                  "action" : "create",
+                  "change" : {
+                    "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                    "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                    "shortDescription" : "",
+                    "longDescription" : "",
+                    "techniqueName" : "packageManagement",
+                    "techniqueVersion" : "1.0",
+                    "parameters" : {
+                      "section" : {
+                        "name" : "sections",
+                        "sections" : [
+                          {
+                            "section" : {
+                              "name" : "Package",
+                              "vars" : [
+                                {
+                                  "var" : {
+                                    "name" : "PACKAGE_LIST",
+                                    "value" : "htop"
+                                  }
+                                },
+                                {
+                                  "var" : {
+                                    "name" : "PACKAGE_STATE",
+                                    "value" : "present"
+                                  }
+                                }
+                              ],
+                              "sections" : [
+                                {
+                                  "section" : {
+                                    "name" : "Package architecture",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_ARCHITECTURE",
+                                          "value" : "default"
+                                        }
+                                      },
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Package manager",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_MANAGER",
+                                          "value" : "default"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Package version",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_VERSION",
+                                          "value" : "latest"
+                                        }
+                                      },
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_VERSION_SPECIFIC",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Post-modification script",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "section" : {
+                              "name" : "Package",
+                              "vars" : [
+                                {
+                                  "var" : {
+                                    "name" : "PACKAGE_LIST",
+                                    "value" : "jq"
+                                  }
+                                },
+                                {
+                                  "var" : {
+                                    "name" : "PACKAGE_STATE",
+                                    "value" : "present"
+                                  }
+                                }
+                              ],
+                              "sections" : [
+                                {
+                                  "section" : {
+                                    "name" : "Package architecture",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_ARCHITECTURE",
+                                          "value" : "default"
+                                        }
+                                      },
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Package manager",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_MANAGER",
+                                          "value" : "default"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Package version",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_VERSION",
+                                          "value" : "latest"
+                                        }
+                                      },
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_VERSION_SPECIFIC",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Post-modification script",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "priority" : 5,
+                    "enabled" : false,
+                    "system" : false,
+                    "policyMode" : "default",
+                    "tags" : [],
+                    "type" : "DirectiveCreateChangeJson"
+                  }
+                }
+              ],
+              "rules" : [],
+              "groups" : [],
+              "parameters" : []
+            }
+          } 
+        ]
+      }
+    }
+---
+description: Decline given change request when it cannot be declined
+method: DELETE
+url: /api/latest/changeRequests/12
+response:
+  code: 500
+  content: >-
+    {
+      "action": "declineChangeRequest",
+      "id": "12",
+      "result": "error",
+      "errorDetails": "Could not decline ChangeRequest 12; cause was: Unexpected: Inconsistency: Could not decline ChangeRequest 12 details cause is: could not decline ChangeRequest 12, because status 'Cancelled' cannot be cancelled."
+    }
+---
+description: Decline given change request when id is unknown
+method: DELETE
+url: /api/latest/changeRequests/999
+response:
+  code: 500
+  content: >-
+    {
+      "action": "declineChangeRequest",
+      "id": "999",
+      "result": "error",
+      "errorDetails": "Could not decline ChangeRequest 999; cause was: Unexpected: Could not get ChangeRequest 999 details cause is: change request with id 999 does not exist."
+    }
+---
+description: Decline given change request when id is not a number
+method: DELETE
+url: /api/latest/changeRequests/aaa
+response:
+  code: 500
+  content: >-
+    {
+      "action": "declineChangeRequest",
+      "id": "aaa",
+      "result": "error",
+      "errorDetails": "Could not decline ChangeRequest aaa; cause was: Unexpected: 'aaa' is not a valid change request id (need to be an integer)"
+    }
+---
+description: Accept given change request
+method: POST
+url: /api/latest/changeRequests/1/accept
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+params:
+  status: Pending deployment
+response:
+  code: 200
+  content: >-
+    {
+      "action": "acceptChangeRequest",
+      "id": "1",
+      "result": "success",
+      "data": {
+        "changeRequests": [
+          {
+            "id" : 1,
+            "displayName" : "first cr directive",
+            "status" : "Pending deployment",
+            "created by" : "test-user",
+            "acceptable" : true,
+            "description" : "My directive first change",
+            "changes" : {
+              "directives" : [
+                {
+                  "action" : "create",
+                  "change" : {
+                    "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                    "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+                    "shortDescription" : "",
+                    "longDescription" : "",
+                    "techniqueName" : "packageManagement",
+                    "techniqueVersion" : "1.0",
+                    "parameters" : {
+                      "section" : {
+                        "name" : "sections",
+                        "sections" : [
+                          {
+                            "section" : {
+                              "name" : "Package",
+                              "vars" : [
+                                {
+                                  "var" : {
+                                    "name" : "PACKAGE_LIST",
+                                    "value" : "htop"
+                                  }
+                                },
+                                {
+                                  "var" : {
+                                    "name" : "PACKAGE_STATE",
+                                    "value" : "present"
+                                  }
+                                }
+                              ],
+                              "sections" : [
+                                {
+                                  "section" : {
+                                    "name" : "Package architecture",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_ARCHITECTURE",
+                                          "value" : "default"
+                                        }
+                                      },
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Package manager",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_MANAGER",
+                                          "value" : "default"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Package version",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_VERSION",
+                                          "value" : "latest"
+                                        }
+                                      },
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_VERSION_SPECIFIC",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Post-modification script",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "section" : {
+                              "name" : "Package",
+                              "vars" : [
+                                {
+                                  "var" : {
+                                    "name" : "PACKAGE_LIST",
+                                    "value" : "jq"
+                                  }
+                                },
+                                {
+                                  "var" : {
+                                    "name" : "PACKAGE_STATE",
+                                    "value" : "present"
+                                  }
+                                }
+                              ],
+                              "sections" : [
+                                {
+                                  "section" : {
+                                    "name" : "Package architecture",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_ARCHITECTURE",
+                                          "value" : "default"
+                                        }
+                                      },
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_ARCHITECTURE_SPECIFIC",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Package manager",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_MANAGER",
+                                          "value" : "default"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Package version",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_VERSION",
+                                          "value" : "latest"
+                                        }
+                                      },
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_VERSION_SPECIFIC",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "section" : {
+                                    "name" : "Post-modification script",
+                                    "vars" : [
+                                      {
+                                        "var" : {
+                                          "name" : "PACKAGE_POST_HOOK_COMMAND",
+                                          "value" : ""
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "priority" : 5,
+                    "enabled" : false,
+                    "system" : false,
+                    "policyMode" : "default",
+                    "tags" : [],
+                    "type" : "DirectiveCreateChangeJson"
+                  }
+                }
+              ],
+              "rules" : [],
+              "groups" : [],
+              "parameters" : []
+            }
+          }
+        ]
+      }
+    }
+---
+description: Accept given change request without target status
+method: POST
+url: /api/latest/changeRequests/1/accept
+response:
+  code: 500
+  content: >-
+    {
+      "action": "acceptChangeRequest",
+      "id": "1",
+      "result": "error",
+      "errorDetails": "Inconsistency: workflow status should not be empty"
+    }
+---
+description: Accept given change request when id is unknown
+method: POST
+url: /api/latest/changeRequests/999/accept
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+params:
+  status: Pending deployment
+response:
+  code: 500
+  content: >-
+    {
+      "action": "acceptChangeRequest",
+      "id": "999",
+      "result": "error",
+      "errorDetails": "Could not accept ChangeRequest 999; cause was: Unexpected: Could not get ChangeRequest 999 details cause is: change request with id 999 does not exist."
+    }
+---
+description: Accept given change request when id is not a number
+method: POST
+url: /api/latest/changeRequests/aaa/accept
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+params:
+  status: Pending deployment
+response:
+  code: 500
+  content: >-
+    {
+      "action": "acceptChangeRequest",
+      "id": "aaa",
+      "result": "error",
+      "errorDetails": "Could not accept ChangeRequest aaa; cause was: Unexpected: 'aaa' is not a valid change request id (need to be an integer)"
+    }
+---
+description: Update information about given change request
+method: POST
+url: /api/latest/changeRequests/4
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+params:
+  name: "my group new name"
+  description: "My group new description"
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "updateChangeRequest",
+      "id" : "4",
+      "result" : "success",
+      "data" : {
+        "changeRequests" : [
+          {
+            "id" : 4,
+            "displayName" : "my group new name",
+            "status" : "Pending deployment",
+            "created by" : "test-user",
+            "acceptable" : true,
+            "description" : "My group new description",
+            "changes" : {
+              "directives" : [],
+              "rules" : [],
+              "groups" : [
+                {
+                  "action" : "create",
+                  "change" : {
+                    "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                    "displayName" : "Real nodes",
+                    "description" : "",
+                    "nodeIds" : [
+                      "node1",
+                      "node2",
+                      "root"
+                    ],
+                    "dynamic" : false,
+                    "enabled" : true,
+                    "groupClass" : [
+                      "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                      "group_real_nodes"
+                    ],
+                    "properties" : [
+                      {
+                        "name" : "jsonParam",
+                        "value" : {
+                          "array" : [
+                            5,
+                            6
+                          ],
+                          "group" : "string",
+                          "json" : {
+                            "g1" : "g1"
+                          }
+                        }
+                      },
+                      {
+                        "name" : "stringParam",
+                        "value" : "string",
+                        "provider" : "datasources",
+                        "inheritMode" : "map"
+                      }
+                    ],
+                    "system" : false,
+                    "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                    "type" : "GroupCreateChangeJson"
+                  }
+                }
+              ],
+              "parameters" : []
+            }
+          }
+        ]
+      }
+    }
+---
+description: Update information about given change request when id is unknown
+method: POST
+url: /api/latest/changeRequests/999
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+params:
+  name: "my group new name"
+  description: "My group new description"
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateChangeRequest",
+      "id": "999",
+      "result": "error",
+      "errorDetails": "Could not update ChangeRequest 999; cause was: Unexpected: Could not get ChangeRequest 999 details cause is: change request with id 999 does not exist."
+    }
+---
+description: Update information about given change request when id is not a number
+method: POST
+url: /api/latest/changeRequests/aaa
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+params:
+  name: "my group new name"
+  description: "My group new description"
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateChangeRequest",
+      "id": "aaa",
+      "result": "error",
+      "errorDetails": "Could not update ChangeRequest aaa; cause was: Unexpected: 'aaa' is not a valid change request id (need to be an integer)"
+    }
+---
+description: Update information about given change request when no parameter is sent
+method: POST
+url: /api/latest/changeRequests/4
+response:
+  code: 500
+  content: >-
+    {
+      "action": "updateChangeRequest",
+      "id": "4",
+      "result": "error",
+      "errorDetails": "Could not update ChangeRequest 4; cause was: Unexpected: Inconsistency: Could not update ChangeRequest 4 details cause is: No changes to save."
+    }
+---
+description: Update information about given change request without changing any info
+method: POST
+url: /api/latest/changeRequests/11
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+params:
+  name: "second cr global param"
+  description: "My global param second change"
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "updateChangeRequest",
+      "id" : "11",
+      "result" : "error",
+      "errorDetails" : "Could not update ChangeRequest 11; cause was: Unexpected: Inconsistency: Could not update ChangeRequest 11 details cause is: No changes to save."
+    }

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/ChangeRequestJdbcRepositoryTest.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/ChangeRequestJdbcRepositoryTest.scala
@@ -1,0 +1,350 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.plugins.changevalidation
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.syntax.apply._
+import com.normation.BoxSpecMatcher
+import com.normation.GitVersion
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.domain.TechniqueVersionHelper
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.db.DBCommon
+import com.normation.rudder.db.Doobie._
+import com.normation.rudder.domain.nodes.AddNodeGroupDiff
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies._
+import com.normation.rudder.domain.properties.AddGlobalParameterDiff
+import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.domain.workflows._
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.services.marshalling.ChangeRequestChangesSerialisation
+import com.normation.rudder.services.marshalling.ChangeRequestChangesUnserialisation
+import com.normation.zio.UnsafeRun
+import com.typesafe.config.ConfigValueFactory
+import doobie.Transactor
+import doobie.specs2.analysisspec.IOChecker
+import doobie.syntax.all._
+import net.liftweb.common.Box
+import net.liftweb.common.Failure
+import net.liftweb.common.Full
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.core.Fragments
+import zio.interop.catz._
+
+@RunWith(classOf[JUnitRunner])
+class ChangeRequestJdbcRepositoryTest extends Specification with DBCommon with IOChecker with BoxSpecMatcher {
+
+  val restTestSetUp = RestTestSetUp.newEnv
+
+  val changeRequestId = ChangeRequestId(1)
+  val actor           = EventActor("actor")
+
+  val sampleChangeRequestContent = {
+    <changeRequest fileFormat="6">
+      <directives>
+        <directive id="foo">
+          <firstChange>
+            <change>
+              <actor>actor</actor>
+            </change>
+          </firstChange>
+        </directive>
+      </directives>
+      <groups>
+        <group id="bar">
+          <firstChange>
+            <change>
+              <actor>actor</actor>
+            </change>
+          </firstChange>
+        </group>
+      </groups>
+      <rules>
+        <rule id="baz">
+          <firstChange>
+            <change>
+              <actor>actor</actor>
+            </change>
+          </firstChange>
+        </rule>
+      </rules>
+      <globalParameters>
+        <globalParameter id="qux">
+          <firstChange>
+            <change>
+              <actor>actor</actor>
+            </change>
+          </firstChange>
+        </globalParameter>
+      </globalParameters>
+    </changeRequest>
+  }
+
+  override def initDb() = {
+    super.initDb()
+    // initialize some change requests to setup change requests
+    doobie.transactRunEither(xa => {
+      // id: 1
+      // same change request to test different xpaths : /changeRequest/directives/directive/@id, "/changeRequest/groups/group/@id", "/changeRequest/rules/rule/@id"
+      // We test change of a directive, nodeGroup and rule using the same change request
+      (sql"insert into ChangeRequest (name, description, creationTime, content, modificationId) values ('a change request', 'a change request description', '2023-01-01T00:00:00', ${sampleChangeRequestContent}, '11111111-1111-1111-1111-111111111111')".update.run *>
+      sql"insert into Workflow (id, state) values (${changeRequestId}, 'Pending validation')".update.run)
+        .transact(xa)
+    }) match {
+      case Right(_) => ()
+      case Left(ex) => throw ex
+    }
+  }
+
+  override def transactor: Transactor[IO] = doobie.xaio
+
+  val directiveId   = DirectiveId(DirectiveUid("foo"))
+  val groupId       = NodeGroupId(NodeGroupUid("bar"))
+  val ruleId        = RuleId(RuleUid("baz"))
+  val globalParamId = "qux"
+
+  // setup DirectiveChanges, NodeGroupChanges, RuleChanges and GlobalParamChanges to test the unserialisation
+  val directiveChanges = DirectiveChanges(
+    DirectiveChange(
+      None,
+      DirectiveChangeItem(
+        actor,
+        DateTime.parse("2023-01-01T00:00:00.000Z"),
+        Some("directive_001 change reason"),
+        AddDirectiveDiff(
+          TechniqueName("packageManagement"),
+          Directive(
+            directiveId,
+            TechniqueVersionHelper("1.0"),
+            Map.empty,
+            "",
+            "",
+            None
+          )
+        )
+      ),
+      List.empty
+    ),
+    List.empty
+  )
+
+  val nodeGroupChanges = NodeGroupChanges(
+    NodeGroupChange(
+      None,
+      NodeGroupChangeItem(
+        actor,
+        DateTime.parse("2023-01-01T00:00:00.000Z"),
+        Some("nodeGroup_001 change reason"),
+        AddNodeGroupDiff(NodeGroup(groupId, "", "", List.empty, None, serverList = Set.empty, _isEnabled = true))
+      ),
+      List.empty
+    ),
+    List.empty
+  )
+  val ruleChanges      = RuleChanges(
+    RuleChange(
+      None,
+      RuleChangeItem(
+        actor,
+        DateTime.parse("2023-01-01T00:00:00.000Z"),
+        Some("rule_001 change reason"),
+        AddRuleDiff(Rule(ruleId, "", RuleCategoryId("")))
+      ),
+      List.empty
+    ),
+    List.empty
+  )
+
+  val globalParamChanges = GlobalParameterChanges(
+    GlobalParameterChange(
+      None,
+      GlobalParameterChangeItem(
+        actor,
+        DateTime.parse("2023-01-01T00:00:00.000Z"),
+        Some("globalParam_001 change reason"),
+        AddGlobalParameterDiff(
+          GlobalParameter(globalParamId, GitVersion.DEFAULT_REV, ConfigValueFactory.fromAnyRef(""), None, "", None)
+        )
+      ),
+      List.empty
+    ),
+    List.empty
+  )
+
+  val expectedChangeRequest = ConfigurationChangeRequest(
+    changeRequestId,
+    Some(ModificationId("11111111-1111-1111-1111-111111111111")),
+    ChangeRequestInfo("a change request", "a change request description"),
+    Map(directiveId   -> directiveChanges),
+    Map(groupId       -> nodeGroupChanges),
+    Map(ruleId        -> ruleChanges),
+    Map(globalParamId -> globalParamChanges)
+  )
+
+  val newChangeRequest = expectedChangeRequest.copy(id = ChangeRequestId(2))
+
+  // Returns the same change request content
+  val changeRequestChangesSerialisation:        ChangeRequestChangesSerialisation   = _ => {
+    sampleChangeRequestContent
+  }
+  lazy val changeRequestChangesUnserialisation: ChangeRequestChangesUnserialisation = _ => {
+    Full(
+      (
+        Full(Map(directiveId -> directiveChanges)),
+        Map(groupId       -> nodeGroupChanges),
+        Map(ruleId        -> ruleChanges),
+        Map(globalParamId -> globalParamChanges)
+      )
+    )
+  }
+  lazy val changeRequestMapper = new ChangeRequestMapper(
+    changeRequestChangesUnserialisation,
+    changeRequestChangesSerialisation
+  )
+  lazy val roChangeRequestJdbcRepository =
+    new RoChangeRequestJdbcRepository(doobie, changeRequestMapper)
+  lazy val woChangeRequestJdbcRepository =
+    new WoChangeRequestJdbcRepository(doobie, changeRequestMapper, roChangeRequestJdbcRepository)
+
+  sequential
+
+  "ChangeRequestJdbcRepository" should {
+
+    "type-check queries" in {
+      if (doDatabaseConnection) {
+        val RoChangeRequestJdbcRepositorySQL: RoChangeRequestJdbcRepositorySQL = roChangeRequestJdbcRepository
+        check(RoChangeRequestJdbcRepositorySQL.getAllSQL)
+        check(RoChangeRequestJdbcRepositorySQL.getSQL(changeRequestId))
+        check(RoChangeRequestJdbcRepositorySQL.getByContributorSQL(actor))
+        check(RoChangeRequestJdbcRepositorySQL.getChangeRequestsByXpathContentSQL(fr"'/'", "", true))
+        check(RoChangeRequestJdbcRepositorySQL.getChangeRequestsByXpathContentSQL(fr"'/'", "", false))
+        check(RoChangeRequestJdbcRepositorySQL.getByFiltersSQL(None, None))
+        check(RoChangeRequestJdbcRepositorySQL.getByFiltersSQL(Some(NonEmptyList.one(WorkflowNodeId("foo"))), None))
+        check(RoChangeRequestJdbcRepositorySQL.getByFiltersSQL(None, Some((fr"'/'", "bar"))))
+        check(WoChangeRequestJdbcRepositorySQL.createChangeRequestSQL(Some("foo"), Some("bar"), <root />, Some("qux")))
+        check(
+          WoChangeRequestJdbcRepositorySQL.updateChangeRequestSQL(
+            Some("foo"),
+            Some("bar"),
+            <changeRequest />,
+            Some("qux"),
+            changeRequestId
+          )
+        )
+      } else Fragments.empty
+    }
+
+    "get all change requests" in {
+      val res = roChangeRequestJdbcRepository.getAll()
+      (res.map(_.size) must beEqualTo(Full(1))) and (res.flatMap(_.headOption) mustFullEq expectedChangeRequest)
+    }
+
+    "get a change request by id" in {
+      val res = roChangeRequestJdbcRepository.get(changeRequestId)
+      res.flatMap(Box(_)) mustFullEq expectedChangeRequest
+    }
+
+    // This does not seem to return any result at all, but the xpath and query look okay... :(
+    // "get change requests by contributor" in {
+    //  val res = roChangeRequestJdbcRepository.getByContributor(actor)
+    //  (res.map(_.size) must beEqualTo(Full(1))) and (res.flatMap(_.headOption) mustFullEq expectedChangeRequest)
+    // }
+
+    "get change requests by xpath content" in {
+      val resDirective = roChangeRequestJdbcRepository.getByDirective(DirectiveUid("foo"), false)
+      val resNodeGroup = roChangeRequestJdbcRepository.getByNodeGroup(NodeGroupId(NodeGroupUid("bar")), false)
+      val resRule      = roChangeRequestJdbcRepository.getByRule(RuleUid("baz"), false)
+      ((resDirective
+        .map(_.size) must beEqualTo(Full(1))) and (resDirective.flatMap(_.headOption) mustFullEq expectedChangeRequest) and
+      (resNodeGroup.map(_.size) must beEqualTo(Full(1))) and (resNodeGroup.flatMap(
+        _.headOption
+      ) mustFullEq expectedChangeRequest) and
+      (resRule.map(_.size) must beEqualTo(Full(1))) and (resRule.flatMap(_.headOption) mustFullEq expectedChangeRequest))
+
+    }
+
+    "get change request by filter" in {
+      val res = roChangeRequestJdbcRepository.getByFilter(ChangeRequestFilter(None, None)).runNow
+      (res.size must beEqualTo(1)) and (res.head must beEqualTo((expectedChangeRequest, WorkflowNodeId("Pending validation"))))
+    }
+
+    "create change request" in {
+      val res = woChangeRequestJdbcRepository.createChangeRequest(
+        newChangeRequest,
+        actor,
+        Some("reason")
+      )
+      res mustFullEq newChangeRequest
+    }
+
+    "delete change request (unimplemented)" in {
+      woChangeRequestJdbcRepository
+        .deleteChangeRequest(changeRequestId, actor, Some("reason")) must throwA[IllegalArgumentException]
+    }
+
+    "update an existing change request" in {
+      val updatedChangeRequest = expectedChangeRequest.copy(
+        info = expectedChangeRequest.info.copy(name = "updated change request")
+      )
+      val res                  = woChangeRequestJdbcRepository.updateChangeRequest(
+        updatedChangeRequest,
+        actor,
+        Some("reason")
+      )
+      res mustFullEq updatedChangeRequest
+    }
+
+    "update a non-existing change request" in {
+      woChangeRequestJdbcRepository.updateChangeRequest(
+        expectedChangeRequest.copy(id = ChangeRequestId(999)),
+        actor,
+        Some("reason")
+      ) must beEqualTo(Failure(s"Cannot update non-existent Change Request with id 999"))
+    }
+
+  }
+}

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/MockServices.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/MockServices.scala
@@ -1,20 +1,83 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
 package com.normation.plugins.changevalidation
 
 import better.files.File
 import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
+import com.normation.eventlog.EventLog
+import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.AuthorizationType
+import com.normation.rudder.api.ApiAuthorization
+import com.normation.rudder.domain.eventlog.ChangeRequestDiff
+import com.normation.rudder.domain.eventlog.ChangeRequestEventLog
+import com.normation.rudder.domain.eventlog.WorkflowStepChanged
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategory
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.policies.DirectiveUid
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.domain.workflows.ChangeRequest
+import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.domain.workflows.ConfigurationChangeRequest
+import com.normation.rudder.domain.workflows.WorkflowNode
+import com.normation.rudder.domain.workflows.WorkflowNodeId
+import com.normation.rudder.domain.workflows.WorkflowStepChange
+import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.repository.CategoryAndNodeGroup
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.repository.RoNodeGroupRepository
+import com.normation.rudder.services.eventlog.ChangeRequestEventLogService
+import com.normation.rudder.services.eventlog.WorkflowEventLogService
+import com.normation.rudder.services.workflows.CommitAndDeployChangeRequestService
+import com.normation.rudder.users.AuthenticatedUser
+import com.normation.rudder.users.RudderAccount
+import com.normation.rudder.users.UserService
+import com.normation.rudder.web.services.StatelessUserPropertyService
+import com.normation.rudder.web.services.UserPropertyService
 import com.normation.zio.UnsafeRun
+import net.liftweb.common.Box
+import net.liftweb.common.Full
 import scala.collection.immutable.SortedMap
 import zio.Chunk
 import zio.Ref
+import zio.ZIO
 import zio.syntax._
 
 class MockSupervisedTargets(unsupervisedDir: File, unsupervisedFilename: String, fullNodeGroupCategory: FullNodeGroupCategory) {
@@ -74,4 +137,157 @@ class MockValidatedUsers(users: Map[EventActor, WorkflowUsers]) {
     override def createUser(newVU: EventActor): IOResult[EventActor]         = ???
   }
 
+}
+
+class MockServices(changeRequestsByStatus: Map[WorkflowNodeId, List[ChangeRequest]] = Map.empty) {
+
+  object changeRequestRepository extends RoChangeRequestRepository with WoChangeRequestRepository {
+
+    override def getByFilter(filter: ChangeRequestFilter): IOResult[Vector[(ChangeRequest, WorkflowNodeId)]] = {
+      import ChangeRequestFilter._
+      changeRequestsByStatus.view
+        .filterKeys(status => filter.status.forall(_.contains(status)))
+        .toVector
+        .flatMap {
+          case (state, crs) =>
+            val checkNoFilter = filter.by.isEmpty
+            val checkDirective: ConfigurationChangeRequest => Boolean = filter.by match {
+              case Some(ByDirective(directiveId)) => _.directives.keySet.map(_.uid).contains(directiveId)
+              case _                              => _ => true
+            }
+            val checkRule:      ConfigurationChangeRequest => Boolean = filter.by match {
+              case Some(ByRule(ruleId)) => _.rules.keySet.map(_.uid).contains(ruleId)
+              case _                    => _ => true
+            }
+            val checkNodeGroup: ConfigurationChangeRequest => Boolean = filter.by match {
+              case Some(ByNodeGroup(nodeGroupId)) => _.nodeGroups.keySet.map(_.uid).contains(nodeGroupId)
+              case _                              => _ => true
+            }
+            crs.collect {
+              case cr: ConfigurationChangeRequest if checkNoFilter || checkDirective(cr) || checkRule(cr) || checkNodeGroup(cr) =>
+                (cr, state)
+            }
+        }
+        .succeed
+    }
+
+    override def get(changeRequestId: ChangeRequestId): Box[Option[ChangeRequest]] = {
+      changeRequestsByStatus.values.flatten.find(_.id == changeRequestId) match {
+        case Some(cr) => Full(Some(cr))
+        case None     => Full(None)
+      }
+    }
+
+    override def updateChangeRequest(
+        changeRequest: ChangeRequest,
+        actor:         EventActor,
+        reason:        Option[String]
+    ): Box[ChangeRequest] = {
+      Full(changeRequest)
+    }
+
+    override def getAll(): Box[Vector[ChangeRequest]] = ???
+
+    override def getByDirective(id: DirectiveUid, onlyPending: Boolean): Box[Vector[ChangeRequest]] = ???
+
+    override def getByNodeGroup(id: NodeGroupId, onlyPending: Boolean): Box[Vector[ChangeRequest]] = ???
+
+    override def getByRule(id: RuleUid, onlyPending: Boolean): Box[Vector[ChangeRequest]] = ???
+
+    override def getByContributor(actor: EventActor): Box[Vector[ChangeRequest]] = ???
+
+    override def createChangeRequest(
+        changeRequest: ChangeRequest,
+        actor:         EventActor,
+        reason:        Option[String]
+    ): Box[ChangeRequest] = ???
+
+    override def deleteChangeRequest(
+        changeRequestId: ChangeRequestId,
+        actor:           EventActor,
+        reason:          Option[String]
+    ): Box[ChangeRequest] = ???
+
+  }
+
+  object workflowRepository extends RoWorkflowRepository with WoWorkflowRepository {
+    override def getStateOfChangeRequest(crId: ChangeRequestId): Box[WorkflowNodeId] = {
+      changeRequestsByStatus.find(_._2.exists(_.id == crId)).map(_._1) match {
+        case Some(state) => Full(state)
+        case None        => Full(WorkflowNodeId("unknown"))
+      }
+    }
+
+    override def updateState(crId: ChangeRequestId, from: WorkflowNodeId, state: WorkflowNodeId): Box[WorkflowNodeId] = {
+      Full(state)
+    }
+
+    override def getAllByState(state: WorkflowNodeId): Box[Seq[ChangeRequestId]] = {
+      ???
+    }
+
+    override def createWorkflow(crId: ChangeRequestId, state: WorkflowNodeId): Box[WorkflowNodeId] = ???
+
+    override def getAllChangeRequestsState(): Box[Map[ChangeRequestId, WorkflowNodeId]] = ???
+
+  }
+
+  object commitAndDeployChangeRequest extends CommitAndDeployChangeRequestService {
+
+    override def save(changeRequest: ChangeRequest, actor: EventActor, reason: Option[String]): Box[ChangeRequest] = Full(
+      changeRequest
+    )
+
+    override def isMergeable(changeRequest: ChangeRequest): Boolean = {
+      // can depend on "mergeable" changeRequest by their id to vary test cases
+      true
+    }
+
+  }
+
+  object workflowEventLogService extends WorkflowEventLogService {
+    override def saveEventLog(stepChange: WorkflowStepChange, actor: EventActor, reason: Option[String]): Box[EventLog] = Full(
+      null
+    )
+
+    override def getChangeRequestHistory(id: ChangeRequestId): Box[Seq[WorkflowStepChanged]]       = ???
+    override def getLastLog(id: ChangeRequestId):              Box[Option[WorkflowStepChanged]]    = ???
+    override def getLastWorkflowEvents():                      Box[Map[ChangeRequestId, EventLog]] = ???
+
+  }
+
+  object changeRequestEventLogService extends ChangeRequestEventLogService {
+
+    override def saveChangeRequestLog(
+        modId:     ModificationId,
+        principal: EventActor,
+        diff:      ChangeRequestDiff,
+        reason:    Option[String]
+    ): Box[EventLog] = Full(null)
+
+    override def getChangeRequestHistory(id: ChangeRequestId): Box[Seq[ChangeRequestEventLog]]     = ???
+    override def getFirstLog(id: ChangeRequestId):             Box[Option[ChangeRequestEventLog]]  = ???
+    override def getLastLog(id: ChangeRequestId):              Box[Option[ChangeRequestEventLog]]  = ???
+    override def getLastCREvents:                              Box[Map[ChangeRequestId, EventLog]] = ???
+  }
+
+  object notificationService extends NotificationService {
+    override def sendNotification(step: WorkflowNode, cr: ChangeRequest): IOResult[Unit] = ZIO.unit
+  }
+
+  val userPropertyService: UserPropertyService = new StatelessUserPropertyService(
+    getEnable = () => true.succeed,
+    getMandatory = () => false.succeed,
+    getExplanation = () => "Test property service".succeed
+  )
+
+  object userService extends UserService {
+    val user           = new AuthenticatedUser {
+      val account                              = RudderAccount.User("admin", "admin")
+      def nodePerms                            = NodeSecurityContext.All
+      def checkRights(auth: AuthorizationType) = true
+      def getApiAuthz                          = ApiAuthorization.RW
+    }
+    val getCurrentUser = user
+  }
 }

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/TestEmailService.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/TestEmailService.scala
@@ -88,7 +88,7 @@ class TestEmailService extends Specification with BeforeAfterAll {
     Resource.getAsStream(f).pipeTo((testDir / f).newOutputStream).close()
   )
   val notification =
-    new NotificationService(new EmailNotificationService(), new LinkUtil(null, null, null, null), conf.pathAsString)
+    new NotificationServiceImpl(new EmailNotificationService(), new LinkUtil(null, null, null, null), conf.pathAsString)
 
   override def beforeAll(): Unit = {
     smtpServer.start()

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/WorkflowJdbcRepositoryTest.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/WorkflowJdbcRepositoryTest.scala
@@ -1,0 +1,114 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.plugins.changevalidation
+
+import cats.effect.IO
+import com.normation.rudder.db.DBCommon
+import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.domain.workflows.WorkflowNodeId
+import doobie.Transactor
+import doobie.specs2.analysisspec.IOChecker
+import doobie.syntax.all._
+import net.liftweb.common.Full
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import zio.interop.catz._
+
+@RunWith(classOf[JUnitRunner])
+class WorkflowJdbcRepositoryTest extends Specification with DBCommon with IOChecker {
+  sequential
+
+  override def initDb() = {
+    super.initDb()
+    // initialize some change requests to setup change requests for workflow
+    doobie.transactRunEither(xa => {
+      // id: 1
+      sql"insert into ChangeRequest (name, description, creationTime, content, modificationId) values ('a change request', 'a change request description', '2023-01-01T00:00:00', '', '11111111-1111-1111-1111-111111111111')".update.run
+        .transact(xa)
+    }) match {
+      case Right(_) => ()
+      case Left(ex) => throw ex
+    }
+  }
+
+  override def transactor: Transactor[IO] = doobie.xaio
+
+  private lazy val roWorkflowJdbcRepository = new RoWorkflowJdbcRepository(doobie)
+  private lazy val woWorkflowJdbcRepository = new WoWorkflowJdbcRepository(doobie)
+
+  val changeRequestId = ChangeRequestId(1)
+
+  "WorkflowJdbcRepository" should {
+
+    "type-check queries" in {
+      check(WorkflowJdbcRepositorySQL.getAllByStateSQL(WorkflowNodeId("foo")))
+      check(WorkflowJdbcRepositorySQL.getStateOfChangeRequestSQL(changeRequestId))
+      check(WorkflowJdbcRepositorySQL.getAllChangeRequestsStateSQL)
+      check(WorkflowJdbcRepositorySQL.createWorkflowSQL(changeRequestId, WorkflowNodeId("foo")))
+      check(WorkflowJdbcRepositorySQL.updateStateSQL(changeRequestId, WorkflowNodeId("foo"), WorkflowNodeId("foo")))
+    }
+
+    val firstWorkflowNodeId  = WorkflowNodeId("first")
+    val secondWorkflowNodeId = WorkflowNodeId("second")
+    "create a workflow" in {
+      woWorkflowJdbcRepository.createWorkflow(changeRequestId, firstWorkflowNodeId) must beEqualTo(Full(firstWorkflowNodeId))
+    }
+
+    "update a workflow" in {
+      woWorkflowJdbcRepository.updateState(changeRequestId, firstWorkflowNodeId, secondWorkflowNodeId) must beEqualTo(
+        Full(secondWorkflowNodeId)
+      )
+    }
+
+    "get all change requests by state" in {
+      roWorkflowJdbcRepository.getAllByState(firstWorkflowNodeId) must beEqualTo(Full(Seq.empty))
+      roWorkflowJdbcRepository.getAllByState(secondWorkflowNodeId) must beEqualTo(Full(Vector(changeRequestId)))
+
+    }
+
+    "get state of change request" in {
+      roWorkflowJdbcRepository.getStateOfChangeRequest(changeRequestId) must beEqualTo(Full(secondWorkflowNodeId))
+    }
+
+    "get all change requests state" in {
+      roWorkflowJdbcRepository.getAllChangeRequestsState() must beEqualTo(Full(Map(changeRequestId -> secondWorkflowNodeId)))
+    }
+
+  }
+}

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/api/ChangeRequestApiTest.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/api/ChangeRequestApiTest.scala
@@ -1,0 +1,659 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.plugins.changevalidation.api
+
+import better.files.File
+import bootstrap.rudder.plugin.ChangeValidationWorkflowLevelService
+import com.normation.cfclerk.domain.InputVariableSpec
+import com.normation.cfclerk.domain.SectionSpec
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.eventlog.EventActor
+import com.normation.plugins.AlwaysEnabledPluginStatus
+import com.normation.plugins.changevalidation.MockServices
+import com.normation.plugins.changevalidation.TwoValidationStepsWorkflowServiceImpl
+import com.normation.plugins.changevalidation.TwoValidationStepsWorkflowServiceImpl._
+import com.normation.rudder.MockGlobalParam
+import com.normation.rudder.MockNodes
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.batch.AsyncWorkflowInfo
+import com.normation.rudder.domain.nodes.AddNodeGroupDiff
+import com.normation.rudder.domain.nodes.DeleteNodeGroupDiff
+import com.normation.rudder.domain.nodes.ModifyToNodeGroupDiff
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.AddDirectiveDiff
+import com.normation.rudder.domain.policies.AddRuleDiff
+import com.normation.rudder.domain.policies.AllTargetExceptPolicyServers
+import com.normation.rudder.domain.policies.DeleteDirectiveDiff
+import com.normation.rudder.domain.policies.DeleteRuleDiff
+import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.DirectiveUid
+import com.normation.rudder.domain.policies.ModifyToDirectiveDiff
+import com.normation.rudder.domain.policies.ModifyToRuleDiff
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.domain.policies.Tags
+import com.normation.rudder.domain.properties.AddGlobalParameterDiff
+import com.normation.rudder.domain.properties.DeleteGlobalParameterDiff
+import com.normation.rudder.domain.properties.ModifyToGlobalParameterDiff
+import com.normation.rudder.domain.queries.And
+import com.normation.rudder.domain.queries.NodeReturnType
+import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.domain.queries.ResultTransformation
+import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.domain.workflows.ChangeRequestInfo
+import com.normation.rudder.domain.workflows.ConfigurationChangeRequest
+import com.normation.rudder.domain.workflows.DirectiveChange
+import com.normation.rudder.domain.workflows.DirectiveChangeItem
+import com.normation.rudder.domain.workflows.DirectiveChanges
+import com.normation.rudder.domain.workflows.GlobalParameterChange
+import com.normation.rudder.domain.workflows.GlobalParameterChangeItem
+import com.normation.rudder.domain.workflows.GlobalParameterChanges
+import com.normation.rudder.domain.workflows.NodeGroupChange
+import com.normation.rudder.domain.workflows.NodeGroupChangeItem
+import com.normation.rudder.domain.workflows.NodeGroupChanges
+import com.normation.rudder.domain.workflows.RuleChange
+import com.normation.rudder.domain.workflows.RuleChangeItem
+import com.normation.rudder.domain.workflows.RuleChanges
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.rest.TraitTestApiFromYamlFiles
+import com.normation.rudder.services.modification.DiffServiceImpl
+import java.nio.file.Files
+import net.liftweb.common.Full
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+
+@RunWith(classOf[JUnitRunner])
+class ChangeRequestApiTest extends TraitTestApiFromYamlFiles with AfterAll {
+  sequential
+
+  val restTestSetUp = RestTestSetUp.newEnv
+
+  val tmpDir: File = File(Files.createTempDirectory("rudder-test-"))
+  override def yamlSourceDirectory  = "changevalidation_api"
+  override def yamlDestTmpDirectory = tmpDir / "templates"
+
+  val actor = EventActor("test-user")
+
+  val directiveSectionSpec = {
+    SectionSpec(
+      name = "sections",
+      children = Seq(
+        InputVariableSpec("PACKAGE_LIST", "", id = None),
+        InputVariableSpec("PACKAGE_STATE", "", id = None),
+        SectionSpec(
+          name = "Package",
+          children = Seq(
+            SectionSpec(
+              name = "Package architecture",
+              children = Seq(
+                SectionSpec(
+                  name = "Package architecture",
+                  children = Seq(
+                    SectionSpec(
+                      name = "PACKAGE_ARCHITECTURE",
+                      children = Seq(
+                        SectionSpec(
+                          name = "PACKAGE_ARCHITECTURE_SPECIFIC"
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            SectionSpec(
+              name = "Package manager",
+              children = Seq(
+                SectionSpec(
+                  name = "PACKAGE_MANAGER"
+                )
+              )
+            ),
+            SectionSpec(
+              name = "Package version",
+              children = Seq(
+                SectionSpec(
+                  name = "PACKAGE_VERSION",
+                  children = Seq(
+                    SectionSpec(
+                      name = "PACKAGE_VERSION_SPECIFIC"
+                    )
+                  )
+                )
+              )
+            ),
+            SectionSpec(
+              name = "Post-modification script",
+              children = Seq(
+                SectionSpec(
+                  name = "PACKAGE_POST_HOOK_COMMAND"
+                )
+              )
+            )
+          )
+        ),
+        SectionSpec(
+          name = "Package",
+          children = Seq(
+            SectionSpec(
+              name = "Package architecture",
+              children = Seq(
+                SectionSpec(
+                  name = "Package architecture",
+                  children = Seq(
+                    SectionSpec(
+                      name = "PACKAGE_ARCHITECTURE",
+                      children = Seq(
+                        SectionSpec(
+                          name = "PACKAGE_ARCHITECTURE_SPECIFIC"
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            SectionSpec(
+              name = "Package manager",
+              children = Seq(
+                SectionSpec(
+                  name = "PACKAGE_MANAGER"
+                )
+              )
+            ),
+            SectionSpec(
+              name = "Package version",
+              children = Seq(
+                SectionSpec(
+                  name = "PACKAGE_VERSION",
+                  children = Seq(
+                    SectionSpec(
+                      name = "PACKAGE_VERSION_SPECIFIC"
+                    )
+                  )
+                )
+              )
+            ),
+            SectionSpec(
+              name = "Post-modification script",
+              children = Seq(
+                SectionSpec(
+                  name = "PACKAGE_POST_HOOK_COMMAND"
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+  val mockDirectives  = restTestSetUp.mockDirectives
+  val mockNodeGroups  = restTestSetUp.mockNodeGroups
+  val mockRules       = restTestSetUp.mockRules
+  val mockGlobalParam = new MockGlobalParam()
+
+  val mockServices = new MockServices(
+    Map(
+      Validation.id -> List(
+        ConfigurationChangeRequest(
+          ChangeRequestId(1),
+          None,
+          ChangeRequestInfo("first cr directive", "My directive first change"),
+          Map(
+            DirectiveId(DirectiveUid("directive_001")) -> DirectiveChanges(
+              DirectiveChange(
+                None,
+                DirectiveChangeItem(
+                  actor,
+                  DateTime.parse("2023-01-01T00:00:00.000Z"),
+                  Some("directive_001 change reason"),
+                  AddDirectiveDiff(TechniqueName("packageManagement"), mockDirectives.directives.pkgDirective)
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          ),
+          Map.empty,
+          Map.empty,
+          Map.empty
+        ),
+        ConfigurationChangeRequest(
+          ChangeRequestId(2),
+          None,
+          ChangeRequestInfo("second cr directive", "My directive second change"),
+          Map(
+            DirectiveId(DirectiveUid("directive_001")) -> DirectiveChanges(
+              DirectiveChange(
+                Some(
+                  (
+                    TechniqueName("packageManagement"),
+                    mockDirectives.directives.pkgDirective,
+                    Some(directiveSectionSpec)
+                  )
+                ),
+                DirectiveChangeItem(
+                  actor,
+                  DateTime.parse("2023-02-02T00:00:00.000Z"),
+                  Some("directive_001 change reason"),
+                  ModifyToDirectiveDiff(
+                    TechniqueName("packageManagement"),
+                    mockDirectives.directives.pkgDirective,
+                    Some(directiveSectionSpec)
+                  )
+                ),
+                List(
+                  DirectiveChangeItem(
+                    actor,
+                    DateTime.parse("2023-02-02T00:00:00.000Z"),
+                    Some("directive_001 another change reason"),
+                    ModifyToDirectiveDiff(
+                      TechniqueName("packageManagement"),
+                      mockDirectives.directives.pkgDirective.copy(
+                        name = "pkg_directive_001",
+                        shortDescription = "testing directive change",
+                        longDescription = "testing directive change",
+                        priority = 1,
+                        isSystem = true,
+                        parameters = mockDirectives.directives.pkgDirective.parameters ++ Map(("PACKAGE_LIST", Seq("curl")))
+                        // ignored changes :
+                        // policyMode = Some(PolicyMode.Audit),
+                        // tags = Tags.fromMaps(List(Map("key" -> "value")))
+                      ),
+                      Some(directiveSectionSpec)
+                    )
+                  )
+                )
+              ),
+              List.empty
+            )
+          ),
+          Map.empty,
+          Map.empty,
+          Map.empty
+        ),
+        ConfigurationChangeRequest(
+          ChangeRequestId(3),
+          None,
+          ChangeRequestInfo("third cr directive", "My directive third change"),
+          Map(
+            DirectiveId(DirectiveUid("directive_001")) -> DirectiveChanges(
+              DirectiveChange(
+                Some(
+                  (
+                    TechniqueName("packageManagement"),
+                    mockDirectives.directives.pkgDirective,
+                    Some(directiveSectionSpec)
+                  )
+                ),
+                DirectiveChangeItem(
+                  actor,
+                  DateTime.parse("2023-03-03T00:00:00.000Z"),
+                  Some("directive_001 delete change reason"),
+                  DeleteDirectiveDiff(
+                    TechniqueName("packageManagement"),
+                    mockDirectives.directives.pkgDirective
+                  )
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          ),
+          Map.empty,
+          Map.empty,
+          Map.empty
+        )
+      ),
+      Deployment.id -> List(
+        ConfigurationChangeRequest(
+          ChangeRequestId(4),
+          None,
+          ChangeRequestInfo("first cr group", "My group first change"),
+          Map.empty,
+          Map(
+            NodeGroupId(NodeGroupUid("group_001")) -> NodeGroupChanges(
+              NodeGroupChange(
+                None,
+                NodeGroupChangeItem(
+                  actor,
+                  DateTime.parse("2023-04-04T00:00:00.000Z"),
+                  Some("group_001 change reason"),
+                  AddNodeGroupDiff(mockNodeGroups.g0)
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          ),
+          Map.empty,
+          Map.empty
+        ),
+        ConfigurationChangeRequest(
+          ChangeRequestId(5),
+          None,
+          ChangeRequestInfo("second cr group", "My group second change"),
+          Map.empty,
+          Map(
+            NodeGroupId(NodeGroupUid("group_001")) -> NodeGroupChanges(
+              NodeGroupChange(
+                Some(mockNodeGroups.g0),
+                NodeGroupChangeItem(
+                  actor,
+                  DateTime.parse("2023-05-05T00:00:00.000Z"),
+                  Some("group_002 change reason"),
+                  ModifyToNodeGroupDiff(mockNodeGroups.g0)
+                ),
+                List(
+                  NodeGroupChangeItem(
+                    actor,
+                    DateTime.parse("2023-05-05T00:00:00.000Z"),
+                    Some("group_001 another change reason"),
+                    ModifyToNodeGroupDiff(
+                      mockNodeGroups.g0.copy(
+                        name = "group_002",
+                        description = "testing node group change",
+                        query = Some(Query(NodeReturnType, And, ResultTransformation.Identity, List.empty)),
+                        serverList = Set(MockNodes.rootId),
+                        isDynamic = true,
+                        properties = mockNodeGroups.g0props.take(1),
+                        _isEnabled = false,
+                        isSystem = false
+                      )
+                    )
+                  )
+                )
+              ),
+              List.empty
+            )
+          ),
+          Map.empty,
+          Map.empty
+        ),
+        ConfigurationChangeRequest(
+          ChangeRequestId(6),
+          None,
+          ChangeRequestInfo("third cr group", "My group third change"),
+          Map.empty,
+          Map(
+            NodeGroupId(NodeGroupUid("group_001")) -> NodeGroupChanges(
+              NodeGroupChange(
+                Some(mockNodeGroups.g0),
+                NodeGroupChangeItem(
+                  actor,
+                  DateTime.parse("2023-06-06T00:00:00.000Z"),
+                  Some("group_001 delete change reason"),
+                  DeleteNodeGroupDiff(mockNodeGroups.g0)
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          ),
+          Map.empty,
+          Map.empty
+        )
+      ),
+      Deployed.id   -> List(
+        ConfigurationChangeRequest(
+          ChangeRequestId(7),
+          None,
+          ChangeRequestInfo("first cr rule", "My rule first change"),
+          Map.empty,
+          Map.empty,
+          Map(
+            RuleId(RuleUid("rule_001")) -> RuleChanges(
+              RuleChange(
+                None,
+                RuleChangeItem(
+                  actor,
+                  DateTime.parse("2023-07-07T00:00:00.000Z"),
+                  Some("rule_001 change reason"),
+                  AddRuleDiff(mockRules.rules.rpmRule.copy(tags = Tags.fromMaps(List(Map("key" -> "value")))))
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          ),
+          Map.empty
+        ),
+        ConfigurationChangeRequest(
+          ChangeRequestId(8),
+          None,
+          ChangeRequestInfo("second cr rule", "My rule second change"),
+          Map.empty,
+          Map.empty,
+          Map(
+            // To this point, RuleChange has a different 'change' implementation than others : it only takes 'firstChange'
+            RuleId(RuleUid("rule_001")) -> RuleChanges(
+              RuleChange(
+                Some(mockRules.rules.rpmRule),
+                RuleChangeItem(
+                  actor,
+                  DateTime.parse("2023-08-08T00:00:00.000Z"),
+                  Some("rule_001 change reason"),
+                  ModifyToRuleDiff(
+                    mockRules.rules.rpmRule.copy(
+                      name = "rule_002",
+                      shortDescription = "testing rule change",
+                      longDescription = "testing rule change",
+                      directiveIds = Set(DirectiveId(DirectiveUid("directive1"))),
+                      targets = Set(AllTargetExceptPolicyServers),
+                      isEnabledStatus = false,
+                      isSystem = false
+                      // ignored changes :
+                      // categoryId = RuleCategoryId("rule_category_001"),
+                      // policyMode = Some(PolicyMode.Audit),
+                      // tags = Tags.fromMaps(List(Map("key" -> "value")))
+                    )
+                  )
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          ),
+          Map.empty
+        ),
+        ConfigurationChangeRequest(
+          ChangeRequestId(9),
+          None,
+          ChangeRequestInfo("third cr rule", "My rule third change"),
+          Map.empty,
+          Map.empty,
+          Map(
+            RuleId(RuleUid("rule_001")) -> RuleChanges(
+              RuleChange(
+                Some(mockRules.rules.rpmRule),
+                RuleChangeItem(
+                  actor,
+                  DateTime.parse("2023-09-09T00:00:00.000Z"),
+                  Some("rule_001 delete change reason"),
+                  DeleteRuleDiff(mockRules.rules.rpmRule)
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          ),
+          Map.empty
+        )
+      ),
+      Cancelled.id  -> List(
+        ConfigurationChangeRequest(
+          ChangeRequestId(10),
+          None,
+          ChangeRequestInfo("first cr global param", "My global param first change"),
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map(
+            "my_global_param" -> GlobalParameterChanges(
+              GlobalParameterChange(
+                None,
+                GlobalParameterChangeItem(
+                  actor,
+                  DateTime.parse("2023-10-10T00:00:00.000Z"),
+                  Some("my_global_param change reason"),
+                  AddGlobalParameterDiff(mockGlobalParam.jsonParam)
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          )
+        ),
+        ConfigurationChangeRequest(
+          ChangeRequestId(11),
+          None,
+          ChangeRequestInfo("second cr global param", "My global param second change"),
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map(
+            "my_global_param" -> GlobalParameterChanges(
+              GlobalParameterChange(
+                Some(mockGlobalParam.jsonParam),
+                GlobalParameterChangeItem(
+                  actor,
+                  DateTime.parse("2023-11-11T00:00:00.000Z"),
+                  Some("my_global_param change reason"),
+                  ModifyToGlobalParameterDiff(
+                    mockGlobalParam.jsonParam
+                      .withDescription("testing global param change")
+                      .withValue(mockGlobalParam.stringParam.value)
+                  )
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          )
+        ),
+        ConfigurationChangeRequest(
+          ChangeRequestId(12),
+          None,
+          ChangeRequestInfo("third cr global param", "My global param third change"),
+          Map.empty,
+          Map.empty,
+          Map.empty,
+          Map(
+            "my_global_param" -> GlobalParameterChanges(
+              GlobalParameterChange(
+                Some(mockGlobalParam.jsonParam),
+                GlobalParameterChangeItem(
+                  actor,
+                  DateTime.parse("2023-12-12T00:00:00.000Z"),
+                  Some("my_global_param delete change reason"),
+                  DeleteGlobalParameterDiff(mockGlobalParam.jsonParam)
+                ),
+                List.empty
+              ),
+              List.empty
+            )
+          )
+        )
+      )
+    )
+  )
+
+  val modules = List(
+    new ChangeRequestApiImpl(
+      new DiffServiceImpl,
+      restTestSetUp.mockTechniques.techniqueRepo,
+      mockServices.changeRequestRepository,
+      mockServices.changeRequestRepository,
+      mockServices.workflowRepository,
+      restTestSetUp.workflowLevelService,
+      mockServices.commitAndDeployChangeRequest,
+      mockServices.userPropertyService,
+      mockServices.userService
+    )
+  )
+
+  val validationWorkflowService = new TwoValidationStepsWorkflowServiceImpl(
+    mockServices.workflowEventLogService,
+    mockServices.commitAndDeployChangeRequest,
+    mockServices.workflowRepository,
+    mockServices.workflowRepository,
+    new AsyncWorkflowInfo,
+    restTestSetUp.uuidGen,
+    mockServices.changeRequestEventLogService,
+    mockServices.changeRequestRepository,
+    mockServices.changeRequestRepository,
+    mockServices.notificationService,
+    mockServices.userService,
+    () => Full(true),
+    () => Full(true),
+    () => Full(true)
+  )
+
+  restTestSetUp.workflowLevelService.overrideLevel(
+    new ChangeValidationWorkflowLevelService(
+      AlwaysEnabledPluginStatus,
+      restTestSetUp.workflowLevelService.defaultWorkflowService,
+      validationWorkflowService,
+      List.empty,
+      () => Full(true),
+      null
+    )
+  )
+
+  val apiVersions            = ApiVersion(13, true) :: ApiVersion(14, false) :: Nil
+  val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(modules, apiVersions, Some(mockServices.userService))
+
+  override def transformations: Map[String, String => String] = Map()
+
+  // we are testing error cases, so we don't want to output error log for them
+  org.slf4j.LoggerFactory
+    .getLogger("com.normation.rudder.rest.RestUtils")
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.OFF)
+
+  override def afterAll(): Unit = {
+    tmpDir.delete()
+  }
+
+  doTest(List("api_changerequest.yml"), semanticJson = true)
+
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/23831

This PR migrates only the zio-json parts of the change request APIs. It consists in : 
* adding tests to the API and the database which is left untouched
* removing usage of `RestExtractorService` from Rudder which is the only part using lift-json indirectly

A whole new ADT tree needed to be created to be in par with the domain model of `ChangeRequest`, and we heavily use _chimney_ to do the mapping, see the [ChangeRequestJson.scala](https://github.com/Normation/rudder-plugins/blob/eebed5083c2ba840ef6919314938d7e5b8178c4b/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeRequestJson.scala) file. This time, we use the `PartialTransformer` from _chimney_ because serialization could result in errors anywhere in the transformations. 

The behavior is slightly changed when encountering errors when attempting to serialize a change request : 
* previously we had serialized an "error string" in place of a serialized `Directive` object to encode the error
* now we fail-fast as early as we can before even serializing (e.g. when fetching the context to serialize the `Directive`) and we accumulate any other serialization errors in the error channel, which is provided by _chimney_ and which we adapt to our app's.

There may still be some works to do to for the migration : 
* the lift `Box` could be rewritten to `IOResult` effect type in most places, even up to Rudder interfaces
* the errors messages could be tested and improved further : _chimney_ tracks the path or errors, so when doing the one partial transformation of a `ChangeRequest` we could have very details errors in nested fields. 