### PR TITLE
Fixes #24630: External reports tab is not aligned in nodes page and content is always displayed

### DIFF
--- a/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/extension/CreateNodeDetailsExtension.scala
+++ b/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/extension/CreateNodeDetailsExtension.scala
@@ -68,13 +68,17 @@ class CreateNodeDetailsExtension(externalReport: ReadExternalReports, val status
         val e = eb ?~! "Can not display external reports for that node"
         ("External reports", <div class="error">{e.messageChain}</div>)
       case Full(config) =>
-        (config.tabTitle, <div id="externalReport">{tabContent(config.reports)(myXml)}</div>)
+        (config.tabTitle, <div id="externalReport" class="tab-pane" role="tabpanel">{tabContent(config.reports)(myXml)}</div>)
     }
 
     (
       "#NodeDetailsTabMenu *" #> { (x: NodeSeq) =>
         x ++ (
-          <li class="ui-tabs-tab"><a href="#externalReport">{tabTitle}</a></li>
+          <li class="nav-item">
+            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#externalReport" type="button" role="tab" aria-controls="externalReport">{
+            tabTitle
+          }</button>
+          </li>
         )
       } &
       "#node_logs" #> { (x: NodeSeq) =>


### PR DESCRIPTION
https://issues.rudder.io/issues/24630