### PR TITLE
Fixes #25085: Datasources tests fail on 404

### DIFF
--- a/datasources/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala
@@ -1224,13 +1224,15 @@ class UpdateHttpDatasetTest extends Specification with BoxSpecMatcher with Logga
         nodeIds.map(n => if (expectMod) NodeUpdateResult.Updated(n) else NodeUpdateResult.Unchanged(n): NodeUpdateResult)
       )
 
-      res.either.runNow must beRight(matcher) and (
-        if (expectMod) {
-          updates.get.runNow must havePairs(nodeIds.map(x => (x, 1)).toSeq*)
-        } else {
-          updates.get.runNow must beEmpty
-        }
-      ) and ({
+      res.either
+        .flatMap(r => {
+          updates.get.map(u => {
+            (r must beRight(matcher)) and (
+              u must (if (expectMod) havePairs(nodeIds.map(x => (x, 1)).toSeq*) else empty)
+            )
+          })
+        })
+        .runNow and ({
         // none should have "test-404"
         val props = infos
           .getAll()(QueryContext.testQC)


### PR DESCRIPTION
https://issues.rudder.io/issues/25085


![noidea](https://github.com/Normation/rudder-plugins/assets/65616064/2563c5d3-2c51-4214-9576-0cfc73f7a8db)

Tests are still unstable, I was not sure of how to reproduce test failures : once I did the change and it passed once, I double-checked the behavior by reverting to the old version but then the tests always passed :weary: 

Before that, I changed the `nThreads` value to 1, and the test passed (but other tests on parallelism failed).
And yet I didn't find any "shared" state within the failing tests on 404 error, so I assumed this is a "client" behavior, and therefore the client IO may not finish before specs2 checks the second branche of the `... and ...`