### PR TITLE
Fixes #24714: /var/rudder/plugin-resources/change-validation is not created anymore on plugin startup

### DIFF
--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsReposiory.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsReposiory.scala
@@ -62,7 +62,7 @@ class UnsupervisedTargetsRepository(
                       // try to create it
                       IOResult
                         .attempt(s"Error when creating directory '$directory'. Please correct the problem.")(
-                          f.createDirectory()
+                          f.createDirectories()
                         )
                         .onError(err => ZIO.foreach(err.failureOption.map(_.fullMsg))(ChangeValidationLoggerPure.error(_)))
                     }


### PR DESCRIPTION
https://issues.rudder.io/issues/24714

createDirectories create also parents contrary to createDirectory