### PR TITLE
Fixes #24771: Update scala plugin dependencies

### DIFF
--- a/api-authorizations/pom-template.xml
+++ b/api-authorizations/pom-template.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/auth-backends/pom-template.xml
+++ b/auth-backends/pom-template.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-       <version>2.16.0</version>
+       <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>com.nimbusds</groupId>

--- a/change-validation/pom-template.xml
+++ b/change-validation/pom-template.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.github.davidmoten</groupId>
       <artifactId>subethasmtp</artifactId>
-      <version>6.0.7</version>
+      <version>7.0.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/openscap/pom-template.xml
+++ b/openscap/pom-template.xml
@@ -47,20 +47,13 @@
     <dependency>
       <groupId>org.owasp.antisamy</groupId>
       <artifactId>antisamy</artifactId>
-      <version>1.7.4</version>
+      <version>1.7.5</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-simple</artifactId>
           <groupId>org.slf4j</groupId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <!-- added because of cve CVE-2023-49093 in neko 3.6.0 that is a dependency of antisamy, should be ok in antisamy 1.7.5 -->
-    <dependency>
-      <groupId>org.htmlunit</groupId>
-      <artifactId>neko-htmlunit</artifactId>
-      <version>3.9.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://issues.rudder.io/issues/24771

Minor bumps for some plugins : 
* `auth-backends` : :man_dancing: jackson-databind 
* `change-validation` : :incoming_envelope: new version uses the jakarta mail 2 API now 
* `openscap` : :wastebasket: neko-html-unit can be deleted as stated in the comment