### PR TITLE
Fixes #26397: Impact of 24872 (API rights) on public plugins

### DIFF
--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/snippet/Oauth2LoginBanner.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/snippet/Oauth2LoginBanner.scala
@@ -40,7 +40,7 @@ package com.normation.plugins.authbackends.snippet
 import bootstrap.rudder.plugin.AuthBackendsConf
 import com.normation.plugins.PluginExtensionPoint
 import com.normation.plugins.PluginStatus
-import com.normation.plugins.RudderPluginVersion
+import com.normation.plugins.PluginVersion
 import com.normation.plugins.authbackends.LoginFormRendering
 import com.normation.plugins.authbackends.RudderPropertyBasedOAuth2RegistrationDefinition
 import com.normation.rudder.web.snippet.Login
@@ -53,7 +53,7 @@ import scala.xml.NodeSeq
 
 class Oauth2LoginBanner(
     val status:    PluginStatus,
-    version:       RudderPluginVersion,
+    version:       PluginVersion,
     registrations: RudderPropertyBasedOAuth2RegistrationDefinition
 )(implicit val ttag: ClassTag[Login])
     extends PluginExtensionPoint[Login] {

--- a/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
@@ -40,7 +40,7 @@ package com.normation.plugins.branding.snippet
 import bootstrap.rudder.plugin.BrandingPluginConf
 import com.normation.plugins.PluginExtensionPoint
 import com.normation.plugins.PluginStatus
-import com.normation.plugins.RudderPluginVersion
+import com.normation.plugins.PluginVersion
 import com.normation.rudder.web.snippet.Login
 import com.normation.zio.UnsafeRun
 import net.liftweb.common.Loggable
@@ -48,7 +48,7 @@ import net.liftweb.util.Helpers.*
 import scala.reflect.ClassTag
 import scala.xml.NodeSeq
 
-class LoginBranding(val status: PluginStatus, version: RudderPluginVersion)(implicit val ttag: ClassTag[Login])
+class LoginBranding(val status: PluginStatus, version: PluginVersion)(implicit val ttag: ClassTag[Login])
     extends PluginExtensionPoint[Login] with Loggable {
 
   def pluginCompose(snippet: Login): Map[String, NodeSeq => NodeSeq] = Map(

--- a/branding/src/main/scala/com/normation/rudder/rest/BrandingApiSchema.scala
+++ b/branding/src/main/scala/com/normation/rudder/rest/BrandingApiSchema.scala
@@ -63,14 +63,16 @@ object BrandingApiEndpoints extends Enum[BrandingApiSchema] with ApiModuleProvid
     val z              = implicitly[Line].value
     val description    = "Update branding plugin configuration"
     val (action, path) = POST / "branding"
-    val dataContainer: Option[String] = None
+    val dataContainer: Option[String]          = None
+    val authz:         List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object ReloadBrandingConf extends BrandingApiSchema with ZeroParam with StartsAtVersion10 with SortIndex {
     val z              = implicitly[Line].value
     val description    = "Reload branding plugin configuration from config file"
     val (action, path) = POST / "branding" / "reload"
-    val dataContainer: Option[String] = None
+    val dataContainer: Option[String]          = None
+    val authz:         List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   def endpoints = values.toList.sortBy(_.z)

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/SupervisedTargetsApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/SupervisedTargetsApi.scala
@@ -88,7 +88,8 @@ object SupervisedTargetsApi       extends Enum[SupervisedTargetsApi] with ApiMod
     val description    = "Save the updated list of groups"
     val (action, path) = POST / "changevalidation" / "supervised" / "targets"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   def endpoints = values.toList.sortBy(_.z)

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ValidatedUserApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ValidatedUserApi.scala
@@ -77,7 +77,8 @@ object ValidatedUserApi       extends Enum[ValidatedUserApi] with ApiModuleProvi
     val (action, path) = DELETE / "validatedUsers" / "{username}"
 
     override val name = "removeValidatedUser"
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
   final case object SaveWorkflowUsers           extends ValidatedUserApi with ZeroParam with StartsAtVersion3 with SortIndex {
     val z              = implicitly[Line].value
@@ -86,6 +87,7 @@ object ValidatedUserApi       extends Enum[ValidatedUserApi] with ApiModuleProvi
 
     override def dataContainer: Option[String] = None
     override val name = "saveWorkflowUser"
+    val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   def endpoints = values.toList.sortBy(_.z)

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/ValidatedUserJdbcRepositoryTest.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/ValidatedUserJdbcRepositoryTest.scala
@@ -5,7 +5,7 @@ import better.files.Resource
 import cats.syntax.apply.*
 import com.normation.eventlog.EventActor
 import com.normation.rudder.db.DBCommon
-import com.normation.rudder.rest.AuthorizationApiMapping
+import com.normation.rudder.rest.ExtensibleAuthorizationApiMapping
 import com.normation.rudder.rest.RoleApiMapping
 import com.normation.rudder.users.FileUserDetailListProvider
 import com.normation.rudder.users.PasswordEncoderDispatcher
@@ -71,7 +71,7 @@ class ValidatedUserJdbcRepositoryTest extends Specification with DBCommon with I
     val usersFile      = {
       UserFile("test-users.xml", getUsersInputStream)
     }
-    val roleApiMapping = new RoleApiMapping(AuthorizationApiMapping.Core)
+    val roleApiMapping = new RoleApiMapping(new ExtensibleAuthorizationApiMapping(Nil))
 
     val res = new FileUserDetailListProvider(roleApiMapping, usersFile, new PasswordEncoderDispatcher(12))
     res.reload()

--- a/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
@@ -66,7 +66,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Reload all datasources for all nodes"
     val (action, path) = POST / "datasources" / "reload" / "node"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object ReloadAllDatasourcesOneNode extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
@@ -74,7 +75,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Reload all datasources for the given node"
     val (action, path) = POST / "datasources" / "reload" / "node" / "{nodeid}"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object ReloadOneDatasourceAllNodes extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
@@ -82,7 +84,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Reload this given datasources for all nodes"
     val (action, path) = POST / "datasources" / "reload" / "{datasourceid}"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object ReloadOneDatasourceOneNode extends DataSourceApi with TwoParam with StartsAtVersion9 with SortIndex {
@@ -90,7 +93,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Reload the given datasource for the given node"
     val (action, path) = POST / "datasources" / "reload" / "{datasourceid}" / "node" / "{nodeid}"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object ClearValueOneDatasourceAllNodes extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
@@ -98,7 +102,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Clear node property values on all nodes for given datasource"
     val (action, path) = POST / "datasources" / "clear" / "{datasourceid}"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object ClearValueOneDatasourceOneNode extends DataSourceApi with TwoParam with StartsAtVersion9 with SortIndex {
@@ -106,7 +111,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Clear node property value set by given datasource on given node"
     val (action, path) = POST / "datasources" / "clear" / "{datasourceid}" / "node" / "{nodeid}"
 
-    override def dataContainer: Option[String] = None
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object GetAllDataSources extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
@@ -132,7 +138,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Delete given datasource"
     val (action, path) = DELETE / "datasources" / "{datasourceid}"
 
-    override def dataContainer: Option[String] = Some("datasources")
+    override def dataContainer: Option[String]          = Some("datasources")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object CreateDataSource extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
@@ -140,7 +147,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Create given datasource"
     val (action, path) = PUT / "datasources"
 
-    override def dataContainer: Option[String] = Some("datasources")
+    override def dataContainer: Option[String]          = Some("datasources")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object UpdateDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
@@ -148,7 +156,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val description    = "Update information about the given datasource"
     val (action, path) = POST / "datasources" / "{datasourceid}"
 
-    override def dataContainer: Option[String] = Some("datasources")
+    override def dataContainer: Option[String]          = Some("datasources")
+    val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   def endpoints = values.toList.sortBy(_.z)

--- a/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApi.scala
+++ b/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApi.scala
@@ -3,6 +3,7 @@ package com.normation.plugins.scaleoutrelay.api
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
 import com.normation.plugins.scaleoutrelay.ScaleOutRelayService
+import com.normation.rudder.AuthorizationType
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction.POST
 import com.normation.rudder.facts.nodes.ChangeContext
@@ -29,12 +30,14 @@ object ScaleOutRelayApi extends Enum[ScaleOutRelayApi] with ApiModuleProvider[Sc
     val z              = implicitly[Line].value
     val description    = "Promote a node to relay"
     val (action, path) = POST / "scaleoutrelay" / "promote" / "{nodeId}"
+    val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   final case object DemoteToNode extends ScaleOutRelayApi with OneParam with StartsAtVersion14 {
     val z              = implicitly[Line].value
     val description    = "Demote a relay to a simple node"
     val (action, path) = POST / "scaleoutrelay" / "demote" / "{nodeId}"
+    val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   override def endpoints: List[ScaleOutRelayApi] = values.toList.sortBy(_.z)


### PR DESCRIPTION
https://issues.rudder.io/issues/26397

Impact of https://github.com/Normation/rudder/pull/5669 (plus some missing renaming of `RudderPluginVersion`) : we need to explicitely declare `Administration.Write` now. 