### PR TITLE
Fixes #25737: Login form for OIDC can disappear depending on branding configuration

### DIFF
--- a/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
@@ -111,7 +111,7 @@ class LoginBranding(val status: PluginStatus, version: PluginVersion)(implicit v
       case _                                 => <div class="motd"></div>
     }
     (".logo-container" #> logoContainer &
-    ".plugin-info" #> bar &
+    ".plugin-info" #> ((x: NodeSeq) => bar ++ x) &
     ".plugin-info *+" #> brandingCss &
     ".motd" #> motd)(xml)
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25737

The branding plugin was brutally replacing the previous content from the auth-backends plugin with empty XML.
It just needed to add the bar if it wanted to do it, really...

![Peek 2024-11-28 17-36](https://github.com/user-attachments/assets/f82436e0-f900-481a-82f1-3a29cf5a60b6)
