### PR TITLE
Fixes #26199: Janino dependency was not provided to plugins causing plugin load issue

### DIFF
--- a/plugins-common/pom-template.xml
+++ b/plugins-common/pom-template.xml
@@ -174,18 +174,6 @@
             <goals>
               <goal>shade</goal>
             </goals>
-	    <configuration>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -334,6 +322,7 @@
     <dependency><groupId>org.bouncycastle</groupId><artifactId>bcpkix-${bouncycastle-compat}</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
     <dependency><groupId>org.bouncycastle</groupId><artifactId>bcprov-${bouncycastle-compat}</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
     <dependency><groupId>org.bouncycastle</groupId><artifactId>bcutil-${bouncycastle-compat}</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
+    <dependency><groupId>org.codehaus.janino</groupId><artifactId>janino</artifactId><scope>provided</scope><version>${janino-version}</version></dependency>
     <dependency><groupId>org.checkerframework</groupId><artifactId>checker-qual</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.eclipse.jgit</groupId><artifactId>org.eclipse.jgit</artifactId><scope>provided</scope><version>${jgit-version}</version></dependency>
     <dependency><groupId>org.graalvm.js</groupId><artifactId>js-language</artifactId><scope>provided</scope><version>${graalvm-version}</version></dependency>


### PR DESCRIPTION
https://issues.rudder.io/issues/26199

Following  https://github.com/Normation/rudder-plugins/pull/786 : 
in fact `janino` has been the only dependency with a signed jar that was added in 8.3, and not provided to plugins, so it was causing the error.