### PR TITLE
Fixes #26066: OpenSCAP needs queryContext and has build issues from stale properties file

### DIFF
--- a/openscap/Makefile
+++ b/openscap/Makefile
@@ -5,7 +5,7 @@ PROXY_ENV = $(if $(PROXY), http_proxy=$(PROXY) ftp_proxy=$(PROXY))
 # grep 'GET=' */SOURCES/Makefile to patch everywhere
 GET=get() { $(PROXY_ENV) curl -s -L -o "$$1.part" "$$2" && { openssl dgst -sha256 "$$1.part" | grep -q "$$3" || { echo "Wrong checksum, aborting"; exit 1; }; } && mv "$$1.part" "$$1"; }; get
 
-FILES = openscap.properties openscap_technique.zip
+FILES = openscap_technique.zip
 SCRIPTS = postinst
 
 #include ../makefiles/common-plugin.mk
@@ -21,9 +21,6 @@ target/openscap_technique.zip: target/rudderc
 
 target/remove_configuration:
 	cp packaging/remove_configuration target/remove_configuration
-
-target/openscap.properties:
-	cp src/main/resources/openscap.properties target/openscap.properties
 
 clean:
 	rm -f $(FULL_NAME)-*.rpkg pom.xml

--- a/openscap/src/main/scala/bootstrap/rudder/plugin/OpenscapPoliciesConf.scala
+++ b/openscap/src/main/scala/bootstrap/rudder/plugin/OpenscapPoliciesConf.scala
@@ -37,8 +37,6 @@
 
 package bootstrap.rudder.plugin
 
-import bootstrap.liftweb.ClassPathResource
-import bootstrap.liftweb.FileSystemResource
 import bootstrap.liftweb.RudderConfig
 import com.normation.plugins.RudderPluginModule
 import com.normation.plugins.openscappolicies.CheckRudderPluginEnableImpl
@@ -47,55 +45,11 @@ import com.normation.plugins.openscappolicies.api.OpenScapApiImpl
 import com.normation.plugins.openscappolicies.extension.OpenScapNodeDetailsExtension
 import com.normation.plugins.openscappolicies.services.GetActiveTechniqueIds
 import com.normation.plugins.openscappolicies.services.OpenScapReportReader
-import com.normation.rudder.domain.logger.ApplicationLogger
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import java.io.File
-
-object OpenScapProperties {
-  val CONFIG_FILE_KEY          = "rudder.plugin.openScapPolicies.config"
-  val DEFAULT_CONFIG_FILE_NAME = "openscap.properties"
-
-  val configResource = System.getProperty(CONFIG_FILE_KEY) match {
-    case null | "" => // use default location in classpath
-      ApplicationLogger.info(s"JVM property -D${CONFIG_FILE_KEY} is not defined, use configuration file in classpath")
-      ClassPathResource(DEFAULT_CONFIG_FILE_NAME)
-    case x         => // so, it should be a full path, check it
-      val config = new File(x)
-      if (config.exists && config.canRead) {
-        ApplicationLogger.info(s"Use configuration file defined by JVM property -D${CONFIG_FILE_KEY} : ${config.toURI.getPath}")
-        FileSystemResource(config)
-      } else {
-        ApplicationLogger.error(s"Can not find configuration file specified by JVM property ${CONFIG_FILE_KEY} ${x} ; abort")
-        throw new IllegalArgumentException("Configuration file not found: %s".format(config.toURI.getPath))
-      }
-  }
-
-  val config: Config = {
-    (configResource match {
-      case ClassPathResource(name)  => ConfigFactory.load(name)
-      case FileSystemResource(file) => ConfigFactory.load(ConfigFactory.parseFile(file))
-    })
-  }
-}
 
 /*
  * Actual configuration of the plugin logic
  */
 object OpenscapPoliciesConf extends RudderPluginModule {
-  import OpenScapProperties.*
-
-  val SANITIZATION_PROPERTY    = "sanitization.file"
-  val POLICY_SANITIZATION_FILE = config.getString(SANITIZATION_PROPERTY)
-
-  // check if sanitization file exists. If it doesn't, then it will silently block the start of Rudder
-  val policy_sanitization_file = new File(POLICY_SANITIZATION_FILE)
-  if (!policy_sanitization_file.exists()) {
-    ApplicationLogger.error(
-      s"Can not find sanitization file specified by configuration property ${SANITIZATION_PROPERTY}: ${POLICY_SANITIZATION_FILE}; abort"
-    )
-    throw new IllegalArgumentException(s"OpenSCAP sanitization file not found: ${POLICY_SANITIZATION_FILE}")
-  }
 
   lazy val pluginStatusService = new CheckRudderPluginEnableImpl(RudderConfig.nodeInfoService)
 
@@ -104,7 +58,7 @@ object OpenscapPoliciesConf extends RudderPluginModule {
   lazy val getActiveTechniqueIds = new GetActiveTechniqueIds(RudderConfig.rudderDit, RudderConfig.roLDAPConnectionProvider)
 
   lazy val openScapReportReader = new OpenScapReportReader(
-    RudderConfig.nodeInfoService,
+    RudderConfig.nodeFactRepository,
     RudderConfig.roDirectiveRepository,
     getActiveTechniqueIds,
     RudderConfig.findExpectedReportRepository,

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/extension/OpenScapNodeDetailsExtension.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/extension/OpenScapNodeDetailsExtension.scala
@@ -41,6 +41,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.plugins.PluginExtensionPoint
 import com.normation.plugins.PluginStatus
 import com.normation.plugins.openscappolicies.services.OpenScapReportReader
+import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.components.ShowNodeDetailsFromNode
 import com.normation.zio.*
 import net.liftweb.common.Full
@@ -69,7 +70,7 @@ class OpenScapNodeDetailsExtension(
     // Actually extend
     def display(): NodeSeq = {
       val nodeId  = snippet.nodeId
-      val content = openScapReader.getOpenScapReportFile(nodeId).either.runNow match {
+      val content = openScapReader.getOpenScapReportFile(nodeId)(CurrentUser.queryContext).either.runNow match {
         case Left(err) =>
           val e = s"Can not display OpenSCAP report for that node: ${err.fullMsg}"
           <div class="error">{e}</div>

--- a/openscap/src/test/resources/openscap_api/api_openscap.yml
+++ b/openscap/src/test/resources/openscap_api/api_openscap.yml
@@ -32,3 +32,12 @@ response:
   type: text
   content: >-
     Could not get the OpenSCAP report for node node_void123: Inconsistency: Node with id node_void123 does not exist
+---
+description: Get OpenSCAP report for a node with file reading issue
+method: GET
+url: /api/latest/openscap/report/root
+response:
+  code: 404
+  type: text
+  content: >-
+    No OpenSCAP report found for node 'root'

--- a/openscap/src/test/scala/com/normation/plugins/openscappolicies/api/OpenScapApiTest.scala
+++ b/openscap/src/test/scala/com/normation/plugins/openscappolicies/api/OpenScapApiTest.scala
@@ -44,9 +44,14 @@ class OpenScapApiTest extends Specification with TraitTestApiFromYamlFiles with 
       """<script>bad js</script><a href="https://example.com">not a trap!</a><div onMouseover="bad things;">content</div>"""
     )
 
+  val rootReportFile = openScapReportDir
+    .createChild("root/", asDirectory = true)
+    // create a directory instead of a file, attempting to read the content should throw an exception
+    .createChild(OpenScapReportReader.OPENSCAP_REPORT_FILENAME, asDirectory = true)
+
   val mockNodes            = new MockNodes()
   val openScapReportReader = new OpenScapReportReader(
-    mockNodes.nodeInfoService,
+    mockNodes.nodeFactRepo,
     restTestSetUp.mockDirectives.directiveRepo,
     null,
     null,


### PR DESCRIPTION
https://issues.rudder.io/issues/26066

* openscap.properties has been deleted in https://github.com/Normation/rudder-plugins/pull/777, the make target should also be removed
* use the NodeFactRepository, that requires `qc: QueryContext`