### PR TITLE
Fixes #24727: Groups node ids list in API should be filtered by tenant in plugins

### DIFF
--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/MockServices.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/MockServices.scala
@@ -59,7 +59,9 @@ import com.normation.rudder.domain.workflows.ConfigurationChangeRequest
 import com.normation.rudder.domain.workflows.WorkflowNode
 import com.normation.rudder.domain.workflows.WorkflowNodeId
 import com.normation.rudder.domain.workflows.WorkflowStepChange
+import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.NodeSecurityContext
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.CategoryAndNodeGroup
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.repository.RoNodeGroupRepository
@@ -86,14 +88,15 @@ class MockSupervisedTargets(unsupervisedDir: File, unsupervisedFilename: String,
 
   object nodeGroupRepo extends RoNodeGroupRepository {
 
-    override def getFullGroupLibrary(): IOResult[FullNodeGroupCategory] = {
+    override def getFullGroupLibrary():                                       IOResult[FullNodeGroupCategory]                    = {
       fullNodeGroupCategory.succeed
     }
 
     override def categoryExists(
         id: com.normation.rudder.domain.nodes.NodeGroupCategoryId
     ): com.normation.errors.IOResult[Boolean] = ???
-    override def getNodeGroupOpt(id: NodeGroupId): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]] = ???
+    override def getNodeGroupOpt(id: NodeGroupId)(implicit qc: QueryContext): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]] =
+      ???
     override def getNodeGroupCategory(id: NodeGroupId): IOResult[NodeGroupCategory] = ???
     override def getAll(): IOResult[Seq[NodeGroup]] = ???
     override def getAllByIds(ids: Seq[NodeGroupId]): IOResult[Seq[com.normation.rudder.domain.nodes.NodeGroup]] = ???
@@ -101,7 +104,7 @@ class MockSupervisedTargets(unsupervisedDir: File, unsupervisedFilename: String,
     override def getAllNodeIdsChunk(): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = ???
     override def getGroupsByCategory(
         includeSystem: Boolean
-    ): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
+    )(implicit qc: QueryContext): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
     override def findGroupWithAnyMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
     override def findGroupWithAllMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
     override def getRootCategory():     NodeGroupCategory                                                 = ???
@@ -238,11 +241,11 @@ class MockServices(changeRequestsByStatus: Map[WorkflowNodeId, List[ChangeReques
 
   object commitAndDeployChangeRequest extends CommitAndDeployChangeRequestService {
 
-    override def save(changeRequest: ChangeRequest, actor: EventActor, reason: Option[String]): Box[ChangeRequest] = Full(
+    def save(changeRequest: ChangeRequest)(implicit cc: ChangeContext): Box[ChangeRequest] = Full(
       changeRequest
     )
 
-    override def isMergeable(changeRequest: ChangeRequest): Boolean = {
+    def isMergeable(changeRequest: ChangeRequest)(implicit qc: QueryContext): Boolean = {
       // can depend on "mergeable" changeRequest by their id to vary test cases
       true
     }

--- a/scale-out-relay/src/test/scala/com/normation/plugins/scaleoutrelay/MockServices.scala
+++ b/scale-out-relay/src/test/scala/com/normation/plugins/scaleoutrelay/MockServices.scala
@@ -10,6 +10,7 @@ import com.normation.ldap.ldif.LDIFNoopChangeRecord
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.PolicyServerTarget
 import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.repository.EventLogRepository
 import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.services.eventlog.EventLogFactory
@@ -95,12 +96,9 @@ class MockServices(nodeGroups: Map[NodeGroupId, NodeGroup]) {
         whyDescription: Option[String]
     ): IOResult[Option[ModifyNodeGroupDiff]] = ???
     override def move(
-        group:          NodeGroupId,
-        containerId:    NodeGroupCategoryId,
-        modId:          ModificationId,
-        actor:          EventActor,
-        whyDescription: Option[String]
-    ): IOResult[Option[ModifyNodeGroupDiff]] = ???
+        group:       NodeGroupId,
+        containerId: NodeGroupCategoryId
+    )(implicit cc: ChangeContext): IOResult[Option[ModifyNodeGroupDiff]] = ???
     override def addGroupCategorytoCategory(
         that:           NodeGroupCategory,
         into:           NodeGroupCategoryId,


### PR DESCRIPTION
https://issues.rudder.io/issues/24727

Fix compilation of the change-validation and scale-out-relay plugin since changes in https://github.com/Normation/rudder/pull/5608