### PR TITLE
Fixes #24849: Fix servlet api dependency in api-authorizations

### DIFF
--- a/api-authorizations/pom-template.xml
+++ b/api-authorizations/pom-template.xml
@@ -48,7 +48,7 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
https://issues.rudder.io/issues/24849

It was updated from 2.5.0 but the [previous artifact](https://mvnrepository.com/artifact/javax.servlet/servlet-api) has been moved since version 3