### PR TITLE
Fixes #23907: List change requests with additional filters

### DIFF
--- a/change-validation/src/main/scala/bootstrap/rudder/plugin/MigrateSupervisedGroups.scala
+++ b/change-validation/src/main/scala/bootstrap/rudder/plugin/MigrateSupervisedGroups.scala
@@ -57,9 +57,9 @@ class MigrateSupervisedGroups(
     groupRepository:  RoNodeGroupRepository,
     unsupervisedRepo: UnsupervisedTargetsRepository
 ) {
-  implicit val formats = net.liftweb.json.Serialization.formats(NoTypeHints)
-  val directory        = "/var/rudder/plugin-resources/change-validation"
-  val oldFilename      = "supervised-targets.json"
+  implicit val formats: net.liftweb.json.Formats = net.liftweb.json.Serialization.formats(NoTypeHints)
+  val directory   = "/var/rudder/plugin-resources/change-validation"
+  val oldFilename = "supervised-targets.json"
 
   def migrate(): Unit = {
     Box.tryo {

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/DataTypes.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/DataTypes.scala
@@ -38,9 +38,13 @@
 package com.normation.plugins.changevalidation
 
 import com.normation.NamedZioLogger
+import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.FullRuleTargetInfo
 import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.policies.SimpleTarget
+import com.normation.rudder.domain.workflows.WorkflowNodeId
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.utils.Control
 import net.liftweb.common.Box
@@ -54,6 +58,7 @@ import net.liftweb.json.NoTypeHints
 import net.liftweb.json.parse
 import org.slf4j.LoggerFactory
 import scala.util.control.NonFatal
+import zio.NonEmptyChunk
 
 /**
  * Applicative log of interest for Rudder ops.
@@ -73,6 +78,18 @@ object ChangeValidationLoggerPure extends NamedZioLogger {
   object Metrics extends NamedZioLogger {
     override def loggerName: String = "change-validation.metrics"
   }
+}
+
+final case class ChangeRequestFilter(
+    status: Option[NonEmptyChunk[WorkflowNodeId]],
+    by:     Option[ChangeRequestFilter.ByFilter]
+)
+
+object ChangeRequestFilter {
+  sealed trait ByFilter
+  final case class ByRule(ruleId: RuleUid)                extends ByFilter
+  final case class ByDirective(directiveId: DirectiveUid) extends ByFilter
+  final case class ByNodeGroup(nodeGroupId: NodeGroupUid) extends ByFilter
 }
 
 /*
@@ -144,7 +161,7 @@ object RudderJsonMapping {
  * Ser utils
  */
 object Ser {
-  implicit val formats = net.liftweb.json.Serialization.formats(NoTypeHints)
+  implicit val formats: net.liftweb.json.Formats = net.liftweb.json.Serialization.formats(NoTypeHints)
 
   /*
    * Parse a string as a simple target ID

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsReposiory.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsReposiory.scala
@@ -42,7 +42,7 @@ class UnsupervisedTargetsRepository(
     directory: Path,
     filename:  String
 ) {
-  implicit val formats   = net.liftweb.json.Serialization.formats(NoTypeHints)
+  implicit val formats: net.liftweb.json.Formats = net.liftweb.json.Serialization.formats(NoTypeHints)
   private[this] val path = new File(directory.toFile, filename)
 
   /*

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowJdbcRepository.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowJdbcRepository.scala
@@ -38,7 +38,6 @@ package com.normation.plugins.changevalidation
 
 import cats.implicits._
 import com.normation.rudder.db.Doobie
-import com.normation.rudder.db.Doobie._
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.domain.workflows.WorkflowNodeId
 import doobie._

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/SupervisedTargetsApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/SupervisedTargetsApi.scala
@@ -39,6 +39,7 @@ package com.normation.plugins.changevalidation.api
 
 import com.normation.box._
 import com.normation.plugins.changevalidation._
+import com.normation.rudder.AuthorizationType
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction.GET
 import com.normation.rudder.api.HttpAction.POST
@@ -59,8 +60,6 @@ import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModule0
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
-import com.normation.rudder.AuthorizationType
-
 import net.liftweb.common._
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
@@ -82,8 +81,8 @@ object SupervisedTargetsApi       extends ApiModuleProvider[SupervisedTargetsApi
     val description    = "Get all available node groups with their role in change request validation"
     val (action, path) = GET / "changevalidation" / "supervised" / "targets"
 
-    override def dataContainer: Option[String] = None
-    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
+    override def dataContainer: Option[String]          = None
+    override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
   final case object UpdateSupervisedTargets extends SupervisedTargetsApi with ZeroParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
@@ -103,7 +102,7 @@ class SupervisedTargetsApiImpl(
 ) extends LiftApiModuleProvider[SupervisedTargetsApi] {
   api =>
 
-  implicit val formats = net.liftweb.json.Serialization.formats(NoTypeHints)
+  implicit val formats: net.liftweb.json.Formats = net.liftweb.json.Serialization.formats(NoTypeHints)
 
   def schemas = SupervisedTargetsApi
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23907

Adding the `ruleId`, `directiveId` and `nodeGroupId` query params filter support for listing change requests.

I fixed compilations issues along the way (missing type declaration for implicits).

There exists repository methods to `getByRule` etc. but the state is queried with a pattern : `LIKE 'Pending%'` in SQL. In the end the result is the same as when passing explicit state values : `IN ('Pending deployment', 'Pending validation')`, I preferred the latter to also avoid conflicts when refactoring from `Box` to `IOResult`