### PR TITLE
Fixes #24191: Make version of backport branch ok for rudder-package

### DIFF
--- a/main-build.conf
+++ b/main-build.conf
@@ -15,5 +15,9 @@
 # It defined the API/ABI used and it is important for binary compatibility
 branch-type=nightly
 rudder-version=7.3.12-backport-24146
+# Uncomment following variable if you want to set the value of rudder version in the
+# metadata file to a different value than rudder-version, for ex when rudder-version
+# does not follow the standard naming scheme and rudder-package refuse a plugin with it. 
+rudder-rpkg-version=7.3.12
 common-version=2.1.1
 private-version=2.1.0

--- a/makefiles/global-vars.mk
+++ b/makefiles/global-vars.mk
@@ -7,6 +7,7 @@ RUDDER_VERSION  = $(shell sed -ne '/^rudder-version=/s/rudder-version=//p' $(MAI
 BRANCH_TYPE     = $(shell sed -ne '/^branch-type=/s/branch-type=//p' $(MAIN_BUILD))
 COMMON_VERSION  = $(shell sed -ne '/^common-version=/s/common-version=//p' $(MAIN_BUILD))
 PRIVATE_VERSION = $(shell sed -ne '/^private-version=/s/private-version=//p' $(MAIN_BUILD))
+RUDDER_RPKG_VERSION = $(shell sed -ne '/^rudder-rpkg-version=/s/rudder-rpkg-version=//p' $(MAIN_BUILD))
 
 ifneq (,$(wildcard ./build.conf))
 PLUGIN_VERSION   = $(shell sed -ne '/^plugin-version=/s/plugin-version=//p' build.conf)
@@ -19,16 +20,16 @@ LIB_PUBLIC_NAME = plugins-parent
 LIB_PRIVATE_VERSION = ${PRIVATE_VERSION}
 LIB_PUBLIC_VERSION = ${COMMON_VERSION}
 
-VERSION = ${RUDDER_VERSION}-${PLUGIN_VERSION}
+VERSION = ${RUDDER_RPKG_VERSION:=RUDDER_VERSION}-${PLUGIN_VERSION}
 PLUGIN_POM_VERSION = $(RUDDER_VERSION)-${PLUGIN_VERSION}
 RUDDER_BUILD_VERSION = $(RUDDER_VERSION)
 ifeq ($(BRANCH_TYPE),nightly)
-VERSION = ${RUDDER_VERSION}-${PLUGIN_VERSION}-nightly
+VERSION = ${RUDDER_RPKG_VERSION}-${PLUGIN_VERSION}-nightly
 PLUGIN_POM_VERSION = $(RUDDER_VERSION)-${PLUGIN_VERSION}-SNAPSHOT
 endif
 ifeq ($(BRANCH_TYPE),next)
 PLUGIN_POM_VERSION = $(RUDDER_VERSION)-${PLUGIN_VERSION}-SNAPSHOT
-VERSION = ${RUDDER_VERSION}-${PLUGIN_VERSION}-nightly
+VERSION = ${RUDDER_RPKG_VERSION}-${PLUGIN_VERSION}-nightly
 RUDDER_BUILD_VERSION = $(RUDDER_VERSION)-SNAPSHOT
 endif
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24191

Add a variable for the version to use in rpdk metadata so that rudder package is happy. It's not a solid way to do it, we should avoid to port it to 7.3 branch when merging - but at least, it will be easy to find/correct if merged in main branches by error.