### PR TITLE
Fixes #24187: Users cards are not evenly aligned and leave some blank space 

### DIFF
--- a/user-management/src/main/elm/sources/View.elm
+++ b/user-management/src/main/elm/sources/View.elm
@@ -292,12 +292,12 @@ displayUsersConf model u =
                 , newUserMenu
                 , panel
             ]
-            , div [ class "col-xs-12 user-list" ][ div [ class "row " ] users ]
+            , div [ class "col-xs-12" ][ div [ class "row user-list" ] users ]
         ]
 
 displayUser : User -> Html Msg
 displayUser user =
-    div [class "user-card-wrapper", onClick (ActivePanelSettings user)]
+    div [class "user-card-wrapper col-xs-6 col-md-4 col-lg-3", onClick (ActivePanelSettings user)]
     [
         div [class "user-card"]
         [

--- a/user-management/src/main/resources/toserve/usermanagement/user-management.css
+++ b/user-management/src/main/resources/toserve/usermanagement/user-management.css
@@ -44,6 +44,12 @@
   font-size   : 14px;
 }
 
+.user-list {
+  display        : flex;
+  flex-wrap      : wrap;
+  justify-content: flex-start;
+}
+
 .user-card {
   float          : left;
   width          : 49%;
@@ -52,7 +58,7 @@
   border-line    : 2px;
   padding-bottom : 10px;
   border-radius  : 8px;
-  width          : 300px;
+  width          : 100%;
   background     : #fff;
   text-align     : center;
   box-shadow     : 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
@@ -64,7 +70,8 @@
 }
 
 .user-card-wrapper {
-  cursor:pointer;
+  width : 300px;
+  cursor : pointer;
 }
 
 .user-card-inner {
@@ -88,7 +95,6 @@ h3 {
   color          : #3a3a3a;
   padding-bottom : 15px;
   word-wrap      : break-word;
-  width          : 260px;
   text-align     : center;
   margin-left    : auto;
   margin-right   : auto;


### PR DESCRIPTION
https://issues.rudder.io/issues/24187

This fix uses the grid system of Bootstrap 3 which has changed in Bootstrap 5 so we will do another fix for the 8.1 branch