### PR TITLE
Fixes #24296: Log on user api authorizations should use a debug string for ACL

### DIFF
--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -654,10 +654,11 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
       }
       .toList
 
+    val apiAuthz    = ApiAuthorization.ACL(acls)
     val userDetails = rudder
-      .copy(roles = roles, apiAuthz = ApiAuthorization.ACL(acls))
+      .copy(roles = roles, apiAuthz = apiAuthz)
     AuthBackendsLogger.debug(
-      s"Principal '${rudder.getUsername}' final roles: [${roles.map(_.name).mkString(", ")}], and API authz: ${userDetails.apiAuthz}"
+      s"Principal '${rudder.getUsername}' final roles: [${roles.map(_.name).mkString(", ")}], and API authz: ${apiAuthz.debugString}"
     )
     // we need to update roles in all cases
     userBuilder(user, userDetails)


### PR DESCRIPTION
https://issues.rudder.io/issues/24296

This depends on the `debugString` method introduced in https://github.com/Normation/rudder/pull/5414