### PR TITLE
Fixes #24185: Group repository in tests should get by ids

### DIFF
--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/MockServices.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/MockServices.scala
@@ -93,6 +93,7 @@ class MockSupervisedTargets(unsupervisedDir: File, unsupervisedFilename: String,
     override def getNodeGroupOpt(id: NodeGroupId):                      IOResult[Option[(NodeGroup, NodeGroupCategoryId)]]                = ???
     override def getNodeGroupCategory(id: NodeGroupId):                 IOResult[NodeGroupCategory]                                       = ???
     override def getAll():                                              IOResult[Seq[NodeGroup]]                                          = ???
+    override def getAllByIds(ids: Seq[NodeGroupId]):                    IOResult[Seq[com.normation.rudder.domain.nodes.NodeGroup]]        = ???
     override def getAllNodeIds():                                       IOResult[Map[NodeGroupId, Set[NodeId]]]                           = ???
     override def getAllNodeIdsChunk():                                  IOResult[Map[NodeGroupId, Chunk[NodeId]]]                         = ???
     override def getGroupsByCategory(


### PR DESCRIPTION
https://issues.rudder.io/issues/24185

Needed to compile tests since https://github.com/Normation/rudder/pull/5298/files#diff-2d8cf21151c3dfe2e8774dfec8128c71392431cc0256299979b9843ba24dba4fR241