### PR TITLE
Fixes #24206: We need an option to force validation of change requests

### DIFF
--- a/change-validation/src/main/resources/template/ChangeValidationManagement.html
+++ b/change-validation/src/main/resources/template/ChangeValidationManagement.html
@@ -194,6 +194,49 @@
                       </div>
                     </div>
                   </div>
+                  <lift:authz role="administration_write">
+                  <br>
+                  <div data-lift="ChangeValidationSettings.validation">
+                    <div class="section-with-doc">
+                      <div class="section-left">
+                        <form class="lift:form.ajax">
+                          <ul>
+                            <li class="rudder-form">
+                              <div class="input-group">
+                                <label class="input-group-addon" for="validationAutoValidatedUser">
+                                  <input type="checkbox" value="Reload" id="validationAutoValidatedUser"/>
+                                  <label for="validationAutoValidatedUser" class="label-radio">
+                                    <span class="ion ion-checkmark-round"></span>
+                                  </label>
+                                  <span class="ion ion-checkmark-round check-icon"></span>
+                                </label>
+                                <label class="form-control" for="validationAutoValidatedUser">
+                                  Validate all changes
+                                </label>
+                              </div>
+                            </li>
+                          </ul>
+                          <input type="submit" value="Save change" id="validationAutoSubmit"/>
+                          <span class="lift:Msg?id=updateValidation">[messages]</span>
+                        </form>
+                      </div>
+                      <div class="section-right">
+                        <div class="doc doc-info">
+                          <div class="marker">
+                            <span class="fa fa-info-circle"></span>
+                          </div>
+                          <p>
+                            Any change done by a Validated User will be automaticaly approved no matter the nature of the change.
+                          </p>
+                          <p>
+                            Configuring groups below will hence have no effect on validated users (in the list above), but will apply to non-validated users, who will still need a change request to modify a node from a supervised group.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                    
+                  </div>
+                  </lift:authz>
                   <div>
                   <h3 class="page-subtitle">Configure Groups with Change Validations</h3>
                   <div class="section-with-doc">

--- a/change-validation/src/main/scala/bootstrap/rudder/plugin/ChangeValidationConf.scala
+++ b/change-validation/src/main/scala/bootstrap/rudder/plugin/ChangeValidationConf.scala
@@ -44,7 +44,6 @@ import bootstrap.liftweb.RudderConfig.restDataSerializer
 import bootstrap.liftweb.RudderConfig.restExtractorService
 import bootstrap.liftweb.RudderConfig.techniqueRepository
 import bootstrap.liftweb.RudderConfig.workflowLevelService
-
 import com.normation.box._
 import com.normation.eventlog.EventActor
 import com.normation.plugins.PluginStatus
@@ -90,7 +89,6 @@ import com.normation.rudder.services.workflows.NodeGroupChangeRequest
 import com.normation.rudder.services.workflows.RuleChangeRequest
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.services.workflows.WorkflowService
-
 import java.nio.file.Paths
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
@@ -105,6 +103,7 @@ class ChangeValidationWorkflowLevelService(
     validationWorkflowService: TwoValidationStepsWorkflowServiceImpl,
     validationNeeded:          Seq[ValidationNeeded],
     workflowEnabledByUser:     () => Box[Boolean],
+    alwaysNeedValidation:      () => Box[Boolean],
     validatedUserRepo:         RoValidatedUserRepository
 ) extends WorkflowLevelService {
 
@@ -144,7 +143,8 @@ class ChangeValidationWorkflowLevelService(
       change:  T
   ): Box[WorkflowService] = {
     def getWorkflowAux = {
-      getWorkflow(validationNeeded.foldLeft(Full(false): Box[Boolean]) {
+      // When we "always need validation", we ignore all validationNeeded checks, otherwise we validate using these checks
+      getWorkflow(validationNeeded.foldLeft(alwaysNeedValidation()) {
         case (shouldValidate, nextCheck) =>
           shouldValidate.flatMap {
             // logic is "or": if previous should validate is true, don't check following
@@ -286,6 +286,7 @@ object ChangeValidationConf extends RudderPluginModule {
         )
       ),
       () => RudderConfig.configService.rudder_workflow_enabled().toBox,
+      () => RudderConfig.configService.rudder_workflow_validate_all().toBox,
       roValidatedUserRepository
     )
   )


### PR DESCRIPTION
https://issues.rudder.io/issues/24206

We use the configuration from https://github.com/Normation/rudder/pull/5404.

The checkbox behaves the same as the ones for enabling/disabling change requests :
![image](https://github.com/Normation/rudder/assets/65616064/10be224b-fd54-4c1f-9254-f186c32806ae)