### PR TITLE
Fixes #24184: User management roles and permissions are intermingled in the UI

### DIFF
--- a/user-management/src/main/elm/sources/ApiCalls.elm
+++ b/user-management/src/main/elm/sources/ApiCalls.elm
@@ -6,10 +6,10 @@ module ApiCalls exposing (..)
 -- API call to get the category tree
 
 
-import DataTypes exposing (AddUserForm, Authorization, Model, Msg(..), User)
+import DataTypes exposing (AddUserForm, Model, Msg(..))
 import Http exposing (emptyBody, expectJson, jsonBody, request, send)
-import JsonDecoder exposing (decodeApiAddUserResult, decodeApiCurrentUsersConf, decodeApiDeleteUserResult, decodeApiReloadResult, decodeApiRoleCoverage, decodeApiUpdateUserResult, decodeGetRoleApiResult)
-import JsonEncoder exposing (encodeAddUser, encodeAuthorization)
+import JsonDecoder exposing (decodeApiAddUserResult, decodeApiCurrentUsersConf, decodeApiDeleteUserResult, decodeApiReloadResult, decodeApiUpdateUserResult, decodeGetRoleApiResult)
+import JsonEncoder exposing (encodeAddUser)
 
 getUrl: DataTypes.Model -> String -> String
 getUrl m url =
@@ -47,22 +47,6 @@ postReloadConf model =
                 }
     in
     send PostReloadUserInfo req
-
-computeRoleCoverage : Model -> Authorization -> Cmd Msg
-computeRoleCoverage model authorizations =
-    let
-        req =
-            request
-                { method          = "POST"
-                , headers         = []
-                , url             = getUrl model "/usermanagement/coverage"
-                , body            = jsonBody (encodeAuthorization authorizations)
-                , expect          = expectJson decodeApiRoleCoverage
-                , timeout         = Nothing
-                , withCredentials = False
-                }
-    in
-    send ComputeRoleCoverage req
 
 addUser : Model -> AddUserForm -> Cmd Msg
 addUser model userForm =

--- a/user-management/src/main/elm/sources/DataTypes.elm
+++ b/user-management/src/main/elm/sources/DataTypes.elm
@@ -87,7 +87,7 @@ type alias Model =
     , login : String
     , isHashedPasswd : Bool
     , isValidInput : StateInput
-    , rolesToAddOnSave : List String --TODO: it's roles and not "authz" here
+    , rolesToAddOnSave : List String
     , providers : List String
     , userForcePasswdInput : Bool
     , openDeleteModal : Bool

--- a/user-management/src/main/elm/sources/Init.elm
+++ b/user-management/src/main/elm/sources/Init.elm
@@ -1,7 +1,7 @@
 module Init exposing (..)
 
 import ApiCalls exposing (getUsersConf)
-import DataTypes exposing (Authorization, Model, Msg(..), PanelMode(..), RoleListOverride(..), StateInput(..))
+import DataTypes exposing (Model, Msg(..), PanelMode(..), RoleListOverride(..), StateInput(..))
 import Dict exposing (fromList)
 import Html.Attributes exposing (style)
 import Http
@@ -12,14 +12,10 @@ subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.none
 
-authorizations : Authorization
-authorizations =
-    {permissions = [], custom = []}
-
 init : { contextPath : String } -> ( Model, Cmd Msg )
 init flags =
     let
-        initModel = Model flags.contextPath "" (fromList []) (fromList []) [] None authorizations Toasty.initialState Closed "" "" True ValidInputs [] [] False False
+        initModel = Model flags.contextPath "" (fromList []) (fromList []) [] None Toasty.initialState Closed "" "" True ValidInputs [] [] False False
     in
     ( initModel
     , getUsersConf initModel

--- a/user-management/src/main/elm/sources/JsonDecoder.elm
+++ b/user-management/src/main/elm/sources/JsonDecoder.elm
@@ -1,6 +1,6 @@
 module JsonDecoder exposing (..)
 
-import DataTypes exposing (Authorization, Role, RoleConf, RoleListOverride(..), User, UsersConf)
+import DataTypes exposing (Role, RoleConf, RoleListOverride(..), User, UsersConf)
 import Json.Decode as D exposing (Decoder)
 import Json.Decode.Pipeline exposing (required)
 
@@ -43,21 +43,8 @@ decodeUser =
         |> required "login" D.string
         |> required "authz" (D.list <| D.string)
         |> required "permissions" (D.list <| D.string)
-
-decodeApiRoleCoverage : Decoder Authorization
-decodeApiRoleCoverage =
-    D.at [ "data" ] decodeRoleCoverage
-
-decodeRoleCoverage : Decoder Authorization
-decodeRoleCoverage =
-    let
-        response =
-            D.succeed Authorization
-                |> required "permissions" (D.list <| D.string)
-                |> required "custom" (D.list <| D.string)
-    in
-        D.at [ "coverage" ] response
-
+        |> required "rolesCoverage" (D.list <| D.string)
+        |> required "customRights" (D.list <| D.string)
 
 decodeApiAddUserResult : Decoder String
 decodeApiAddUserResult =

--- a/user-management/src/main/elm/sources/JsonEncoder.elm
+++ b/user-management/src/main/elm/sources/JsonEncoder.elm
@@ -1,23 +1,14 @@
 module JsonEncoder exposing (..)
 
-import DataTypes exposing (AddUserForm, Authorization, User)
+import DataTypes exposing (AddUserForm, User)
 import Json.Encode exposing (Value, bool, list, object, string)
-import String
-
-encodeAuthorization: Authorization -> Value
-encodeAuthorization authorizations =
-    object
-    [ ("action", string "rolesCoverageOnRights")
-    , ("permissions", list (\s -> string s) authorizations.permissions)
-    , ("authz", list (\s -> string s) authorizations.permissions)
-    ]
 
 encodeUser: (User, String) -> Value
 encodeUser (user, password) =
     object
     [ ("username", string user.login)
     , ("password", string password)
-    , ("permissions", list (\s -> string s) (user.authz ++  user.permissions))
+    , ("permissions", list (\s -> string s) (user.authz ++  user.roles))
     ]
 
 encodeAddUser: AddUserForm -> Value
@@ -25,6 +16,6 @@ encodeAddUser userForm =
     object
     [ ("username", string userForm.user.login)
     , ("password", string userForm.password)
-    , ("permissions", list (\s -> string s) (userForm.user.authz ++  userForm.user.permissions))
+    , ("permissions", list (\s -> string s) (userForm.user.authz ++  userForm.user.roles))
     , ("isPreHashed", bool userForm.isPreHashed)
     ]

--- a/user-management/src/main/elm/sources/View.elm
+++ b/user-management/src/main/elm/sources/View.elm
@@ -219,7 +219,7 @@ displayCoverageRoles user =
                 , div [class "callout-fade callout-info"]
                 [
                       div[class "marker"][span[class "glyphicon glyphicon-info-sign"][]]
-                    , text "Roles that are also included with the authorizations of this user. You can add them explicitly to user roles without changing user authorizations."
+                    , text "Roles that are also included with the authorizations of this user. You can add them explicitly to user roles, and user authorizations will remain the same."
                 ]
                 , div [class "role-management-wrapper"] 
                 [
@@ -239,7 +239,7 @@ displayAuthorizations user =
             div [class "row-foldable row-folded"]
             [
                   h4 [class "role-title"][text "Authorizations"]
-                , text "Current rights of the user."
+                , text "Current rights of the user :"
                 , div [class "role-management-wrapper"]
                 [
                     div[id "input-role"](userAuthz)

--- a/user-management/src/main/resources/toserve/usermanagement/user-management.css
+++ b/user-management/src/main/resources/toserve/usermanagement/user-management.css
@@ -94,6 +94,13 @@ h3 {
   margin-right   : auto;
 }
 
+.list-auths {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  row-gap: 5px;
+}
+
 .list-auths-empty {
   color   : grey;
   opacity : 0.3;
@@ -108,7 +115,7 @@ h3 {
   padding          : 5px;
   text-align       : center;
   text-decoration  : none;
-  margin           : 5px;
+  margin           : 0 5px;
   border-radius    : 3px;
 }
 
@@ -324,6 +331,7 @@ h3 {
   display: flex;
   flex-direction: row;
   justify-content: end;
+  margin-top: 60px;
 }
 .btn-container .btn-save .fa{
   margin-left: 6px;
@@ -367,10 +375,6 @@ h3 {
   margin  : 10px 0 25px 0;
 }
 
-#input-role > .auth {
-  margin-bottom : 0;
-}
-
 .role-title {
   margin-top:45px;
 }
@@ -384,7 +388,8 @@ h3 {
   border-radius : 3px;
   display       : flex;
   flex-flow     : row wrap;
-
+  row-gap       : 5px;
+  padding       : 5px 0;
 }
 .card-header {
   padding : 5px;
@@ -514,4 +519,8 @@ h3 {
 }
 .hash-type {
   display:inline-block;
+}
+
+.panel hr {
+  margin-top: 40px;
 }

--- a/user-management/src/test/resources/usermanagement_api/api_usermanagement.yml
+++ b/user-management/src/test/resources/usermanagement_api/api_usermanagement.yml
@@ -14,27 +14,78 @@ response:
         "users" : [
           {
             "login" : "user1",
-            "authz" : [],
+            "authz" : [
+              "configuration_edit",
+              "configuration_read",
+              "configuration_write",
+              "directive_edit",
+              "directive_read",
+              "directive_write",
+              "group_edit",
+              "group_read",
+              "group_write",
+              "node_edit",
+              "node_read",
+              "node_write",
+              "parameter_edit",
+              "parameter_read",
+              "parameter_write",
+              "rule_edit",
+              "rule_read",
+              "rule_write",
+              "technique_edit",
+              "technique_read",
+              "technique_write",
+              "userAccount_edit",
+              "userAccount_read",
+              "userAccount_write"
+            ],
             "permissions" : [
+              "user"
+            ],
+            "rolesCoverage" : [
               "inventory",
               "configuration",
               "rule_only",
               "user"
-            ]
+            ],
+            "customRights" : []
           },
           {
             "login" : "user2",
-            "authz" : [],
+            "authz" : [
+              "administration_read",
+              "compliance_read",
+              "configuration_read",
+              "deployer_read",
+              "deployment_read",
+              "directive_read",
+              "group_read",
+              "node_read",
+              "parameter_read",
+              "rule_read",
+              "technique_read",
+              "userAccount_edit",
+              "userAccount_read",
+              "userAccount_write",
+              "validator_read"
+            ],
             "permissions" : [
+              "read_only"
+            ],
+            "rolesCoverage" : [
               "inventory",
               "read_only",
               "rule_only"
-            ]
+            ],
+            "customRights" : []
           },
           {
             "login" : "user3",
             "authz" : [],
-            "permissions" : []
+            "permissions" : [],
+            "rolesCoverage" : [],
+            "customRights" : []
           }
         ]
       }

--- a/user-management/src/test/scala/com/normation/plugins/usermanagement/RoleComputationTest.scala
+++ b/user-management/src/test/scala/com/normation/plugins/usermanagement/RoleComputationTest.scala
@@ -22,12 +22,21 @@ class RoleComputationTest extends Specification {
     }
 
     "return 'None' when authzs contains no_rights" in {
-      (computeRoleCoverage(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)), Set(AuthorizationType.NoRights)) must beNone) and
-      (computeRoleCoverage(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)), Set(AuthorizationType.NoRights) ++ AuthorizationType.allKind) must beNone)
+      (computeRoleCoverage(
+        Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)),
+        Set(AuthorizationType.NoRights)
+      ) must beNone) and
+      (computeRoleCoverage(
+        Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)),
+        Set(AuthorizationType.NoRights) ++ AuthorizationType.allKind
+      ) must beNone)
     }
 
     "return a 'Custom' role for empty intersection" in {
-      computeRoleCoverage(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)), Set(AuthorizationType.Compliance.Read)) must beEqualTo(
+      computeRoleCoverage(
+        Set(Role.allBuiltInRoles(Role.BuiltinName.User.value)),
+        Set(AuthorizationType.Compliance.Read)
+      ) must beEqualTo(
         Some(Set(Role.forRight(AuthorizationType.Compliance.Read)))
       )
     }
@@ -36,7 +45,9 @@ class RoleComputationTest extends Specification {
       computeRoleCoverage(
         Role.allBuiltInRoles.values.toSet,
         Set(AuthorizationType.Compliance.Read) ++ Role.allBuiltInRoles(Role.BuiltinName.Inventory.value).rights.authorizationTypes
-      ) must beEqualTo(Some(Set(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value), Role.forRight(AuthorizationType.Compliance.Read))))
+      ) must beEqualTo(
+        Some(Set(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value), Role.forRight(AuthorizationType.Compliance.Read)))
+      )
     }
 
     "only detect 'Inventory' role" in {
@@ -68,8 +79,13 @@ class RoleComputationTest extends Specification {
     "allows intersection between know roles" in {
       computeRoleCoverage(
         Set(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value), Role.allBuiltInRoles(Role.BuiltinName.User.value)),
-        Role.allBuiltInRoles(Role.BuiltinName.User.value).rights.authorizationTypes ++ Role.allBuiltInRoles(Role.BuiltinName.Inventory.value).rights.authorizationTypes
-      ) must beEqualTo(Some(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value), Role.allBuiltInRoles(Role.BuiltinName.Inventory.value))))
+        Role
+          .allBuiltInRoles(Role.BuiltinName.User.value)
+          .rights
+          .authorizationTypes ++ Role.allBuiltInRoles(Role.BuiltinName.Inventory.value).rights.authorizationTypes
+      ) must beEqualTo(
+        Some(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value), Role.allBuiltInRoles(Role.BuiltinName.Inventory.value)))
+      )
     }
 
     "ignore NoRights role" in {
@@ -77,6 +93,25 @@ class RoleComputationTest extends Specification {
         Set(Role.NoRights, Role.allBuiltInRoles(Role.BuiltinName.User.value)),
         Role.allBuiltInRoles(Role.BuiltinName.User.value).rights.authorizationTypes
       ) must beEqualTo(Some(Set(Role.allBuiltInRoles(Role.BuiltinName.User.value))))
+    }
+
+    "compute inventory read_only role with a rule_only right added" in {
+      computeRoleCoverage(
+        Role.allBuiltInRoles.values.toSet,
+        Role
+          .allBuiltInRoles(Role.BuiltinName.Inventory.value)
+          .rights
+          .authorizationTypes ++
+        Role.allBuiltInRoles(Role.BuiltinName.ReadOnly.value).rights.authorizationTypes
+      ) must beEqualTo(
+        Some(
+          Set(
+            Role.allBuiltInRoles(Role.BuiltinName.Inventory.value),
+            Role.allBuiltInRoles(Role.BuiltinName.ReadOnly.value),
+            Role.allBuiltInRoles(Role.BuiltinName.RuleOnly.value)
+          )
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/24184

Basically we change the API format to separate _roles_ and _authorizations_, and also to add some fields, now the meaning of the fields are :
* `permissions` : roles only, without any authorizations
* `authz` : all authorizations (or "rights" if you prefer) associated with the `permissions`
* `rolesCoverage` : all inferred roles from all user authorizations, a superset of `permissions`
* `customRights` : set of custom authorizations that were manually added (not related to any `permissions`)

In the UI we add a "readonly section" (below the "Delete" and "Save" buttons to edit the user), in which we display the authorizations and the inferred roles (the roles can still be edited in the same field as before) :

![image](https://github.com/Normation/rudder-plugins/assets/65616064/3f877a8f-b1ca-4f58-bb79-b35467941edb)


Now the UI is more consistent, we can remove only remove roles from the UI, and the related information will update accordingly.
But we still need to add/remove custom rights from the users file, it's the desired behavior because ideally they should be defined in custom roles.