### PR TITLE
Fixes #24298: Display current session permission and split appart form to update user details

### DIFF
--- a/user-management/src/main/elm/sources/ApiCalls.elm
+++ b/user-management/src/main/elm/sources/ApiCalls.elm
@@ -6,11 +6,10 @@ module ApiCalls exposing (..)
 -- API call to get the category tree
 
 
-import DataTypes exposing (AddUserForm, Model, Msg(..), Username)
+import DataTypes exposing (AddUserForm, Model, Msg(..), Username, UserInfoForm, UserAuth)
 import Http exposing (emptyBody, expectJson, jsonBody, request, send)
-import JsonDecoder exposing (decodeApiAddUserResult, decodeApiCurrentUsersConf, decodeApiDeleteUserResult, decodeApiReloadResult, decodeApiUpdateUserResult, decodeGetRoleApiResult)
-import JsonEncoder exposing (encodeAddUser)
-import JsonDecoder exposing (decodeApiStatusResult)
+import JsonDecoder exposing (decodeApiAddUserResult, decodeApiCurrentUsersConf, decodeApiDeleteUserResult, decodeApiReloadResult, decodeApiUpdateUserResult, decodeGetRoleApiResult, decodeApiStatusResult, decodeApiUpdateUserInfoResult)
+import JsonEncoder exposing (encodeAddUser, encodeUserInfo, encodeUserAuth)
 import Json.Decode as Decode
 
 getUrl: DataTypes.Model -> String -> String
@@ -82,7 +81,7 @@ deleteUser  username model =
     in
     send DeleteUser req
 
-updateUser : Model -> String -> AddUserForm -> Cmd Msg
+updateUser : Model -> String -> UserAuth -> Cmd Msg
 updateUser model toUpdate userForm =
     let
         req =
@@ -90,13 +89,30 @@ updateUser model toUpdate userForm =
                 { method          = "POST"
                 , headers         = []
                 , url             = getUrl model ("/usermanagement/update/" ++ toUpdate)
-                , body            = jsonBody (encodeAddUser userForm)
+                , body            = jsonBody (encodeUserAuth userForm)
                 , expect          = expectJson decodeApiUpdateUserResult
                 , timeout         = Nothing
                 , withCredentials = False
                 }
     in
     send UpdateUser req
+
+updateUserInfo : Model -> String -> UserInfoForm -> Cmd Msg
+updateUserInfo model toUpdate userForm =
+    let
+        req =
+            request
+                { method          = "POST"
+                , headers         = []
+                , url             = getUrl model ("/usermanagement/update/info/" ++ toUpdate)
+                , body            = jsonBody (encodeUserInfo userForm)
+                , expect          = expectJson decodeApiUpdateUserInfoResult
+                , timeout         = Nothing
+                , withCredentials = False
+                }
+    in
+    send UpdateUserInfo req
+
 
 activateUser : Model -> Username -> Cmd Msg
 activateUser model username =

--- a/user-management/src/main/elm/sources/Init.elm
+++ b/user-management/src/main/elm/sources/Init.elm
@@ -1,7 +1,7 @@
 module Init exposing (..)
 
 import ApiCalls exposing (getUsersConf)
-import DataTypes exposing (Model, Msg(..), PanelMode(..), RoleListOverride(..), StateInput(..), UserForm, UI)
+import DataTypes exposing (Model, Msg(..), PanelMode(..), RoleListOverride(..), StateInput(..), UserForm, UI, UserInfoForm)
 import Dict exposing (fromList)
 import Html.Attributes exposing (style)
 import Http
@@ -16,7 +16,8 @@ init : { contextPath : String } -> ( Model, Cmd Msg )
 init flags =
     let
         initUi = UI Closed False
-        initUserForm = UserForm "" "" True False [] "" "" Dict.empty [] ValidInputs 
+        initUserInfoForm = UserInfoForm "" "" Dict.empty
+        initUserForm = UserForm "" "" True False [] initUserInfoForm [] ValidInputs 
         initModel = Model flags.contextPath "" (fromList []) (fromList []) [] None Toasty.initialState initUserForm initUi [] Dict.empty
     in
     ( initModel

--- a/user-management/src/main/elm/sources/JsonDecoder.elm
+++ b/user-management/src/main/elm/sources/JsonDecoder.elm
@@ -1,11 +1,9 @@
 module JsonDecoder exposing (..)
 
-import DataTypes exposing (Role, RoleConf, RoleListOverride(..), User, UserStatus(..), UsersConf)
+import DataTypes exposing (Role, RoleConf, RoleListOverride(..), User, UserStatus(..), UsersConf, ProviderInfo, ProvidersInfo, ProviderProperties, UserInfoForm)
 import Json.Decode as D exposing (Decoder)
 import Json.Decode.Pipeline exposing (optional, required)
-import DataTypes exposing (ProviderInfo)
-import DataTypes exposing (ProvidersInfo)
-import DataTypes exposing (ProviderProperties)
+import Dict
 
 decodeApiReloadResult : Decoder String
 decodeApiReloadResult =
@@ -34,14 +32,13 @@ decodeProviderProperties : Decoder ProviderProperties
 decodeProviderProperties =
     D.succeed ProviderProperties
         |> required "roleListOverride" decodeRoleListOverride
-        |> required "hasModifiablePassword" D.bool
 
 decodeRoleListOverride : Decoder RoleListOverride
 decodeRoleListOverride =
   D.string |> D.andThen
     (\str ->
       case str of
-        "extend"   -> D.succeed Extend
+        "no-override"   -> D.succeed Extend
         "override" -> D.succeed Override
         _          -> D.succeed None
     )
@@ -100,6 +97,21 @@ decodeApiUpdateUserResult =
 decodeUpdateUser : Decoder String
 decodeUpdateUser =
     D.at [ "updatedUser" ] (D.at [ "username" ] D.string)
+
+decodeApiUpdateUserInfoResult : Decoder UserInfoForm
+decodeApiUpdateUserInfoResult =
+    D.at [ "data" ] decodeUpdateUserInfo
+
+decodeUpdateUserInfoResult : Decoder UserInfoForm
+decodeUpdateUserInfoResult =
+    D.at [ "updatedUser" ] decodeUpdateUserInfo
+
+decodeUpdateUserInfo : Decoder UserInfoForm
+decodeUpdateUserInfo =
+    D.succeed UserInfoForm
+        |> optional "name" D.string ""
+        |> optional "email" D.string ""
+        |> optional "otherInfo" (D.dict D.string) Dict.empty
 
 decodeApiDeleteUserResult : Decoder String
 decodeApiDeleteUserResult =

--- a/user-management/src/main/elm/sources/JsonEncoder.elm
+++ b/user-management/src/main/elm/sources/JsonEncoder.elm
@@ -1,15 +1,15 @@
 module JsonEncoder exposing (..)
-
-import DataTypes exposing (AddUserForm, NewUser, User)
+import DataTypes exposing (AddUserForm, UserAuth, UserInfoForm)
 import Json.Encode exposing (Value, bool, list, object, string)
 import Dict
 
-encodeUser: (User, String) -> Value
-encodeUser (user, password) =
+encodeUserAuth: UserAuth -> Value
+encodeUserAuth user =
     object
     [ ("username", string user.login)
-    , ("password", string password)
-    , ("permissions", list (\s -> string s) (user.authz ++  user.roles))
+    , ("password", string user.password)
+    , ("permissions", list (\s -> string s) user.permissions)
+    , ("isPreHashed", bool user.isPreHashed)
     ]
 
 encodeAddUser: AddUserForm -> Value
@@ -22,4 +22,12 @@ encodeAddUser userForm =
     , ("name", string userForm.user.name)
     , ("email", string userForm.user.email)
     , ("otherInfo", object (List.map (\(k, v) -> (k, string v)) (Dict.toList userForm.user.otherInfo)))
+    ]
+
+encodeUserInfo: UserInfoForm -> Value
+encodeUserInfo user =
+    object
+    [ ("name", string user.name)
+    , ("email", string user.email)
+    , ("otherInfo", object (List.map (\(k, v) -> (k, string v)) (Dict.toList user.otherInfo)))
     ]

--- a/user-management/src/main/resources/toserve/usermanagement/user-management.css
+++ b/user-management/src/main/resources/toserve/usermanagement/user-management.css
@@ -296,14 +296,14 @@ h3 {
   margin-bottom: 5em;
 }
 
-.user-info .user-info-row:last-child {
-  text-align: right;
-}
-
 .user-info .user-info-row.user-info-other {
   display: flex;
   flex-direction: column;
   column-gap: 5px;
+}
+
+.user-info .user-info-row .user-info-add {
+  text-align: right;
 }
 
 .user-info .user-info-row .user-info-row-edit {

--- a/user-management/src/test/resources/usermanagement_api/api_usermanagement.yml
+++ b/user-management/src/test/resources/usermanagement_api/api_usermanagement.yml
@@ -9,9 +9,13 @@ response:
       "result" : "success",
       "data" : {
         "digest" : "BCRYPT",
-        "roleListOverride" : "none",
+        "roleListOverride" : "override",
         "authenticationBackends" : [],
-        "providerProperties" : {},
+        "providerProperties" : {
+          "file" : {
+            "roleListOverride" : "override"
+          }
+        },
         "users" : [
           {
             "login" : "user1",
@@ -426,7 +430,7 @@ response:
       }
     }
 ---
-description: Update user's infos
+description: Update user's admninistrative information
 method: POST
 url: /api/latest/usermanagement/update/user1
 headers:
@@ -442,7 +446,7 @@ response:
   code: 200
   content: >-
     {
-      "action" : "updateUserInfos",
+      "action" : "updateUser",
       "result" : "success",
       "data" : {
         "updatedUser" : {
@@ -455,7 +459,7 @@ response:
       }
     }
 ---
-description: Update user's infos with a non-existing username
+description: Update user's admninistrative information with non-existing username
 method: POST
 url: /api/latest/usermanagement/update/hello%20world
 headers:
@@ -471,9 +475,65 @@ response:
   code: 500
   content: >-
     {
-      "action" : "updateUserInfos",
+      "action" : "updateUser",
       "result" : "error",
-      "errorDetails" : "Could not update user 'hello+world'; cause was: Inconsistency: 'hello+world' does not exists"
+      "errorDetails" : "Could not update user 'hello+world'; cause was: Inconsistency: User 'hello+world' does not exist therefore cannot be updated"
+    }
+---
+description: Update an user's info
+method: POST
+url: /api/latest/usermanagement/update/info/user1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "name" : "User 1",
+    "email" : "newemail@example.com",
+    "otherInfo" : {
+      "some" : "value",
+      "another" : "value"
+    }
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "updateUserInfo",
+      "id" : "user1",
+      "result" : "success",
+      "data" : {
+        "updatedUser" : {
+          "name" : "User 1",
+          "email" : "newemail@example.com",
+          "otherInfo" : {
+            "some" : "value",
+            "another" : "value"
+          }
+        }
+      }
+    }
+---
+description: Update an user's info with non-existing username with idempotence
+method: POST
+url: /api/latest/usermanagement/update/info/hello%20world
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "name" : "Hello World"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "updateUserInfo",
+      "id" : "hello+world",
+      "result" : "success",
+      "data" : {
+        "updatedUser" : {
+          "name" : "Hello World"
+        }
+      }
     }
 ---
 description: Activate an already active user

--- a/user-management/src/test/scala/com/normation/plugins/usermanagement/MockServices.scala
+++ b/user-management/src/test/scala/com/normation/plugins/usermanagement/MockServices.scala
@@ -36,7 +36,7 @@ class MockServices(userInfos: List[UserInfo], userSessions: List[UserSession], u
 
     override def closeAllOpenSession(endDate: DateTime, endCause: String): IOResult[Unit] = ???
 
-    override def getLastPreviousLogin(userId: String): IOResult[Option[UserSession]] = {
+    override def getLastPreviousLogin(userId: String, closedSessionsOnly: Boolean): IOResult[Option[UserSession]] = {
       userSessions.find(_.userId == userId).succeed
     }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24298

* Splitting the endpoints in 2 : the existing one should only be used for the "roles" and "password" update, the new one to update user info : "name", "email" and "otherInfo"
* Updating the display to keep consistency and have clearer messages when roles are defined both in the users.xml file and from the provider. For that we have migrated the "role extension" ADT from the plugin to Rudder [in this PR](https://github.com/Normation/rudder/pull/5428), and pattern matching on it now makes the logic of handling both file and external provider more fluent.