### PR TITLE
Fixes #26182: Datasources tests fail in 8.2 since restextractorservice deletion

### DIFF
--- a/datasources/src/test/scala/com/normation/plugins/datasources/api/RestDataSourceFilesTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/api/RestDataSourceFilesTest.scala
@@ -61,7 +61,6 @@ class RestDataSourceFilesTest extends ZIOSpecDefault {
 
   val mockNodes      = new MockNodes()
   val dataSourceApi9 = new DataSourceApiImpl(
-    restTestSetUp.restExtractorService,
     datasourceRepo,
     mockNodes.nodeInfoService,
     null,


### PR DESCRIPTION
https://issues.rudder.io/issues/26182

It is weird that we did not get an upmerge conflict from https://github.com/Normation/rudder-plugins/pull/784/files#diff-989df757ea97a81756f5beb30e2373c1467346fa13c2847917f2db0e54a284dcL68