### PR TITLE
Fixes #26756: Skipped tests are not skipped

### DIFF
--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsRepositoryTest.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsRepositoryTest.scala
@@ -36,15 +36,13 @@ class UnsupervisedTargetsRepositoryTest extends Specification with JsonSpecMatch
     val file       = tmpDir / "unsupervised-targets.json"
 
     "do nothing if the directory is not writable" in {
-      // THIS IS SKIPPED, see at the end of block
+      skipped("Permissions testing could fail on CI in temporary folder, skipping this for now")
       val unsupervisedRepo = new UnsupervisedTargetsRepository(tmpDirPath, "unsupervised-targets.json")
       tmpDir.setPermissions(PosixFilePermissions.fromString("r--r--r--").asScala.toSet)
 
       unsupervisedRepo.checkPathAndInitRepos().either.runNow must beLeft
       val file = tmpDir / "unsupervised-targets.json"
       file.exists must beFalse
-
-      skipped("Permissions testing could fail on CI in temporary folder, skipping this for now")
     }
 
     "do nothing if the file exists" in {


### PR DESCRIPTION
https://issues.rudder.io/issues/26756

When `skipped` is put at the end, some assertions may still fail and throw before the `Skipped` exception is thrown   