### PR TITLE
Fixes #26195: Maven shade plugin update and ignore signatures

### DIFF
--- a/plugins-common/pom-template.xml
+++ b/plugins-common/pom-template.xml
@@ -163,7 +163,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.0</version>
         <configuration>
           <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
         </configuration>
@@ -174,6 +174,18 @@
             <goals>
               <goal>shade</goal>
             </goals>
+	    <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
https://issues.rudder.io/issues/26195

The webapp was not able to load the plugin. See https://stackoverflow.com/a/64263739, some dependencies in 8.3 come with signatures, we just want to ignore them in all plugins