### PR TITLE
Fixes #26890: Make node-external-reports not licensed in release build

### DIFF
--- a/Jenkinsfile-release
+++ b/Jenkinsfile-release
@@ -40,7 +40,7 @@ pipeline {
                   running.add("Build")
                   updateSlack(errors, running, slackResponse, message, changeUrl)
                   makeTarget = "licensed"
-                  if (plugin_name == "cis"  || plugin_name == "openscap") {
+                  if (plugin_name == "cis"  || plugin_name == "openscap" || plugin_name == "node-external-reports") {
                     makeTarget = ""
                   }
                   dir("${plugin_name}") {


### PR DESCRIPTION
https://issues.rudder.io/issues/26890