### PR TITLE
Fixes #26457: Impact of #26335 to ApiAuthorization - again

### DIFF
--- a/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/MockServices.scala
+++ b/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/MockServices.scala
@@ -5,7 +5,7 @@ import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.api.ApiAccount
 import com.normation.rudder.api.ApiAccountId
-import com.normation.rudder.api.ApiToken
+import com.normation.rudder.api.ApiTokenHash
 import com.normation.rudder.api.RoApiAccountRepository
 import com.normation.rudder.api.TokenGenerator
 import com.normation.rudder.api.WoApiAccountRepository
@@ -27,7 +27,7 @@ class MockServices(newToken: String, accounts: Map[ApiAccountId, ApiAccount] = M
     }
 
     override def getAllStandardAccounts: IOResult[Seq[ApiAccount]] = ???
-    override def getByToken(token: ApiToken): IOResult[Option[ApiAccount]] = ???
+    override def getByToken(token: ApiTokenHash): IOResult[Option[ApiAccount]] = ???
     override def getSystemAccount: ApiAccount = ???
   }
 

--- a/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/api/UserApiTest.scala
+++ b/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/api/UserApiTest.scala
@@ -4,19 +4,11 @@ import better.files.*
 import com.normation.errors.IOResult
 import com.normation.errors.effectUioUnit
 import com.normation.rudder.AuthorizationType
-import com.normation.rudder.api.ApiAccount
-import com.normation.rudder.api.ApiAccountId
-import com.normation.rudder.api.ApiAccountKind
-import com.normation.rudder.api.ApiAccountName
-import com.normation.rudder.api.ApiAuthorization
-import com.normation.rudder.api.ApiToken
-import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.api.*
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.rest.RestTestSetUp
 import com.normation.rudder.rest.TraitTestApiFromYamlFiles
-import com.normation.rudder.users.AuthenticatedUser
-import com.normation.rudder.users.RudderAccount
-import com.normation.rudder.users.UserService
+import com.normation.rudder.users.*
 import java.nio.file.Files
 import org.joda.time.DateTime
 import org.joda.time.DateTimeUtils
@@ -43,7 +35,7 @@ class UserApiTest extends ZIOSpecDefault {
       ApiAccountId("user1"),
       ApiAccountKind.System, // so that we have access to the plugin endpoints
       ApiAccountName("user1"),
-      Some(ApiToken("v2:some-hashed-token")),
+      Some(ApiTokenHash.fromHashValue("v2:some-hashed-token")),
       "number one user",
       isEnabled = true,
       creationDate = accountCreationDate,

--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -221,7 +221,7 @@ object AuthBackendsConf extends RudderPluginModule {
   if (isOauthConfiguredByUser) {
     PluginLogger.info(s"Oauthv2 or OIDC authentication backend is enabled, updating login form")
     RudderConfig.snippetExtensionRegister.register(
-      new Oauth2LoginBanner(pluginStatusService, pluginDef.version, oauth2registrations)
+      new Oauth2LoginBanner(pluginStatusService, oauth2registrations)
     )
   }
 }
@@ -1331,7 +1331,7 @@ class RudderJwtAuthenticationConverter(
                   ApiAccountId(jwt.getId),
                   ApiAccountKind.PublicApi(apiAuthz, exp),
                   ApiAccountName(jwt.getId),
-                  Some(ApiToken(jwt.getTokenValue)),
+                  Some(ApiTokenHash.fromHashValue(jwt.getTokenValue)),
                   "",
                   isEnabled = true, // always enabled at that point, since the token is valid
                   created,

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/snippet/Oauth2LoginBanner.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/snippet/Oauth2LoginBanner.scala
@@ -40,7 +40,6 @@ package com.normation.plugins.authbackends.snippet
 import bootstrap.rudder.plugin.AuthBackendsConf
 import com.normation.plugins.PluginExtensionPoint
 import com.normation.plugins.PluginStatus
-import com.normation.plugins.PluginVersion
 import com.normation.plugins.authbackends.LoginFormRendering
 import com.normation.plugins.authbackends.RudderPropertyBasedOAuth2RegistrationDefinition
 import com.normation.rudder.web.snippet.Login
@@ -53,7 +52,6 @@ import scala.xml.NodeSeq
 
 class Oauth2LoginBanner(
     val status:    PluginStatus,
-    version:       PluginVersion,
     registrations: RudderPropertyBasedOAuth2RegistrationDefinition
 )(implicit val ttag: ClassTag[Login])
     extends PluginExtensionPoint[Login] {

--- a/branding/src/main/scala/bootstrap/rudder/plugin/BrandingPluginConf.scala
+++ b/branding/src/main/scala/bootstrap/rudder/plugin/BrandingPluginConf.scala
@@ -65,5 +65,5 @@ object BrandingPluginConf extends RudderPluginModule {
   RudderConfig.rudderApi.addModules(brandingApi.getLiftEndpoints())
   RudderConfig.snippetExtensionRegister.register(new BrandingResources(pluginDef.status))
   RudderConfig.snippetExtensionRegister.register(new CommonBranding(pluginStatusService))
-  RudderConfig.snippetExtensionRegister.register(new LoginBranding(pluginStatusService, pluginDef.version))
+  RudderConfig.snippetExtensionRegister.register(new LoginBranding(pluginStatusService))
 }

--- a/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
@@ -40,7 +40,6 @@ package com.normation.plugins.branding.snippet
 import bootstrap.rudder.plugin.BrandingPluginConf
 import com.normation.plugins.PluginExtensionPoint
 import com.normation.plugins.PluginStatus
-import com.normation.plugins.PluginVersion
 import com.normation.rudder.web.snippet.Login
 import com.normation.zio.UnsafeRun
 import net.liftweb.common.Loggable
@@ -48,7 +47,7 @@ import net.liftweb.util.Helpers.*
 import scala.reflect.ClassTag
 import scala.xml.NodeSeq
 
-class LoginBranding(val status: PluginStatus, version: PluginVersion)(implicit val ttag: ClassTag[Login])
+class LoginBranding(val status: PluginStatus)(implicit val ttag: ClassTag[Login])
     extends PluginExtensionPoint[Login] with Loggable {
 
   def pluginCompose(snippet: Login): Map[String, NodeSeq => NodeSeq] = Map(


### PR DESCRIPTION
https://issues.rudder.io/issues/26457

- remove unused call to `PluginVersion` (changed to `RudderPluginVersion`)
- impact of https://github.com/Normation/rudder/pull/6173 and related PR weren't fully repercuted