### PR TITLE
Fixes #24182: Add a role mapping and filtering for OIDC provided roles

### DIFF
--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -42,6 +42,7 @@ import bootstrap.liftweb.AuthenticationMethods
 import bootstrap.liftweb.RudderConfig
 import bootstrap.liftweb.RudderInMemoryUserDetailsService
 import bootstrap.liftweb.RudderProperties
+import com.normation.errors.IOResult
 import com.normation.plugins.RudderPluginModule
 import com.normation.plugins.authbackends.AuthBackendsLogger
 import com.normation.plugins.authbackends.AuthBackendsLoggerPure
@@ -61,6 +62,7 @@ import com.normation.rudder.domain.logger.PluginLogger
 import com.normation.rudder.users._
 import com.normation.zio._
 import com.typesafe.config.ConfigException
+import java.net.URI
 import java.util
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -81,6 +83,7 @@ import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMap
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationProvider
 import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient
 import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler
@@ -195,7 +198,6 @@ object AuthBackendsConf extends RudderPluginModule {
       new Oauth2LoginBanner(pluginStatusService, pluginDef.version, oauth2registrations)
     )
   }
-
 }
 
 /*
@@ -245,6 +247,7 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
         authenticationFilter.setAuthenticationFailureHandler(
           applicationContext.getBean("rudderWebAuthenticationFailureHandler").asInstanceOf[AuthenticationFailureHandler]
         )
+
         (authorizationRequestFilter, authenticationFilter)
       }
 
@@ -278,6 +281,8 @@ class AuthBackendsSpringConfiguration extends ApplicationContextAware {
       applicationContext.getAutowireCapableBeanFactory.configureBean(newSecurityChain, "mainHttpSecurityFilters")
     }
   }
+
+  @Bean def userRepository: UserRepository = RudderConfig.userRepository
 
   @Bean def rudderOauth2AuthSuccessHandler: AuthenticationSuccessHandler = new SimpleUrlAuthenticationSuccessHandler(
     "/secure/index.html"
@@ -550,8 +555,6 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
                   user
                     .getAttribute[java.util.ArrayList[String]](reg.roles.attributeName)
                     .asScala
-                    .map(r => RudderRoles.findRoleByName(r).runNow)
-                    .flatten
                     .toSet
                 } else {
                   AuthBackendsLogger.warn(
@@ -559,20 +562,53 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
                     s"which is the one configured for custom role provisioning (see 'rudder.auth.oauth2.provider.$${idpID}.roles.attribute'" +
                     s" value). Please check that the attribute name is correct and that requested scope provides that attribute."
                   )
-                  Set.empty[Role]
+                  Set.empty[String]
                 }
               } catch {
                 case ex: Exception =>
                   AuthBackendsLogger.warn(
                     s"Unable to get custom roles for user '${rudder.getUsername}' when looking for attribute '${reg.roles.attributeName}' :${ex.getMessage}'"
                   )
-                  Set.empty[Role]
+                  Set.empty[String]
               }
             }
 
-            if (custom.nonEmpty) {
+            // check if we have role mapping or restriction
+            val filteredRoles = if (reg.restrictRoleMapping) {
+              val f = custom.filter(r => reg.roleMapping.keySet.contains(r))
+              AuthBackendsLogger.debug(
+                s"IdP configuration enforce restriction to mapped role, resulting filtered list: [${f.mkString(", ")}]"
+              )
+              f
+            } else custom
+            AuthBackendsLogger.trace(
+              s"IdP configuration has registered role mapping: [${reg.roleMapping.toList.sorted.map(x => s"${x._1 -> x._2}").mkString("; ")}]"
+            )
+            val mappedRoles: Set[Role] = filteredRoles.flatMap { r =>
+              val role = reg.roleMapping.get(r) match {
+                // if the role is not in the mapping, use the provided name as is.
+                case None    => RudderRoles.findRoleByName(r)
+                case Some(m) =>
+                  AuthBackendsLogger.debug(
+                    s"Principal '${rudder.getUsername}': mapping IdP provided role '${r}' to Rudder role '${m}' "
+                  )
+                  RudderRoles
+                    .findRoleByName(m)
+                    .map(_.map(x => Role.Alias(x, r, s"Alias from ${reg.registration.getRegistrationId} IdP")))
+              }
+              role.runNow.orElse {
+                AuthBackendsLogger.debug(
+                  s"Role '${r}' does not match any Rudder role, ignoring it for user ${rudder.getUsername}"
+                )
+                None
+              }
+            }
+
+            if (mappedRoles.nonEmpty) {
               ApplicationLoggerPure.Authz.logEffect.info(
-                s"Principal '${rudder.getUsername}' role list extended with ${protocolName} provided roles: [${custom.toList.map(_.name).sorted.mkString(", ")}] (override: ${reg.roles.over})"
+                s"Principal '${rudder.getUsername}' role list extended with ${protocolName} provided roles: [${Role
+                    .toDisplayNames(mappedRoles)
+                    .mkString(", ")}] (override: ${reg.roles.over})"
               )
             } else {
               AuthBackendsLogger.debug(
@@ -582,9 +618,9 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
 
             val roles = if (reg.roles.over) {
               // override means: don't use user role configured in rudder-users.xml
-              custom
+              mappedRoles
             } else {
-              rudder.roles ++ custom
+              rudder.roles ++ mappedRoles
             }
             AuthBackendsLogger.debug(
               s"Principal '${rudder.getUsername}' final list of roles: [${roles.map(_.name).mkString(", ")}]"
@@ -637,6 +673,42 @@ class RudderOAuth2UserService(
       userRequest,
       new RudderOauth2Details(_, _)
     )
+  }
+}
+
+/*
+ * An utility to help build logout request to IdP
+ */
+object BuildLogout {
+  // will call by GET the given string and happening if possible "id_token_hint=${id_token}"
+  def build(registrationId: String, url: String, logoutRedirect: Option[String]): Authentication => IOResult[Option[URI]] = {
+    (authentication: Authentication) =>
+      {
+        authentication match {
+          case oauth2Token: OAuth2AuthenticationToken =>
+            for {
+              queryParam <- oauth2Token.getPrincipal match {
+                              case oidc: OidcUser =>
+                                val redirect = logoutRedirect match {
+                                  case None    => ""
+                                  case Some(u) => s"&post_logout_redirect_uri=${u}"
+                                }
+                                s"?id_token_hint=${oidc.getIdToken.getTokenValue}${redirect}".succeed
+                              case x =>
+                                AuthBackendsLoggerPure.debug(
+                                  s"That user kind of oauth2 token (${x}) does not provide a token_id"
+                                ) *>
+                                "".succeed
+                            }
+              // query IdP
+              fullUrl     = url + queryParam
+              _          <- AuthBackendsLoggerPure.debug(s"OAuth2/OIDC logout: calling remote URL for '${registrationId}': ${fullUrl}")
+              uri        <- IOResult.attempt(s"Error: bad redirect URL")(URI.create(fullUrl))
+            } yield Some(uri)
+          case x =>
+            AuthBackendsLoggerPure.debug(s"That kind of authentication (${x}) does not support remote logout") *> None.succeed
+        }
+      }
   }
 }
 

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/Oauth2Authentication.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/Oauth2Authentication.scala
@@ -34,6 +34,9 @@
 
 package com.normation.plugins.authbackends
 
+import bootstrap.liftweb.LogoutPostAction
+import bootstrap.liftweb.UserLogout
+import bootstrap.rudder.plugin.BuildLogout
 import cats.data.NonEmptyList
 import com.normation.errors._
 import com.typesafe.config.Config
@@ -71,17 +74,22 @@ final case class OIDCProvidedRole(enabled: Boolean, attributeName: String, over:
  * We never want to print the secret in logs, so override it.
  */
 final case class RudderClientRegistration(
-    registration: ClientRegistration,
-    infoMsg:      String,
-    roles:        OIDCProvidedRole,
-    provisioning: Boolean
+    registration:        ClientRegistration,
+    logoutUrl:           Option[String],
+    logoutRedirectUrl:   Option[String],
+    infoMsg:             String,
+    roles:               OIDCProvidedRole,
+    provisioning:        Boolean,
+    restrictRoleMapping: Boolean,
+    roleMapping:         Map[String, String]
 ) {
   override def toString: String = {
     toDebugStringWithSecret.replaceFirst("""clientSecret='([^']+?)'""", "clientSecret='*****'")
   }
 
   // avoid that in logs etc, use only for interactive debugging sessions
-  def toDebugStringWithSecret = s"""{${registration.toString}}, '${infoMsg}', roles: ${roles.toString}, user provisioning enabled: ${provisioning}"""
+  def toDebugStringWithSecret =
+    s"""{${registration.toString}}, '${infoMsg}', roles: ${roles.toString}, user provisioning enabled: ${provisioning}"""
 }
 
 /*
@@ -93,23 +101,27 @@ final case class RudderClientRegistration(
  */
 object RudderPropertyBasedOAuth2RegistrationDefinition {
 
-  val A_NAME            = "name"
-  val A_CLIENT_ID       = "client.id"
-  val A_CLIENT_SECRET   = "client.secret"
-  val A_CLIENT_REDIRECT = "client.redirect"
-  val A_AUTH_METHOD     = "authMethod"
-  val A_GRANT_TYPE      = "grantType"
-  val A_INFO_MESSAGE    = "ui.infoMessage"
-  val A_SCOPE           = "scope"
-  val A_URI_AUTH        = "uri.auth"
-  val A_URI_TOKEN       = "uri.token"
-  val A_URI_USER_INFO   = "uri.userInfo"
-  val A_URI_JWK_SET     = "uri.jwkSet"
-  val A_PIVOT_ATTR      = "userNameAttributeName"
-  val A_ROLES_ENABLED   = "roles.enabled"
-  val A_ROLES_ATTRIBUTE = "roles.attribute"
-  val A_ROLES_OVERRIDE  = "roles.override"
-  val A_PROVISIONING    = "enableProvisioning"
+  val A_NAME                 = "name"
+  val A_CLIENT_ID            = "client.id"
+  val A_CLIENT_SECRET        = "client.secret"
+  val A_CLIENT_REDIRECT      = "client.redirect"
+  val A_AUTH_METHOD          = "authMethod"
+  val A_GRANT_TYPE           = "grantType"
+  val A_INFO_MESSAGE         = "ui.infoMessage"
+  val A_SCOPE                = "scope"
+  val A_URI_AUTH             = "uri.auth"
+  val A_URI_TOKEN            = "uri.token"
+  val A_URI_USER_INFO        = "uri.userInfo"
+  val A_URI_JWK_SET          = "uri.jwkSet"
+  val A_URI_LOGOUT           = "uri.logout"
+  val A_URI_LOGOUT_REDIRECT  = "uri.logoutRedirect"
+  val A_PIVOT_ATTR           = "userNameAttributeName"
+  val A_ROLES_ENABLED        = "roles.enabled"
+  val A_ROLES_ATTRIBUTE      = "roles.attribute"
+  val A_ROLES_OVERRIDE       = "roles.override"
+  val A_ENFORCE_ROLE_MAPPING = "roles.mapping.restricted"
+  val A_ROLE_MAPPING         = "roles.mapping.entitlements"
+  val A_PROVISIONING         = "enableProvisioning"
 
   val authMethods = {
     import ClientAuthenticationMethod._
@@ -124,23 +136,27 @@ object RudderPropertyBasedOAuth2RegistrationDefinition {
   val baseProperty = "rudder.auth.oauth2.provider"
 
   val registrationAttributes = Map(
-    A_NAME            -> "human readable name to use in the button 'login with XXXX'",
-    A_CLIENT_ID       -> "id generated in the Oauth2 service provider to identify rudder as a client app",
-    A_CLIENT_SECRET   -> "the corresponding secret key",
-    A_CLIENT_REDIRECT -> "rudder URL to redirect to once authentication is done on the provider (must be resolvable from user browser)",
-    A_AUTH_METHOD     -> s"authentication method to use (${authMethods.map(_.getValue).mkString(",")})",
-    A_GRANT_TYPE      -> s"authorization grant type to use (${grantTypes.map(_.getValue).mkString(",")}",
-    A_INFO_MESSAGE    -> "message displayed in the login form, for example to tell the user what login he must use",
-    A_SCOPE           -> "data scope to request access to",
-    A_URI_AUTH        -> "provider URL to contact for main authentication (see provider documentation)",
-    A_URI_TOKEN       -> "provider URL to contact for token verification (see provider documentation)",
-    A_URI_USER_INFO   -> "provider URL to contact to get user information (see provider documentation)",
-    A_URI_JWK_SET     -> "provider URL to check signature of JWT token (see provider documentation)",
-    A_PIVOT_ATTR      -> "the attribute used to find local app user",
-    A_ROLES_ENABLED   -> "enable custom role extension by OIDC",
-    A_ROLES_ATTRIBUTE -> "the attribute to use for list of custom role name. It's content in token must be a array of strings.",
-    A_ROLES_OVERRIDE  -> "keep user configured roles in rudder-user.xml or override them with the one provided in the token",
-    A_PROVISIONING    -> "allows the automatic creation of users in Rudder in they successfully authenticate with OIDC"
+    A_NAME                 -> "human readable name to use in the button 'login with XXXX'",
+    A_CLIENT_ID            -> "id generated in the Oauth2 service provider to identify rudder as a client app",
+    A_CLIENT_SECRET        -> "the corresponding secret key",
+    A_CLIENT_REDIRECT      -> "rudder URL to redirect to once authentication is done on the provider (must be resolvable from user browser)",
+    A_AUTH_METHOD          -> s"authentication method to use (${authMethods.map(_.getValue).mkString(",")})",
+    A_GRANT_TYPE           -> s"authorization grant type to use (${grantTypes.map(_.getValue).mkString(",")}",
+    A_INFO_MESSAGE         -> "message displayed in the login form, for example to tell the user what login he must use",
+    A_SCOPE                -> "data scope to request access to",
+    A_URI_AUTH             -> "provider URL to contact for main authentication (see provider documentation)",
+    A_URI_TOKEN            -> "provider URL to contact for token verification (see provider documentation)",
+    A_URI_USER_INFO        -> "provider URL to contact to get user information (see provider documentation)",
+    A_URI_JWK_SET          -> "provider URL to check signature of JWT token (see provider documentation)",
+    A_URI_LOGOUT           -> "(optional) provider URL to logout and end session (see provider documentation).",
+    A_URI_LOGOUT_REDIRECT  -> "(optional) the redirect URL to provide to the IdP after logout",
+    A_PIVOT_ATTR           -> "the attribute used to find local app user",
+    A_ROLES_ENABLED        -> "enable custom role extension by OIDC",
+    A_ROLES_ATTRIBUTE      -> "the attribute to use for list of custom role name. It's content in token must be a array of strings.",
+    A_ROLES_OVERRIDE       -> "keep user configured roles in rudder-user.xml or override them with the one provided in the token",
+    A_PROVISIONING         -> "allows the automatic creation of users in Rudder in they successfully authenticate with OIDC",
+    A_ROLE_MAPPING         -> s"provide a map of alias `IdP role name` -> `Rudder role name`, where each IdP role name is a sub-key of '${A_ROLE_MAPPING}'",
+    A_ENFORCE_ROLE_MAPPING -> "if true (default), restricts roles available by the IdP to the role defined in mapping entitlement. Else the map provides alias for Rudder internal role names."
   )
 
   def parseAuthenticationMethod(method: String): PureResult[ClientAuthenticationMethod] = {
@@ -214,9 +230,29 @@ object RudderPropertyBasedOAuth2RegistrationDefinition {
         config.getString(path)
       )
     }
+
     def toBool(s: String) = s.toLowerCase match {
       case "true" => true
       case _      => false
+    }
+    def readMap(key: String): IOResult[Map[String, String]] = {
+      val path = baseProperty + "." + id + "." + key
+      import scala.jdk.CollectionConverters._
+      for {
+        keySet <- IOResult
+                    .attempt(s"Missing key '${path}' for OAUTH2 registration '${id}' (${registrationAttributes(key)})")(
+                      config.getConfig(path).entrySet().asScala.map(_.getKey()).toList
+                    )
+                    .catchAll(_ =>
+                      List().succeed
+                    ) // in that case, we suppose that the key is just missing so we return a default empty value for mapping
+        values <- ZIO.foreach(keySet) { key =>
+                    val wholeKey = path + "." + key
+                    IOResult.attempt(s"Error when reading role entitlement mapping '${wholeKey}'") {
+                      (key, config.getString(wholeKey))
+                    }
+                  }
+      } yield values.toMap
     }
 
     for {
@@ -233,10 +269,14 @@ object RudderPropertyBasedOAuth2RegistrationDefinition {
       uriUserInfo         <- read(A_URI_USER_INFO)
       pivotAttr           <- read(A_PIVOT_ATTR)
       jwkSetUri           <- read(A_URI_JWK_SET)
+      logoutUri           <- read(A_URI_LOGOUT).fold(_ => Option.empty[String], Some(_))
+      logoutUriRedirect   <- read(A_URI_LOGOUT_REDIRECT).fold(_ => Option.empty[String], Some(_))
       rolesEnabled        <- read(A_ROLES_ENABLED).catchAll(_ => "false".succeed)
       rolesAttr           <- read(A_ROLES_ATTRIBUTE).catchAll(_ => "".succeed)
       rolesOverride       <- read(A_ROLES_OVERRIDE).catchAll(_ => "false".succeed)
       provisioningAllowed <- read(A_PROVISIONING).catchAll(_ => "false".succeed)
+      enforceRoleMapping  <- read(A_ENFORCE_ROLE_MAPPING).catchAll(_ => "false".succeed)
+      roleMapping         <- readMap(A_ROLE_MAPPING)
     } yield {
       RudderClientRegistration(
         ClientRegistration
@@ -254,13 +294,17 @@ object RudderPropertyBasedOAuth2RegistrationDefinition {
           .clientName(name)
           .jwkSetUri(jwkSetUri)
           .build(),
+        logoutUri,
+        logoutUriRedirect,
         infoMessage,
         OIDCProvidedRole(
           toBool(rolesEnabled),
           rolesAttr,
           toBool(rolesOverride)
         ),
-        toBool(provisioningAllowed)
+        toBool(provisioningAllowed),
+        toBool(enforceRoleMapping),
+        roleMapping
       )
     }
   }
@@ -320,6 +364,19 @@ class RudderPropertyBasedOAuth2RegistrationDefinition(val registrations: Ref[Lis
     for {
       newOnes <- readAllRegistrations(config)
       _       <- registrations.set(newOnes)
+      // for each oauthRegistration, register a logout action
+      _       <- ZIO.foreach(newOnes) {
+                   case (id, r) =>
+                     r.logoutUrl match {
+                       case Some(url) =>
+                         val logoutAction =
+                           LogoutPostAction(s"oauth2_end_session:${id}", BuildLogout.build(id, url, r.logoutRedirectUrl))
+                         AuthBackendsLoggerPure.debug(s"Adding remote logout URL GET for '${id}'") *>
+                         UserLogout.logoutActions.update(_.appended(logoutAction))
+                       case None      =>
+                         AuthBackendsLoggerPure.debug(s"No remote logout URL configured for '${id}'")
+                     }
+                 }
     } yield ()
   }
 

--- a/auth-backends/src/test/scala/com/normation/plugins/authbackends/TestReadOidcConfig.scala
+++ b/auth-backends/src/test/scala/com/normation/plugins/authbackends/TestReadOidcConfig.scala
@@ -1,0 +1,87 @@
+/*
+ *************************************************************************************
+ * Copyright 2011 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.plugins.authbackends
+
+import com.normation.zio._
+import com.typesafe.config.ConfigFactory
+import java.io.StringReader
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestReadOidcConfig extends Specification {
+
+  val oidcConfig = {
+    """rudder.auth.oauth2.provider.registrations=someidp
+      |rudder.auth.oauth2.provider.someidp.name=Some ID
+      |rudder.auth.oauth2.provider.someidp.ui.infoMessage="Hey, log in to Some Idp!"
+      |rudder.auth.oauth2.provider.someidp.client.id=xxxClientIdxxx
+      |rudder.auth.oauth2.provider.someidp.client.secret=xxxClientPassxxx
+      |rudder.auth.oauth2.provider.someidp.scope=openid email profile groups
+      |rudder.auth.oauth2.provider.someidp.userNameAttributeName=email
+      |rudder.auth.oauth2.provider.someidp.uri.auth="https://someidp/oauth2/v1/authorize"
+      |rudder.auth.oauth2.provider.someidp.uri.token="https://someidp/oauth2/v1/token"
+      |rudder.auth.oauth2.provider.someidp.uri.userInfo="https://someidp/oauth2/v1/userinfo"
+      |rudder.auth.oauth2.provider.someidp.uri.jwkSet="https://someidp/oauth2/v1/keys"
+      |rudder.auth.oauth2.provider.someidp.client.redirect="{baseUrl}/login/oauth2/code/{registrationId}"
+      |rudder.auth.oauth2.provider.someidp.grantType=authorization_code
+      |rudder.auth.oauth2.provider.someidp.authMethod=basic
+      |rudder.auth.oauth2.provider.someidp.roles.enabled=true
+      |rudder.auth.oauth2.provider.someidp.roles.attribute=customroles
+      |rudder.auth.oauth2.provider.someidp.roles.override=true
+      |rudder.auth.oauth2.provider.someidp.roles.mapping.enforced=true
+      |rudder.auth.oauth2.provider.someidp.roles.mapping.entitlements.rudder_admin=administrator
+      |rudder.auth.oauth2.provider.someidp.roles.mapping.entitlements.rudder_readonly=readonly
+      |rudder.auth.oauth2.provider.someidp.enableProvisioning=true
+      |""".stripMargin
+  }
+
+  val config = ConfigFactory.parseReader(new StringReader(oidcConfig))
+  val regs   = RudderPropertyBasedOAuth2RegistrationDefinition.readAllRegistrations(config).runNow.toMap
+
+  "reading the configuration should works" >> {
+    regs.keySet === Set("someidp")
+  }
+
+  "we should have two entitlement mapping" >> {
+    regs("someidp").roleMapping === Map(
+      "rudder_admin"    -> "administrator",
+      "rudder_readonly" -> "readonly"
+    )
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/24182

This PR provides two main things: 
- a way to map IdP provided roles to rudder internal roles, and optionnally to restrict IdP addressable roles to only the mapped one
- configuration option to use IdP Single Log Out by configuring a logout url (and post logout redirect url)

The code is not very interesting and mostly deals with adding option, reading them, logs and spring workaround. 

For role, we just have a new layer of mapping that uses the `Alias` role. 
For redirect, we just have a new `PostLogoutAction` that build the correct URL (the main changes are in rudder). 
