### PR TITLE
Update DataSourcesPluginDef.scala to fix URL

### DIFF
--- a/datasources/src/main/scala/com/normation/plugins/datasources/DataSourcesPluginDef.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/DataSourcesPluginDef.scala
@@ -71,7 +71,7 @@ class DataSourcesPluginDef(override val status: PluginStatus) extends DefaultPlu
   override def pluginMenuEntry: List[(Menu, Option[String])] = {
     (
       (Menu("150-dataSourceManagement", <span>Data sources</span>) /
-      "secure" / "plugins" / "dataSourceManagement"
+      "secure" / "administration" / "dataSourceManagement"
       >> TestAccess(() => Boot.userIsAllowed("/secure/index", Administration.Read))
       >> Template(() =>
         ClasspathTemplates("template" :: "dataSourceManagement" :: Nil) openOr <div>Template not found</div>


### PR DESCRIPTION
In Plugins / Plugin Information, the link points to rudder/secure/administration/dataSourceManagement but page was available at rudder/secure/plugins/dataSourceManagement. I choosed to fix it based on a href reference.