### PR TITLE
Fixes #25015: Plugins need to be ported, too

### DIFF
--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeRequestJson.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeRequestJson.scala
@@ -578,10 +578,10 @@ object GroupChangeJson {
   )
 
   object GroupJson {
-    implicit val serverListEncoder:  JsonEncoder[Set[NodeId]] =
+    implicit val serverListEncoder: JsonEncoder[Set[NodeId]] =
       JsonEncoder[List[String]].contramap[Set[NodeId]](_.toList.map(_.value).sorted)
-    implicit val targetEncoder:      JsonEncoder[GroupTarget] = JsonEncoder[String].contramap[GroupTarget](_.target)
-    implicit val encoder:            JsonEncoder[GroupJson]   = DeriveJsonEncoder.gen[GroupJson]
+    implicit val targetEncoder:     JsonEncoder[GroupTarget] = JsonEncoder[String].contramap[GroupTarget](_.target)
+    implicit val encoder:           JsonEncoder[GroupJson]   = DeriveJsonEncoder.gen[GroupJson]
   }
 
   final case class PropertiesJson( // we sort the properties by name on serialization
@@ -658,9 +658,9 @@ object GroupChangeJson {
   )
 
   object ModifyGroupJson {
-    implicit lazy val nodeIdEncoder:              JsonEncoder[NodeId]              = JsonEncoder[String].contramap[NodeId](_.value)
-    implicit lazy val queryEncoder:               JsonEncoder[Query]               = JsonEncoder[String].contramap[Query](_.toString)
-    implicit lazy val encoder:                    JsonEncoder[ModifyGroupJson]     =
+    implicit lazy val nodeIdEncoder: JsonEncoder[NodeId]          = JsonEncoder[String].contramap[NodeId](_.value)
+    implicit lazy val queryEncoder:  JsonEncoder[Query]           = JsonEncoder[String].contramap[Query](_.toString)
+    implicit lazy val encoder:       JsonEncoder[ModifyGroupJson] =
       DeriveJsonEncoder.gen[ModifyGroupJson]
 
     def from(

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowService.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowService.scala
@@ -156,13 +156,13 @@ class TwoValidationStepsWorkflowServiceImpl(
     // We need to remap back to the original type to fetch the id of the CR created
     val save          = diff match {
       case _:      AddChangeRequestDiff      =>
-        woChangeRequestRepository.createChangeRequest(diff.changeRequest, actor, reason).map(AddChangeRequestDiff)
+        woChangeRequestRepository.createChangeRequest(diff.changeRequest, actor, reason).map(AddChangeRequestDiff.apply)
       case modify: ModifyToChangeRequestDiff =>
         woChangeRequestRepository
           .updateChangeRequest(changeRequest, actor, reason)
           .map(_ => modify) // For modification the id is already correct
       case _:      DeleteChangeRequestDiff   =>
-        woChangeRequestRepository.deleteChangeRequest(changeRequest.id, actor, reason).map(DeleteChangeRequestDiff)
+        woChangeRequestRepository.deleteChangeRequest(changeRequest.id, actor, reason).map(DeleteChangeRequestDiff.apply)
     }
 
     for {

--- a/change-validation/src/test/resources/changevalidation_api/api_changerequest.yml
+++ b/change-validation/src/test/resources/changevalidation_api/api_changerequest.yml
@@ -2980,6 +2980,7 @@ response:
                 {
                   "action" : "delete",
                   "change" : {
+                    "type": "GlobalParameterDeleteChangeJson",
                     "id" : "jsonParam",
                     "value" : {
                       "array" : [
@@ -2993,8 +2994,7 @@ response:
                       },
                       "string" : "a string"
                     },
-                    "description" : "a simple string param",
-                    "type": "GlobalParameterDeleteChangeJson"
+                    "description" : "a simple string param"
                   }
                 }
               ]
@@ -3054,6 +3054,7 @@ response:
                 {
                   "action" : "create",
                   "change" : {
+                    "type" : "DirectiveCreateChangeJson",
                     "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
                     "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
                     "shortDescription" : "",
@@ -3241,8 +3242,7 @@ response:
                     "enabled" : false,
                     "system" : false,
                     "policyMode" : "default",
-                    "tags" : [],
-                    "type" : "DirectiveCreateChangeJson"
+                    "tags" : []
                   }
                 }
               ],
@@ -3322,6 +3322,7 @@ response:
                 {
                   "action" : "create",
                   "change" : {
+                    "type" : "DirectiveCreateChangeJson",
                     "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
                     "displayName" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
                     "shortDescription" : "",
@@ -3509,8 +3510,7 @@ response:
                     "enabled" : false,
                     "system" : false,
                     "policyMode" : "default",
-                    "tags" : [],
-                    "type" : "DirectiveCreateChangeJson"
+                    "tags" : []
                   }
                 }
               ],
@@ -3601,6 +3601,7 @@ response:
                 {
                   "action" : "create",
                   "change" : {
+                    "type" : "GroupCreateChangeJson",
                     "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
                     "displayName" : "Real nodes",
                     "description" : "",
@@ -3632,13 +3633,12 @@ response:
                       {
                         "name" : "stringParam",
                         "value" : "string",
-                        "provider" : "datasources",
-                        "inheritMode" : "map"
+                        "inheritMode" : "map",
+                        "provider" : "datasources"
                       }
                     ],
-                    "system" : false,
                     "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
-                    "type" : "GroupCreateChangeJson"
+                    "system" : false
                   }
                 }
               ],

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/ValidatedUserJdbcRepositoryTest.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/ValidatedUserJdbcRepositoryTest.scala
@@ -8,6 +8,7 @@ import com.normation.rudder.db.DBCommon
 import com.normation.rudder.rest.AuthorizationApiMapping
 import com.normation.rudder.rest.RoleApiMapping
 import com.normation.rudder.users.FileUserDetailListProvider
+import com.normation.rudder.users.PasswordEncoderDispatcher
 import com.normation.rudder.users.UserFile
 import com.normation.zio.UnsafeRun
 import doobie.Transactor
@@ -72,7 +73,7 @@ class ValidatedUserJdbcRepositoryTest extends Specification with DBCommon with I
     }
     val roleApiMapping = new RoleApiMapping(AuthorizationApiMapping.Core)
 
-    val res = new FileUserDetailListProvider(roleApiMapping, usersFile)
+    val res = new FileUserDetailListProvider(roleApiMapping, usersFile, new PasswordEncoderDispatcher(12))
     res.reload()
     res
   }

--- a/datasources/src/main/scala/bootstrap/rudder/plugin/DataSourcesConf.scala
+++ b/datasources/src/main/scala/bootstrap/rudder/plugin/DataSourcesConf.scala
@@ -81,9 +81,8 @@ object DatasourcesConf extends RudderPluginModule {
   lazy val dataSourceRepository = new DataSourceRepoImpl(
     new DataSourceJdbcRepository(Cfg.doobie),
     new HttpQueryDataSourceService(
-      Cfg.nodeInfoService,
+      Cfg.nodeFactRepository,
       Cfg.roLDAPParameterRepository,
-      Cfg.woNodeRepository,
       Cfg.interpolationCompiler,
       regenerationHook.hook _,
       () => Cfg.configService.rudder_global_policy_mode()

--- a/datasources/src/main/scala/com/normation/plugins/datasources/Repository.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/Repository.scala
@@ -46,8 +46,8 @@ import com.normation.plugins.PluginStatus
 import com.normation.plugins.datasources.DataSourceSchedule.*
 import com.normation.rudder.db.Doobie
 import com.normation.rudder.domain.eventlog.*
-import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio.*
 import doobie.*
@@ -60,10 +60,10 @@ import zio.json.*
 import zio.syntax.*
 
 final case class PartialNodeUpdate(
-    nodes:         Map[NodeId, NodeInfo] // the node to update
-    ,
-    policyServers: Map[NodeId, NodeInfo] // there policy servers
-    ,
+    // the node to update
+    nodes:         Map[NodeId, CoreNodeFact],
+    // there policy servers
+    policyServers: Map[NodeId, CoreNodeFact],
     parameters:    Set[GlobalParameter]
 )
 

--- a/datasources/src/main/scala/com/normation/plugins/datasources/Serialization.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/Serialization.scala
@@ -496,7 +496,7 @@ object DataSourceExtractor {
     def parse[A: JsonDecoder](key: String):                PureResult[Option[A]] = {
       optGet(key) match {
         case None    => Right(None)
-        case Some(x) => JsonDecoder[A].decodeJson(x).map(Some(_)).left.map(Unexpected)
+        case Some(x) => JsonDecoder[A].decodeJson(x).map(Some(_)).left.map(Unexpected.apply)
       }
     }
     def parseString[A](key: String, decoder: String => A): PureResult[Option[A]] = {

--- a/datasources/src/test/scala/com/normation/plugins/datasources/api/RestDataSourceFilesTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/api/RestDataSourceFilesTest.scala
@@ -1,0 +1,127 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.plugins.datasources.api
+
+import better.files.File
+import com.normation.errors.IOResult
+import com.normation.errors.effectUioUnit
+import com.normation.plugins.datasources.*
+import com.normation.rudder.MockNodes
+import com.normation.rudder.rest.RestTest
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.rest.TraitTestApiFromYamlFiles
+import com.normation.zio.*
+import java.nio.file.Files
+import org.junit.runner.RunWith
+import zio.*
+import zio.test.*
+import zio.test.junit.ZTestJUnitRunner
+
+@RunWith(classOf[ZTestJUnitRunner])
+class RestDataSourceFilesTest extends ZIOSpecDefault {
+
+  val restTestSetUp = RestTestSetUp.newEnv
+
+  val datasourceRepo = new MemoryDataSourceRepository with NoopDataSourceCallbacks
+
+  val mockNodes      = new MockNodes()
+  val dataSourceApi9 = new DataSourceApiImpl(
+    restTestSetUp.restExtractorService,
+    datasourceRepo,
+    mockNodes.nodeInfoService,
+    null,
+    restTestSetUp.uuidGen
+  )
+
+  val (rudderApi, liftRules) =
+    TraitTestApiFromYamlFiles.buildLiftRules(dataSourceApi9 :: Nil, restTestSetUp.apiVersions, Some(restTestSetUp.userService))
+  val restTest               = new RestTest(liftRules)
+  restTestSetUp.rudderApi.addModules(dataSourceApi9.getLiftEndpoints())
+
+  val tmpDir: File = File(Files.createTempDirectory("rudder-test-"))
+  val yamlSourceDirectory  = "datasources_api"
+  val yamlDestTmpDirectory = tmpDir / "templates"
+
+  val transformations: Map[String, String => String] = Map()
+
+  val baseSourceType = DataSourceType.HTTP(
+    "",
+    Map(),
+    HttpMethod.GET,
+    Map(),
+    false,
+    "",
+    DataSourceType.HTTP.defaultMaxParallelRequest,
+    HttpRequestMode.OneRequestByNode,
+    DataSource.defaultDuration,
+    MissingNodeBehavior.Delete
+  )
+  val baseRunParam   = DataSourceRunParameters(DataSourceSchedule.NoSchedule(DataSource.defaultDuration), false, false)
+
+  val datasource1 = DataSource(
+    DataSourceId("datasource1"),
+    DataSourceName(""),
+    baseSourceType,
+    baseRunParam,
+    "",
+    false,
+    DataSource.defaultDuration
+  )
+
+  datasourceRepo.save(datasource1).runNow
+
+  // Execute API request/response test cases from .yml files
+  override def spec: Spec[TestEnvironment with Scope, Any] = {
+    (suite("All REST tests defined in files") {
+
+      for {
+        s <- TraitTestApiFromYamlFiles.doTest(
+               yamlSourceDirectory,
+               yamlDestTmpDirectory,
+               liftRules,
+               Nil,
+               transformations
+             )
+        _ <- effectUioUnit(
+               if (java.lang.System.getProperty("tests.clean.tmp") != "false") IOResult.attempt(restTestSetUp.cleanup())
+               else ZIO.unit
+             )
+      } yield s
+    })
+  }
+}

--- a/datasources/src/test/scala/com/normation/plugins/datasources/api/RestDataSourceTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/api/RestDataSourceTest.scala
@@ -49,15 +49,15 @@ import com.normation.zio.*
 import io.scalaland.chimney.syntax.*
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit.SECONDS
-import net.liftweb.common.Loggable
 import org.junit.runner.RunWith
+import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
 import zio.*
 import zio.json.*
 import zio.json.ast.Json
 
 @RunWith(classOf[JUnitRunner])
-class RestDataSourceTest extends TraitTestApiFromYamlFiles with Loggable {
+class RestDataSourceTest extends Specification {
 
   val restTestSetUp = RestTestSetUp.newEnv
 
@@ -78,10 +78,6 @@ class RestDataSourceTest extends TraitTestApiFromYamlFiles with Loggable {
   restTestSetUp.rudderApi.addModules(dataSourceApi9.getLiftEndpoints())
 
   val tmpDir: File = File(Files.createTempDirectory("rudder-test-"))
-  override def yamlSourceDirectory  = "datasources_api"
-  override def yamlDestTmpDirectory = tmpDir / "templates"
-
-  override def transformations: Map[String, String => String] = Map()
 
   val baseSourceType = DataSourceType.HTTP(
     "",
@@ -259,7 +255,4 @@ class RestDataSourceTest extends TraitTestApiFromYamlFiles with Loggable {
     }
 
   }
-
-  // Execute API request/response test cases from .yml files
-  doTest()
 }

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/api/OpenScapApi.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/api/OpenScapApi.scala
@@ -35,8 +35,8 @@ object OpenScapApi extends Enum[OpenScapApi] with ApiModuleProvider[OpenScapApi]
     val description    = "Get OpenSCAP report for a node"
     val (action, path) = GET / "openscap" / "report" / "{id}"
 
-    override def dataContainer: Option[String] = None
-    override val authz : List[AuthorizationType] = AuthorizationType.Node.Read :: Nil
+    override def dataContainer: Option[String]          = None
+    override val authz:         List[AuthorizationType] = AuthorizationType.Node.Read :: Nil
   }
 
   final case object GetSanitizedOpenScapReport extends OpenScapApi with OneParam with StartsAtVersion12 {
@@ -44,8 +44,8 @@ object OpenScapApi extends Enum[OpenScapApi] with ApiModuleProvider[OpenScapApi]
     val description    = "Get sanitized OpenSCAP report for a node"
     val (action, path) = GET / "openscap" / "sanitized" / "{id}"
 
-    override def dataContainer: Option[String] = None
-    override val authz : List[AuthorizationType] = AuthorizationType.Node.Read :: Nil
+    override def dataContainer: Option[String]          = None
+    override val authz:         List[AuthorizationType] = AuthorizationType.Node.Read :: Nil
   }
 
   def endpoints = values.toList.sortBy(_.z)

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/services/GetActiveTechniqueIds.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/services/GetActiveTechniqueIds.scala
@@ -63,7 +63,7 @@ class GetActiveTechniqueIds(
       allEntries <- con.searchSub(rudderDit.ACTIVE_TECHNIQUES_LIB.dn, filter, A_ACTIVE_TECHNIQUE_UUID)
       ids        <- ZIO.foreach(allEntries)(e => e.required(A_ACTIVE_TECHNIQUE_UUID).toIO)
     } yield {
-      ids.toList.map(ActiveTechniqueId)
+      ids.toList.map(ActiveTechniqueId.apply)
     }
   }
 }

--- a/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/DataTypes.scala
+++ b/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/DataTypes.scala
@@ -86,12 +86,9 @@ class ScaleOutRelayAgentSpecificGeneration(pluginInfo: PluginStatus) extends Age
   import com.normation.rudder.services.policies.write.BuildBundleSequence.InputFile
   import com.normation.rudder.services.policies.write.BuildBundleSequence.TechniqueBundles
   override def getBundleVariables(
-      systemInputs: List[InputFile],
-      sytemBundles: List[TechniqueBundles],
-      userInputs:   List[InputFile],
-      userBundles:  List[TechniqueBundles],
-      runHooks:     List[NodeRunHook]
+      inputs:   List[InputFile],
+      bundles:  List[TechniqueBundles],
+      runHooks: List[NodeRunHook]
   ): BundleSequenceVariables =
-    CfengineBundleVariables.getBundleVariables(escape, systemInputs, sytemBundles, userInputs, userBundles, runHooks)
-
+    CfengineBundleVariables.getBundleVariables(escape, inputs, bundles, runHooks)
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/25015

Lots of changes going on here : 
- for all plugins, changing the use of `TraitTestApiFromYamlFiles` ; similar, purely mechanic changes appart in datasources because the test was mixing both that and standard specs2 tests, I splitted it in two files (`RestDataSourceTest.scala` for specs2 and `RestDataSourceFilesTest.scala` for rest YAML)
- some YAML test file have some changes in json property orders. This is due to the fact that the normalisation with the new `TraitTestApiFromYamlFiles` is not exactly the same than before
- some `.apply` are added to comply to more recent scala rules
- `ScaleOutRelay` is adapted to `policyTag`: it seems that it's limited to only removing parameters in  `getBundleVariables` 
- because of changes in node API and policyType, it was simpler to finish migrating datasource to `CoreNodeFact` than to try to add more compatibility layer with `NodeInfo`

Datasources changes: 

- change everywhere `NodeInfoService` and `WoNodeRepository` to `NodeFactRepository`. It tends to simplify things since now we have only one repo for both read and write parts
- change `NodeInfo` to `CoreNodeFact` with the usual impact on some attributes path (`policyServerId`, `hostname`/`fqdn`, etc)
- adapt the check that look if a node is updated to also use what `CoreNodeFactRespository` say with its change event
- then, big big changes in [UpdateHttpDatasetTest.scala](https://github.com/Normation/rudder-plugins/pull/727/files#diff-44d43b7b8b22fabae4537dae04dcf91ea30fe5594278681a49ffe9e43951e4e8)

Datasources > UpdateHttpDatasetTest changes : 
The changes are due to the fact that we use to have a special `NodeInfoService` that is used to track how many time a node property is changed in a side `Map[NodeId, Int]` and avoid having to deal with LDAP. This needed to be reworked because of the change to `CoreNodeFactRepository`, but it's *much simpler* now: 
- we can avoid backend storage mess by configuring a `CoreNodeFactRepository` with `NoopFactStorage` , 
- we can finely track node changes with a `NodeFactChangeEventCallback`, they are for that.

So now, we just update the `updates: Map[NodeId, Int]` in a callback. I also put it into a `Ref`, hoping it will limit the number of instability on that test. 
The remaning changes are implication of that. 

