### PR TITLE
Fixes #24042: When the Oauth2 role provisioning attribute is incorrect, the error is misleading

### DIFF
--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -516,12 +516,21 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
             val custom = {
               try {
                 import scala.jdk.CollectionConverters._
-                user
-                  .getAttribute[java.util.ArrayList[String]](reg.roles.attributeName)
-                  .asScala
-                  .map(r => RudderRoles.findRoleByName(r).runNow)
-                  .flatten
-                  .toSet
+                if (user.getAttributes.containsKey(reg.roles.attributeName)) {
+                  user
+                    .getAttribute[java.util.ArrayList[String]](reg.roles.attributeName)
+                    .asScala
+                    .map(r => RudderRoles.findRoleByName(r).runNow)
+                    .flatten
+                    .toSet
+                } else {
+                  AuthBackendsLogger.warn(
+                    s"User '${rudder.getUsername}' returned information does not contain an attribute '${reg.roles.attributeName}' " +
+                    s"which is the one configured for custom role provisioning (see 'rudder.auth.oauth2.provider.$${idpID}.roles.attribute'" +
+                    s" value). Please check that the attribute name is correct and that requested scope provides that attribute."
+                  )
+                  Set.empty[Role]
+                }
               } catch {
                 case ex: Exception =>
                   AuthBackendsLogger.warn(

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/api/AuthBackendsApi.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/api/AuthBackendsApi.scala
@@ -39,6 +39,7 @@ package com.normation.plugins.authbackends.api
 
 import com.normation.plugins.authbackends.AuthBackendsRepository
 import com.normation.plugins.authbackends.JsonSerialization
+import com.normation.rudder.AuthorizationType
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction.GET
 import com.normation.rudder.rest.ApiModuleProvider
@@ -56,8 +57,6 @@ import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModule0
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
-import com.normation.rudder.AuthorizationType
-
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import net.liftweb.json._
@@ -77,8 +76,8 @@ object AuthBackendsApi       extends ApiModuleProvider[AuthBackendsApi] {
     val description    = "Get information about current authentication configuration"
     val (action, path) = GET / "authbackends" / "current-configuration"
 
-    override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
-    override def dataContainer: Option[String] = None
+    override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
+    override def dataContainer: Option[String]          = None
   }
 
   def endpoints = ca.mrvisser.sealerate.values[AuthBackendsApi].toList.sortBy(_.z)


### PR DESCRIPTION
https://issues.rudder.io/issues/24042

Test for the attribute existence in the map to provide a better warning log if it's missing: 
![image](https://github.com/Normation/rudder-plugins/assets/44649/62e3025c-a5b0-4ef0-8139-12878de71261)
