### PR TITLE
Fixes #26788: Rewrite WorkflowInformation navigation bar in Elm

### DIFF
--- a/change-validation/src/main/elm/elm.json
+++ b/change-validation/src/main/elm/elm.json
@@ -12,11 +12,13 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
-            "elm/regex": "1.0.0"
+            "elm/regex": "1.0.0",
+            "elm-explorations/test": "2.2.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
+            "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.3"

--- a/change-validation/src/main/elm/sources/ErrorMessages.elm
+++ b/change-validation/src/main/elm/sources/ErrorMessages.elm
@@ -1,0 +1,26 @@
+module ErrorMessages exposing (..)
+
+import Http
+
+
+getErrorMessage : Http.Error -> String
+getErrorMessage e =
+    let
+        errMessage =
+            case e of
+                Http.BadStatus status ->
+                    "Code " ++ String.fromInt status
+
+                Http.BadUrl str ->
+                    "Invalid API url"
+
+                Http.Timeout ->
+                    "It took too long to get a response"
+
+                Http.NetworkError ->
+                    "Network error"
+
+                Http.BadBody c ->
+                    "Wrong content in request body" ++ c
+    in
+    errMessage

--- a/change-validation/src/main/elm/sources/Init.elm
+++ b/change-validation/src/main/elm/sources/Init.elm
@@ -1,15 +1,6 @@
-port module Init exposing (..)
+module Init exposing (..)
 
 import DataTypes exposing (EditMod(..), Model, Msg(..))
-import Http
-
-------------------------------
--- PORTS
-------------------------------
-
-
-port successNotification : String -> Cmd msg
-port errorNotification : String -> Cmd msg
 
 
 
@@ -20,30 +11,9 @@ port errorNotification : String -> Cmd msg
 
 subscriptions : Model -> Sub Msg
 subscriptions _ =
-  Sub.none
+    Sub.none
+
 
 initModel : String -> Model
-initModel contextPath  =
-  Model contextPath [] [] [] [] [] [] Off
-
-getErrorMessage : Http.Error -> String
-getErrorMessage e =
-    let
-        errMessage =
-            case e of
-                Http.BadStatus status ->
-                    "Code " ++ String.fromInt status
-
-                Http.BadUrl str ->
-                    "Invalid API url"
-
-                Http.Timeout ->
-                    "It took too long to get a response"
-
-                Http.NetworkError ->
-                    "Network error"
-                Http.BadBody c->
-                  "Wrong content in request body" ++ c
-
-    in
-    errMessage
+initModel contextPath =
+    Model contextPath [] [] [] [] [] [] Off

--- a/change-validation/src/main/elm/sources/Notifications.elm
+++ b/change-validation/src/main/elm/sources/Notifications.elm
@@ -1,0 +1,11 @@
+port module Notifications exposing (..)
+
+------------------------------
+-- PORTS
+------------------------------
+
+
+port successNotification : String -> Cmd msg
+
+
+port errorNotification : String -> Cmd msg

--- a/change-validation/src/main/elm/sources/SupervisedTargets.elm
+++ b/change-validation/src/main/elm/sources/SupervisedTargets.elm
@@ -1,16 +1,17 @@
 module SupervisedTargets exposing (Category, Model, Msg(..), Subcategories(..), Target, alphanumericRegex, decodeApiCategory, decodeApiSave, decodeCategory, decodeSubcategories, decodeTarget, displayCategory, displaySubcategories, displayTarget, encodeTargets, getSupervisedIds, getTargets, init, isAlphanumeric, main, saveTargets, subscriptions, update, updateTarget, view)
 
-import Html exposing (..)
 import Browser
+import ErrorMessages exposing (getErrorMessage)
+import Html exposing (..)
 import Html.Attributes exposing (checked, class, type_)
 import Html.Events exposing (..)
 import Http exposing (..)
 import Json.Decode as D exposing (Decoder)
 import Json.Decode.Pipeline exposing (..)
 import Json.Encode as E
+import Notifications exposing (errorNotification, successNotification)
 import Regex
 import String
-import Init exposing (errorNotification, successNotification, getErrorMessage)
 
 
 
@@ -86,10 +87,10 @@ type Msg
     | SaveTargets (Result Error String) -- here the string is just the status message
     | SendSave
     | UpdateTarget Target
-      -- NOTIFICATIONS
 
 
 
+-- NOTIFICATIONS
 ------------------------------
 -- API --
 ------------------------------
@@ -108,7 +109,7 @@ getTargets model =
         req =
             request
                 { method = "GET"
-                , headers = [Http.header "X-Requested-With" "XMLHttpRequest"]
+                , headers = [ Http.header "X-Requested-With" "XMLHttpRequest" ]
                 , url = url
                 , body = emptyBody
                 , expect = expectJson GetTargets decodeApiCategory
@@ -116,7 +117,7 @@ getTargets model =
                 , tracker = Nothing
                 }
     in
-      req
+    req
 
 
 
@@ -129,7 +130,7 @@ saveTargets model =
         req =
             request
                 { method = "POST"
-                , headers = [Http.header "X-Requested-With" "XMLHttpRequest"]
+                , headers = [ Http.header "X-Requested-With" "XMLHttpRequest" ]
                 , url = model.contextPath ++ "/secure/api/changevalidation/supervised/targets"
                 , body = jsonBody (encodeTargets (getSupervisedIds model.allTargets))
                 , expect = expectJson SaveTargets decodeApiSave
@@ -210,7 +211,7 @@ decodeTarget =
 
 encodeTargets : List String -> E.Value
 encodeTargets targets =
-    E.object [ ( "supervised", E.list  (\s -> E.string s) targets ) ]
+    E.object [ ( "supervised", E.list (\s -> E.string s) targets ) ]
 
 
 
@@ -366,6 +367,7 @@ displayTarget target =
                 ]
             ]
         ]
+
 
 
 ------------------------------

--- a/change-validation/src/main/elm/sources/WorkflowInformation.elm
+++ b/change-validation/src/main/elm/sources/WorkflowInformation.elm
@@ -1,0 +1,310 @@
+module WorkflowInformation exposing (..)
+
+import Browser
+import ErrorMessages exposing (getErrorMessage)
+import Html exposing (Html, a, i, li, span, text, ul)
+import Html.Attributes as Attr
+import Http exposing (Error, emptyBody, expectJson, header, request)
+import Json.Decode exposing (Decoder, at, bool, field, index, int, list, map2, maybe)
+import Notifications exposing (errorNotification)
+
+
+
+------------------------------
+-- Init and main --
+------------------------------
+
+
+getApiUrl : Model -> String -> String
+getApiUrl m url =
+    m.contextPath ++ "/secure/api/" ++ url
+
+
+getPendingValidationUrl : Model -> String
+getPendingValidationUrl m =
+    m.contextPath ++ "/secure/configurationManager/changes/changeRequests/Pending_validation"
+
+
+getPendingDeploymentUrl : Model -> String
+getPendingDeploymentUrl m =
+    m.contextPath ++ "/secure/configurationManager/changes/changeRequests/Pending_deployment"
+
+
+init : { contextPath : String } -> ( Model, Cmd Msg )
+init flags =
+    let
+        initModel =
+            Model flags.contextPath NotSet
+    in
+    ( initModel, getWorkflowEnabledSetting initModel )
+
+
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
+
+
+------------------------------
+-- MODEL --
+------------------------------
+
+
+type alias PendingCount =
+    { pendingValidation : Maybe Int
+    , pendingDeployment : Maybe Int
+    , totalCount : Int
+    }
+
+
+type PendingCountOpt
+    = NotSet
+    | PendingCountWithTotal PendingCount
+
+
+type WorkflowInfoStatus
+    = Enabled
+    | Disabled
+
+
+type alias Model =
+    { contextPath : String
+    , pendingCount : PendingCountOpt
+    }
+
+
+type Msg
+    = GetPendingCount (Result Error PendingCountOpt)
+    | GetWorkflowEnabledSetting (Result Error WorkflowInfoStatus)
+
+
+
+------------------------------
+-- API --
+------------------------------
+-- API call to get the number of pending change request for each respective "pending" status
+
+
+getPendingCount : Model -> Cmd Msg
+getPendingCount model =
+    let
+        req =
+            request
+                { method = "GET"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getApiUrl model "changevalidation/workflow/pendingCountByStatus"
+                , body = emptyBody
+                , expect = expectJson GetPendingCount decodePendingCountList
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
+    req
+
+
+getWorkflowEnabledSetting : Model -> Cmd Msg
+getWorkflowEnabledSetting model =
+    let
+        req =
+            request
+                { method = "GET"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getApiUrl model "settings/enable_change_request"
+                , body = emptyBody
+                , expect = expectJson GetWorkflowEnabledSetting decodeEnabledSetting
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
+    req
+
+
+
+------------------------------
+-- ENCODE / DECODE JSON --
+------------------------------
+
+
+pendingCountOpt : Maybe Int -> Maybe Int -> PendingCountOpt
+pendingCountOpt pendingValidation pendingDeployment =
+    case ( pendingValidation, pendingDeployment ) of
+        ( Nothing, Nothing ) ->
+            NotSet
+
+        -- At least one field (pendingValidation and/or pendingDeployment) is not equal to Nothing
+        ( _, _ ) ->
+            PendingCountWithTotal
+                { pendingDeployment = pendingDeployment
+                , pendingValidation = pendingValidation
+                , totalCount = Maybe.withDefault 0 pendingValidation + Maybe.withDefault 0 pendingDeployment
+                }
+
+
+decodePendingCountOpt : Decoder PendingCountOpt
+decodePendingCountOpt =
+    map2
+        pendingCountOpt
+        (maybe (field "pendingValidation" int))
+        (maybe (field "pendingDeployment" int))
+
+
+decodePendingCountList : Decoder PendingCountOpt
+decodePendingCountList =
+    at [ "data" ] (field "workflow" (index 0 decodePendingCountOpt))
+
+
+decodeEnabledSetting : Decoder WorkflowInfoStatus
+decodeEnabledSetting =
+    let
+        boolToStatus b =
+            case b of
+                True ->
+                    Enabled
+
+                False ->
+                    Disabled
+    in
+    let
+        decSetting =
+            field "settings" (field "enable_change_request" (Json.Decode.map boolToStatus bool))
+    in
+    at [ "data" ] decSetting
+
+
+
+------------------------------
+-- UPDATE --
+------------------------------
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        GetPendingCount result ->
+            case result of
+                Ok pendingCount ->
+                    ( { model | pendingCount = pendingCount }, Cmd.none )
+
+                -- Unauthorized access
+                Err (Http.BadStatus 403) ->
+                    ( { model | pendingCount = NotSet }, Cmd.none )
+
+                Err err ->
+                    ( model, errorNotification ("Error while trying to fetch pending change requests: " ++ getErrorMessage err) )
+
+        GetWorkflowEnabledSetting result ->
+            case result of
+                Ok setting ->
+                    case setting of
+                        Enabled ->
+                            ( model, getPendingCount model )
+
+                        Disabled ->
+                            ( { model | pendingCount = NotSet }, Cmd.none )
+
+                -- Unauthorized access
+                Err (Http.BadStatus 403) ->
+                    ( { model | pendingCount = NotSet }, Cmd.none )
+
+                Err err ->
+                    ( model, errorNotification ("Error while trying to fetch change_requests_enabled setting: " ++ getErrorMessage err) )
+
+
+
+------------------------------
+-- VIEW --
+------------------------------
+
+
+view : Model -> Html Msg
+view model =
+    case model.pendingCount of
+        PendingCountWithTotal pc ->
+            li
+                [ Attr.class "nav-item dropdown notifications-menu"
+                , Attr.id "workflow-app"
+                ]
+                [ a
+                    [ Attr.href "#"
+                    , Attr.class "dropdown-toggle"
+                    , Attr.attribute "data-bs-toggle" "dropdown"
+                    , Attr.attribute "role" "button"
+                    , Attr.attribute "aria-expanded" "false"
+                    ]
+                    [ span []
+                        [ text "CR" ]
+                    , viewDropdownToggle pc.totalCount
+                    ]
+                , ul
+                    [ Attr.class "dropdown-menu"
+                    , Attr.attribute "role" "menu"
+                    ]
+                    [ li [] [ viewDropDownMenu model ] ]
+                ]
+
+        NotSet ->
+            text ""
+
+
+viewDropDownMenu : Model -> Html Msg
+viewDropDownMenu model =
+    case model.pendingCount of
+        NotSet ->
+            ul [ Attr.class "menu" ] []
+
+        PendingCountWithTotal pc ->
+            ul [ Attr.class "menu" ]
+                [ displayPendingCount pc.pendingValidation "Pending Validation" (getPendingValidationUrl model) "pe-2 fa fa-flag-o"
+                , displayPendingCount pc.pendingDeployment "Pending Deployment" (getPendingDeploymentUrl model) "pe-2 fa fa-flag-checkered"
+                ]
+
+
+viewDropdownToggle : Int -> Html Msg
+viewDropdownToggle totalCount =
+    span
+        [ Attr.id "number"
+        , Attr.class "badge rudder-badge"
+        ]
+        [ Html.text (String.fromInt totalCount) ]
+
+
+displayPendingCount : Maybe Int -> String -> String -> String -> Html Msg
+displayPendingCount countOpt countName link flag =
+    case countOpt of
+        Nothing ->
+            Html.text ""
+
+        Just count ->
+            li []
+                [ a
+                    [ Attr.href link
+                    , Attr.class "pe-auto"
+                    ]
+                    [ span []
+                        [ i
+                            [ Attr.class flag
+                            ]
+                            []
+                        , Html.text countName
+                        ]
+                    , span
+                        [ Attr.class "float-end badge bg-light text-dark px-2"
+                        ]
+                        [ Html.text (String.fromInt count) ]
+                    ]
+                ]
+
+
+
+------------------------------
+-- SUBSCRIPTIONS
+------------------------------
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.none

--- a/change-validation/src/main/elm/sources/WorkflowInformationTest.elm
+++ b/change-validation/src/main/elm/sources/WorkflowInformationTest.elm
@@ -1,0 +1,88 @@
+module WorkflowInformationTest exposing (..)
+
+import Expect
+import Fuzz exposing (int, maybe)
+import Test exposing (..)
+import WorkflowInformation exposing (PendingCountOpt(..), pendingCountOpt)
+
+
+expectedTotalCount nonOptCount optCount =
+    case optCount of
+        Just res ->
+            res + nonOptCount
+
+        Nothing ->
+            nonOptCount
+
+
+suite =
+    describe "pending count"
+        [ -- A PendingCount Json that has two empty fields will always be decoded as a NotSet object
+          test "NotSet" <|
+            \_ ->
+                pendingCountOpt Nothing Nothing
+                    |> Expect.equal NotSet
+        , -- A PendingCount Json whose pendingValidation field is present will always be decoded as a PendingCountWithTotal object
+          fuzz2
+            int
+            (maybe int)
+            "Non-empty pendingValidation field"
+          <|
+            \pendingValidation pendingDeploymentOpt ->
+                pendingCountOpt (Just pendingValidation) pendingDeploymentOpt
+                    |> Expect.equal
+                        (PendingCountWithTotal
+                            { pendingValidation = Just pendingValidation
+                            , pendingDeployment = pendingDeploymentOpt
+                            , totalCount = expectedTotalCount pendingValidation pendingDeploymentOpt
+                            }
+                        )
+        , -- A PendingCount Json whose pendingDeployment field is present will always be decoded as a PendingCountWithTotal object
+          fuzz2
+            (maybe int)
+            int
+            "Non-empty pendingDeployment field"
+          <|
+            \pendingValidationOpt pendingDeployment ->
+                pendingCountOpt pendingValidationOpt (Just pendingDeployment)
+                    |> Expect.equal
+                        (PendingCountWithTotal
+                            { pendingValidation = pendingValidationOpt
+                            , pendingDeployment = Just pendingDeployment
+                            , totalCount = expectedTotalCount pendingDeployment pendingValidationOpt
+                            }
+                        )
+        , -- A PendingCount Json whose pendingValidation and pendingDeployment fields are both present will always be decoded as a PendingCountWithTotal object
+          fuzz2
+            int
+            int
+            "Non-empty pendingDeployment and pendingValidation fields"
+          <|
+            \pendingValidation pendingDeployment ->
+                pendingCountOpt (Just pendingValidation) (Just pendingDeployment)
+                    |> Expect.equal
+                        (PendingCountWithTotal
+                            { pendingValidation = Just pendingValidation
+                            , pendingDeployment = Just pendingDeployment
+                            , totalCount = pendingValidation + pendingDeployment
+                            }
+                        )
+        , -- After decoding, the obtained PendingCountOpt object must be a 'NotSet' if the two given fields are equal to 'Nothing', and be a 'PendingCountWithTotal' object whose fields are exactly equal to the given values.
+          fuzz2
+            (maybe int)
+            (maybe int)
+            "PendingCountWithTotal cannot have two empty fields"
+          <|
+            \pendingValidation pendingDeployment ->
+                case pendingCountOpt pendingValidation pendingDeployment of
+                    NotSet ->
+                        ( pendingValidation, pendingDeployment ) |> Expect.equal ( Nothing, Nothing )
+
+                    PendingCountWithTotal pendingCount ->
+                        case ( pendingCount.pendingValidation, pendingCount.pendingDeployment ) of
+                            ( Nothing, Nothing ) ->
+                                Expect.fail "PendingCountWithTotal cannot have both of its pendingValidation and pendingDeployment fields be equal to 'Nothing'"
+
+                            ( _, _ ) ->
+                                ( pendingCount.pendingValidation, pendingCount.pendingDeployment ) |> Expect.equal ( pendingValidation, pendingDeployment )
+        ]

--- a/change-validation/src/main/elm/sources/WorkflowUsers.elm
+++ b/change-validation/src/main/elm/sources/WorkflowUsers.elm
@@ -3,8 +3,10 @@ module WorkflowUsers exposing (..)
 import ApiCalls exposing (getUsers)
 import Browser
 import DataTypes exposing (ColPos(..), EditMod(..), Model, Msg(..), User, UserList)
-import Init exposing (initModel, subscriptions, errorNotification, successNotification, getErrorMessage)
+import ErrorMessages exposing (getErrorMessage)
+import Init exposing (initModel, subscriptions)
 import List exposing (filter, member)
+import Notifications exposing (errorNotification, successNotification)
 import String
 import View exposing (view)
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26788

This is part of the plan to remove the dependency to the lift library.

- The `WorkflowInformation` app (the dropdown menu in the navigation bar which displays the number of pending change requests) was mostly migrated to Elm   (see `WorkflowInformation.elm`)
- The `WorkflowInformation.scala` comet actor was not removed since it allows for rerendering the app without refreshing the entire page. The check of the user's authorization type(s) and the check of the value of the `enable_change_request` setting are handled in this comet actor.
- The actor has a mutable state, which allows for the Elm app to be loaded if and only if the app needs to be displayed i.e. if change requests are enabled, *and* if the current user has either or both of the needed rights in order to view the menu (i.e. `Validator.Read` and/or `Deployer.read`). 
Hence, the `workflowEnabledPrev` variable stores the value of the `enable_change_request` setting during the last render, which is compared to the current value of the setting during each re-render. The `shouldLoadScript` variable is updated accordingly during each re-render, and indicates whether the Elm app should be displayed.