### PR TITLE
Fixes #25999: Disabling user rest API token feature from api-authorizations plugin UI 

### DIFF
--- a/api-authorizations/src/main/scala/bootstrap/rudder/plugin/ApiAuthorizationsConf.scala
+++ b/api-authorizations/src/main/scala/bootstrap/rudder/plugin/ApiAuthorizationsConf.scala
@@ -63,6 +63,8 @@ object ApiAuthorizationsConf extends RudderPluginModule {
   lazy val userApi = new UserApiImpl(
     RudderConfig.roApiAccountRepository,
     RudderConfig.woApiAccountRepository,
+    RudderConfig.userRepository,
+    RudderConfig.authenticationProviders,
     RudderConfig.tokenGenerator,
     RudderConfig.stringUuidGenerator
   )
@@ -71,5 +73,7 @@ object ApiAuthorizationsConf extends RudderPluginModule {
   )
 
   RudderConfig.snippetExtensionRegister.register(new ApiAccountsExtension(pluginStatusService))
-  RudderConfig.snippetExtensionRegister.register(new UserInformationExtension(pluginStatusService))
+  RudderConfig.snippetExtensionRegister.register(
+    new UserInformationExtension(pluginStatusService, RudderConfig.userRepository, RudderConfig.authenticationProviders)
+  )
 }

--- a/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/api/UserApiTest.scala
+++ b/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/api/UserApiTest.scala
@@ -70,6 +70,8 @@ class UserApiTest extends Specification with TraitTestApiFromYamlFiles with Logg
     new UserApiImpl(
       mockServices.apiAccountRepository,
       mockServices.apiAccountRepository,
+      null,
+      null,
       mockServices.tokenGenerator,
       restTestSetUp.uuidGen
     )

--- a/user-management/src/main/scala/com/normation/plugins/usermanagement/DataTypes.scala
+++ b/user-management/src/main/scala/com/normation/plugins/usermanagement/DataTypes.scala
@@ -42,6 +42,7 @@ import bootstrap.liftweb.ProviderRoleExtension
 import com.normation.rudder.Rights
 import com.normation.rudder.Role
 import com.normation.rudder.Role.Custom
+import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.users.RudderUserDetail
 import com.normation.rudder.users.UserStatus
 import com.normation.utils.DateFormaterService
@@ -85,6 +86,7 @@ object Serialisation {
   implicit val userStatusEncoder:                    JsonEncoder[UserStatus]                    = JsonEncoder[String].contramap(_.value)
   implicit val providerRoleExtensionEncoder:         JsonEncoder[ProviderRoleExtension]         =
     JsonEncoder[String].contramap(_.name)
+  implicit val featureSwitchEncoder:                 JsonEncoder[FeatureSwitch]                 = JsonEncoder[String].contramap(_.entryName)
   implicit val authBackendProviderPropertiesEncoder: JsonEncoder[AuthBackendProviderProperties] =
     DeriveJsonEncoder.gen[AuthBackendProviderProperties]
 

--- a/user-management/src/test/resources/usermanagement_api/api_usermanagement.yml
+++ b/user-management/src/test/resources/usermanagement_api/api_usermanagement.yml
@@ -9,11 +9,14 @@ response:
       "result" : "success",
       "data" : {
         "digest" : "BCRYPT",
-        "roleListOverride" : "override",
+        "roleListOverride" : "no-override",
         "authenticationBackends" : [],
         "providerProperties" : {
           "file" : {
-            "roleListOverride" : "override"
+            "roleListOverride" : "no-override"
+          },
+          "rootAdmin": {
+              "roleListOverride": "no-override"
           }
         },
         "users" : [


### PR DESCRIPTION
https://issues.rudder.io/issues/25999

UI for the feature switch in https://github.com/Normation/rudder/pull/6050 : essentially we don't display the user API token menu in the api-authorizations plugin snippet.
We still have an API endpoint to pass the configuration value, also there is some refactoring and formatting applied to the Elm code which knows about the status by calling the endpoint.

In the related PR, the user management roles and default providers are also changed, so there is some changes in the user-management plugin