### PR TITLE
Fixes #26946: Add the 'Validate All' check box to the WorkflowUsers Elm app

### DIFF
--- a/change-validation/src/main/elm/sources/ApiCalls.elm
+++ b/change-validation/src/main/elm/sources/ApiCalls.elm
@@ -1,58 +1,62 @@
 module ApiCalls exposing (..)
 
+import DataTypes exposing (..)
 import Http exposing (emptyBody, expectJson, header, jsonBody, request)
 import JsonDecoders exposing (decodeApiDeleteUsername, decodeUserList)
-import DataTypes exposing (..)
 import JsonEncoders exposing (encodeUsernames)
 
-getUrl: DataTypes.Model -> String -> String
+
+getUrl : DataTypes.Model -> String -> String
 getUrl m url =
-  m.contextPath ++ "/secure/api/" ++ url
+    m.contextPath ++ "/secure/api/" ++ url
+
 
 getUsers : DataTypes.Model -> Cmd Msg
 getUsers model =
-  let
-    req =
-      request
-        { method  = "GET"
-        , headers = [header "X-Requested-With" "XMLHttpRequest"]
-        , url     = getUrl model "users"
-        , body    = emptyBody
-        , expect  = expectJson GetUsers decodeUserList
-        , timeout = Nothing
-        , tracker = Nothing
-        }
-  in
+    let
+        req =
+            request
+                { method = "GET"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getUrl model "users"
+                , body = emptyBody
+                , expect = expectJson GetUsers decodeUserList
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
     req
 
-removeValidatedUser: Username -> Model -> Cmd Msg
+
+removeValidatedUser : Username -> Model -> Cmd Msg
 removeValidatedUser username model =
-  let
-    req =
-      request
-        { method  = "DELETE"
-        , headers = [header "X-Requested-With" "XMLHttpRequest"]
-        , url     = getUrl model ("validatedUsers/" ++ username)
-        , body    = emptyBody
-        , expect  = expectJson RemoveUser decodeApiDeleteUsername
-        , timeout = Nothing
-        , tracker = Nothing
-        }
-  in
+    let
+        req =
+            request
+                { method = "DELETE"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getUrl model ("validatedUsers/" ++ username)
+                , body = emptyBody
+                , expect = expectJson RemoveUser decodeApiDeleteUsername
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
     req
+
 
 saveWorkflow : List Username -> Model -> Cmd Msg
 saveWorkflow usernames model =
-  let
-    req =
-      request
-        { method  = "POST"
-        , headers = [header "X-Requested-With" "XMLHttpRequest"]
-        , url     = getUrl model "validatedUsers"
-        , body    = jsonBody (encodeUsernames usernames)
-        , expect  = expectJson SaveWorkflow decodeUserList
-        , timeout = Nothing
-        , tracker = Nothing
-        }
-  in
+    let
+        req =
+            request
+                { method = "POST"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getUrl model "validatedUsers"
+                , body = jsonBody (encodeUsernames usernames)
+                , expect = expectJson SaveWorkflow decodeUserList
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
     req

--- a/change-validation/src/main/elm/sources/ApiCalls.elm
+++ b/change-validation/src/main/elm/sources/ApiCalls.elm
@@ -2,8 +2,9 @@ module ApiCalls exposing (..)
 
 import DataTypes exposing (..)
 import Http exposing (emptyBody, expectJson, header, jsonBody, request)
-import JsonDecoders exposing (decodeApiDeleteUsername, decodeUserList)
-import JsonEncoders exposing (encodeUsernames)
+import Json.Decode exposing (Decoder)
+import JsonDecoders exposing (decodeApiDeleteUsername, decodeSetting, decodeUserList)
+import JsonEncoders exposing (encodeSetting, encodeUsernames)
 
 
 getUrl : DataTypes.Model -> String -> String
@@ -60,3 +61,47 @@ saveWorkflow usernames model =
                 }
     in
     req
+
+
+getSetting : Model -> String -> (Result Http.Error Bool -> Msg) -> Cmd Msg
+getSetting model settingId msg =
+    let
+        req =
+            request
+                { method = "GET"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getUrl model ("settings/" ++ settingId)
+                , body = emptyBody
+                , expect = expectJson msg (decodeSetting settingId)
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
+    req
+
+
+getValidateAllSetting : Model -> Cmd Msg
+getValidateAllSetting model =
+    getSetting model "enable_validate_all" GetValidateAllSetting
+
+
+setSetting : Model -> String -> (Result Http.Error Bool -> Msg) -> Bool -> Cmd Msg
+setSetting model settingId msg newValue =
+    let
+        req =
+            request
+                { method = "POST"
+                , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+                , url = getUrl model ("settings/" ++ settingId)
+                , body = jsonBody (encodeSetting newValue)
+                , expect = expectJson msg (decodeSetting settingId)
+                , timeout = Nothing
+                , tracker = Nothing
+                }
+    in
+    req
+
+
+saveValidateAllSetting : Bool -> Model -> Cmd Msg
+saveValidateAllSetting newValue model =
+    setSetting model "enable_validate_all" SaveValidateAllSetting newValue

--- a/change-validation/src/main/elm/sources/DataTypes.elm
+++ b/change-validation/src/main/elm/sources/DataTypes.elm
@@ -50,8 +50,7 @@ type alias Model =
     , leftChecked : List User
     , hasMoved : List User -- To track updates
     , editMod : EditMod
-    , adminWrite : Bool
-    , validateAll : Bool
+    , hasWriteRights : Bool
     , viewState : ViewState
     }
 

--- a/change-validation/src/main/elm/sources/DataTypes.elm
+++ b/change-validation/src/main/elm/sources/DataTypes.elm
@@ -35,6 +35,7 @@ type alias Model =
   , leftChecked      : List User
   , hasMoved         : List User -- Too track updates
   , editMod          : EditMod
+  , adminWrite       : Bool
   }
 
 getUsernames : UserList -> List Username

--- a/change-validation/src/main/elm/sources/DataTypes.elm
+++ b/change-validation/src/main/elm/sources/DataTypes.elm
@@ -4,57 +4,73 @@ import Http exposing (Error)
 import List exposing (map)
 import Result exposing (Result)
 
-type alias UserList = List User
-type alias Username = String
-type alias ApiMsg = String
+
+type alias UserList =
+    List User
+
+
+type alias Username =
+    String
+
+
+type alias ApiMsg =
+    String
+
 
 type EditMod
-  = On
-  | Off
+    = On
+    | Off
+
+
 
 {--
   Left  : validated users
   Right : unvalidated users
 --}
+
+
 type ColPos
-  = Left
-  | Right
+    = Left
+    | Right
+
 
 type alias User =
-  { username    : Username
-  , isValidated : Bool
-  , isInFile    : Bool
-  }
+    { username : Username
+    , isValidated : Bool
+    , isInFile : Bool
+    }
+
 
 type alias Model =
-  { contextPath      : String
-  , users            : UserList
-  , validatedUsers   : UserList
-  , unvalidatedUsers : UserList
-  , rightChecked     : List User
-  , leftChecked      : List User
-  , hasMoved         : List User -- Too track updates
-  , editMod          : EditMod
-  , adminWrite       : Bool
-  }
+    { contextPath : String
+    , users : UserList
+    , validatedUsers : UserList
+    , unvalidatedUsers : UserList
+    , rightChecked : List User
+    , leftChecked : List User
+    , hasMoved : List User -- Too track updates
+    , editMod : EditMod
+    , adminWrite : Bool
+    }
+
 
 getUsernames : UserList -> List Username
-getUsernames users = map .username users
+getUsernames users =
+    map .username users
+
 
 type Msg
-  =
-  {-- API CALLS --}
-  GetUsers (Result Error UserList)
-  | RemoveUser (Result Error Username)
-  | SaveWorkflow (Result Error UserList)
-  | CallApi (Model -> Cmd Msg)
-  {-- TABLE MANAGE CONTENT --}
-  | LeftToRight
-  | RightToLeft
-  | AddLeftChecked User Bool
-  | AddRightChecked User Bool
-  | CheckAll ColPos Bool
-  {-- MOD MANAGEMENT --}
-  | SwitchMode
-  | ExitEditMod
-
+    = {--API CALLS --}
+      GetUsers (Result Error UserList)
+    | RemoveUser (Result Error Username)
+    | SaveWorkflow (Result Error UserList)
+    | CallApi (Model -> Cmd Msg)
+      {--TABLE MANAGE CONTENT --}
+    | LeftToRight
+    | RightToLeft
+    | AddLeftChecked User Bool
+    | AddRightChecked User Bool
+    | CheckAll ColPos Bool
+      {--MOD MANAGEMENT --}
+    | SwitchMode
+    | ExitEditMod

--- a/change-validation/src/main/elm/sources/DataTypes.elm
+++ b/change-validation/src/main/elm/sources/DataTypes.elm
@@ -48,9 +48,21 @@ type alias Model =
     , unvalidatedUsers : UserList
     , rightChecked : List User
     , leftChecked : List User
-    , hasMoved : List User -- Too track updates
+    , hasMoved : List User -- To track updates
     , editMod : EditMod
     , adminWrite : Bool
+    , validateAll : Bool
+    , viewState : ViewState
+    }
+
+
+type ViewState
+    = NoView
+    | Form { initValues : FormState, formValues : FormState }
+
+
+type alias FormState =
+    { validateAll : Bool -- "enable_validate_all" setting
     }
 
 
@@ -60,7 +72,8 @@ getUsernames users =
 
 
 type Msg
-    = {--API CALLS --}
+    = {--Messages for the "Workflow Users" table --}
+      {--API CALLS --}
       GetUsers (Result Error UserList)
     | RemoveUser (Result Error Username)
     | SaveWorkflow (Result Error UserList)
@@ -74,3 +87,9 @@ type Msg
       {--MOD MANAGEMENT --}
     | SwitchMode
     | ExitEditMod
+      {--Messages for the "Validate all changes" checkbox and button --}
+      {--API CALLS--}
+    | GetValidateAllSetting (Result Error Bool)
+    | SaveValidateAllSetting (Result Error Bool)
+      {--VIEW UPDATE--}
+    | ChangeValidateAllSetting Bool

--- a/change-validation/src/main/elm/sources/Init.elm
+++ b/change-validation/src/main/elm/sources/Init.elm
@@ -1,6 +1,6 @@
 module Init exposing (..)
 
-import DataTypes exposing (EditMod(..), Model, Msg(..))
+import DataTypes exposing (EditMod(..), Model, Msg(..), ViewState(..))
 
 
 
@@ -16,4 +16,4 @@ subscriptions _ =
 
 initModel : String -> Bool -> Model
 initModel contextPath adminWrite =
-    Model contextPath [] [] [] [] [] [] Off adminWrite
+    Model contextPath [] [] [] [] [] [] Off adminWrite False NoView

--- a/change-validation/src/main/elm/sources/Init.elm
+++ b/change-validation/src/main/elm/sources/Init.elm
@@ -14,6 +14,6 @@ subscriptions _ =
     Sub.none
 
 
-initModel : String -> Model
-initModel contextPath =
-    Model contextPath [] [] [] [] [] [] Off
+initModel : String -> Bool -> Model
+initModel contextPath adminWrite =
+    Model contextPath [] [] [] [] [] [] Off adminWrite

--- a/change-validation/src/main/elm/sources/Init.elm
+++ b/change-validation/src/main/elm/sources/Init.elm
@@ -15,5 +15,5 @@ subscriptions _ =
 
 
 initModel : String -> Bool -> Model
-initModel contextPath adminWrite =
-    Model contextPath [] [] [] [] [] [] Off adminWrite False NoView
+initModel contextPath hasWriteRights =
+    Model contextPath [] [] [] [] [] [] Off hasWriteRights NoView

--- a/change-validation/src/main/elm/sources/JsonDecoders.elm
+++ b/change-validation/src/main/elm/sources/JsonDecoders.elm
@@ -1,7 +1,7 @@
 module JsonDecoders exposing (..)
 
 import DataTypes exposing (ApiMsg, User, UserList, Username)
-import Json.Decode exposing (Decoder, at, bool, list, string, succeed)
+import Json.Decode exposing (Decoder, at, bool, field, list, string, succeed)
 import Json.Decode.Pipeline exposing (required)
 
 
@@ -21,3 +21,12 @@ decodeUserList =
 decodeApiDeleteUsername : Decoder Username
 decodeApiDeleteUsername =
     at [ "data" ] string
+
+
+decodeSetting : String -> Decoder Bool
+decodeSetting fieldName =
+    let
+        decSetting =
+            field "settings" (field fieldName bool)
+    in
+    at [ "data" ] decSetting

--- a/change-validation/src/main/elm/sources/JsonDecoders.elm
+++ b/change-validation/src/main/elm/sources/JsonDecoders.elm
@@ -4,17 +4,20 @@ import DataTypes exposing (ApiMsg, User, UserList, Username)
 import Json.Decode exposing (Decoder, at, bool, list, string, succeed)
 import Json.Decode.Pipeline exposing (required)
 
+
 decodeUser : Decoder User
 decodeUser =
-  succeed User
-    |> required "username" string
-    |> required "isValidated" bool
-    |> required "userExists" bool
+    succeed User
+        |> required "username" string
+        |> required "isValidated" bool
+        |> required "userExists" bool
+
 
 decodeUserList : Decoder UserList
 decodeUserList =
-  at [ "data" ] (list decodeUser)
+    at [ "data" ] (list decodeUser)
+
 
 decodeApiDeleteUsername : Decoder Username
 decodeApiDeleteUsername =
-  at [ "data" ] string
+    at [ "data" ] string

--- a/change-validation/src/main/elm/sources/JsonEncoders.elm
+++ b/change-validation/src/main/elm/sources/JsonEncoders.elm
@@ -34,3 +34,8 @@ encodeUsernames usernames =
         [ ( "action", string "addValidatedUsersList" )
         , ( "validatedUsers", list (\s -> string s) usernames )
         ]
+
+
+encodeSetting : Bool -> Value
+encodeSetting value =
+    object [ ( "value", bool value ) ]

--- a/change-validation/src/main/elm/sources/JsonEncoders.elm
+++ b/change-validation/src/main/elm/sources/JsonEncoders.elm
@@ -3,29 +3,34 @@ module JsonEncoders exposing (..)
 import DataTypes exposing (User, Username)
 import Json.Encode exposing (Value, bool, list, object, string)
 
-username : Username -> (String, Value)
+
+username : Username -> ( String, Value )
 username value =
-  ("username", string value)
+    ( "username", string value )
 
-isValidated : Bool -> (String, Value)
+
+isValidated : Bool -> ( String, Value )
 isValidated value =
-  ("isValidated", bool value)
+    ( "isValidated", bool value )
 
-isInFile : Bool -> (String, Value)
+
+isInFile : Bool -> ( String, Value )
 isInFile value =
-  ("userExists", bool value)
+    ( "userExists", bool value )
+
 
 encodeUser : User -> Value
 encodeUser userInfo =
-  object
-  [ username userInfo.username
-  , isValidated userInfo.isValidated
-  , isInFile userInfo.isInFile
-  ]
+    object
+        [ username userInfo.username
+        , isValidated userInfo.isValidated
+        , isInFile userInfo.isInFile
+        ]
+
 
 encodeUsernames : List Username -> Value
 encodeUsernames usernames =
-  object
-  [ ("action", string "addValidatedUsersList")
-  , ("validatedUsers", list (\s -> string s) usernames)
-  ]
+    object
+        [ ( "action", string "addValidatedUsersList" )
+        , ( "validatedUsers", list (\s -> string s) usernames )
+        ]

--- a/change-validation/src/main/elm/sources/SupervisedTargets.elm
+++ b/change-validation/src/main/elm/sources/SupervisedTargets.elm
@@ -31,7 +31,7 @@ subscriptions model =
 ------------------------------
 
 
-init : { contextPath : String, adminWrite : Bool } -> ( Model, Cmd Msg )
+init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 init flags =
     let
         initModel =

--- a/change-validation/src/main/elm/sources/SupervisedTargets.elm
+++ b/change-validation/src/main/elm/sources/SupervisedTargets.elm
@@ -31,7 +31,7 @@ subscriptions model =
 ------------------------------
 
 
-init : { contextPath : String } -> ( Model, Cmd Msg )
+init : { contextPath : String, adminWrite : Bool } -> ( Model, Cmd Msg )
 init flags =
     let
         initModel =

--- a/change-validation/src/main/elm/sources/View.elm
+++ b/change-validation/src/main/elm/sources/View.elm
@@ -8,92 +8,104 @@ import Html.Events exposing (onCheck, onClick)
 import List exposing (isEmpty, length, member)
 import String exposing (fromInt)
 
+
 createInfoTootlip : String -> String -> Html msg
 createInfoTootlip content placement =
-  span
-  [
-      class "fa fa-exclamation-triangle center-box-element input-icon bstool"
-    , attribute "data-bs-toggle" "tooltip"
-    , attribute "data-bs-placement" placement
-    , attribute "title" content
-  ][]
+    span
+        [ class "fa fa-exclamation-triangle center-box-element input-icon bstool"
+        , attribute "data-bs-toggle" "tooltip"
+        , attribute "data-bs-placement" placement
+        , attribute "title" content
+        ]
+        []
+
+
 
 -- Displayed nb items and nb selected items when edition mod is On
-displayFooter: Model -> ColPos -> Html Msg
+
+
+displayFooter : Model -> ColPos -> Html Msg
 displayFooter model pos =
-  let
-    isChecked =
-      case pos of
-        Left ->
-          (length model.leftChecked == length model.validatedUsers) && not (isEmpty model.leftChecked)
-        Right ->
-          (length model.rightChecked == length model.unvalidatedUsers) && not (isEmpty model.rightChecked)
-  in
-    div [class "box-footer"]
-    [
-      label [class "all-items"]
-      [
-        input
-        [
-            class ""
-          , onCheck (\checkStatus-> CheckAll pos checkStatus)
-          , type_ "checkbox"
-          , value
-          (
+    let
+        isChecked =
             case pos of
-              Left ->
-                 fromInt (length model.validatedUsers)
-              Right ->
-                 fromInt (length model.unvalidatedUsers)
-          )
-          , checked  (isChecked)
-          , disabled
-          (
-            case pos of
-              Left ->
-                isEmpty model.validatedUsers
-              Right ->
-                isEmpty model.unvalidatedUsers
-          )
-        ] []
-      ],
-      div [id "nb-items", class "footer-infos nb-items"]
-      [
-        case pos of
-          Left -> text (( fromInt (length model.validatedUsers)) ++ " Items")
-          Right ->  text (( fromInt (length model.unvalidatedUsers)) ++ " Items")
-      ],
-      div [id "nb-selected", class "footer-infos"]
-      [
-        case pos of
-          Left ->
-            if (length model.leftChecked == length model.validatedUsers) && (not (isEmpty model.leftChecked)) then
-              text "All Selected"
-            else
-              text ((fromInt (length model.leftChecked)) ++ " Selected")
-          Right ->
-            if (length model.rightChecked == length model.unvalidatedUsers) && (not (isEmpty model.rightChecked)) then
-              text "All Selected"
-            else
-              text ((fromInt (length model.rightChecked)) ++ " Selected")
-      ]
-    ]
+                Left ->
+                    (length model.leftChecked == length model.validatedUsers) && not (isEmpty model.leftChecked)
+
+                Right ->
+                    (length model.rightChecked == length model.unvalidatedUsers) && not (isEmpty model.rightChecked)
+    in
+    div [ class "box-footer" ]
+        [ label [ class "all-items" ]
+            [ input
+                [ class ""
+                , onCheck (\checkStatus -> CheckAll pos checkStatus)
+                , type_ "checkbox"
+                , value
+                    (case pos of
+                        Left ->
+                            fromInt (length model.validatedUsers)
+
+                        Right ->
+                            fromInt (length model.unvalidatedUsers)
+                    )
+                , checked isChecked
+                , disabled
+                    (case pos of
+                        Left ->
+                            isEmpty model.validatedUsers
+
+                        Right ->
+                            isEmpty model.unvalidatedUsers
+                    )
+                ]
+                []
+            ]
+        , div [ id "nb-items", class "footer-infos nb-items" ]
+            [ case pos of
+                Left ->
+                    text (fromInt (length model.validatedUsers) ++ " Items")
+
+                Right ->
+                    text (fromInt (length model.unvalidatedUsers) ++ " Items")
+            ]
+        , div [ id "nb-selected", class "footer-infos" ]
+            [ case pos of
+                Left ->
+                    if (length model.leftChecked == length model.validatedUsers) && not (isEmpty model.leftChecked) then
+                        text "All Selected"
+
+                    else
+                        text (fromInt (length model.leftChecked) ++ " Selected")
+
+                Right ->
+                    if (length model.rightChecked == length model.unvalidatedUsers) && not (isEmpty model.rightChecked) then
+                        text "All Selected"
+
+                    else
+                        text (fromInt (length model.rightChecked) ++ " Selected")
+            ]
+        ]
+
+
 
 {--
   The box containing all users in the system who are not validated
   Displayed when edition mod is On
 --}
+
+
 displayRightCol : Model -> Html Msg
 displayRightCol model =
-  div [ class "box-users-container"]
-  [
-    h5 [ class "box-header" ] [ b [][ text "Users" ]],
-    div  [ class "box-users-content" ]
-    [
-      renderUsers  model.unvalidatedUsers Right model
-    ],
-    displayFooter model Right
-  ]
+    div [ class "box-users-container" ]
+        [ h5 [ class "box-header" ] [ b [] [ text "Users" ] ]
+        , div [ class "box-users-content" ]
+            [ renderUsers model.unvalidatedUsers Right model
+            ]
+        , displayFooter model Right
+        ]
+
+
 
 {--
   Helper function to display individual user's row
@@ -105,105 +117,131 @@ displayRightCol model =
 
   On edition mod "On" interactions are activated
 --}
+
+
 renderUserHelper : User -> ColPos -> Model -> Html Msg
 renderUserHelper user pos model =
-  let
-    isEditActivate = if model.editMod == On then True else False
-    sideChecked =
-      case pos of
-        Left -> AddLeftChecked user ( not (member user model.leftChecked))
-        Right -> AddRightChecked user (  not (member user model.rightChecked))
-    isChecked =
-      case pos of
-        Left -> member user model.leftChecked
-        Right -> member user model.rightChecked
-    content =
-      li[ class "li-box-content-user" ]
-      [
-        label [ style "vertical-align" "middle", style "display" "inline-block" ]
-        [
-          if isEditActivate then
-            input
-            [
-              class "box-input-element center-box-element"
-            , type_ "checkbox"
-            , value user.username
-            , checked isChecked
-            ] []
-          else
-            div [class "box-input-element center-box-element"] []
-        ]
-        , div[ class "center-box-element" ][ text <| user.username ],
-          if not user.isInFile then
-            createInfoTootlip
-            """
+    let
+        isEditActivate =
+            if model.editMod == On then
+                True
+
+            else
+                False
+
+        sideChecked =
+            case pos of
+                Left ->
+                    AddLeftChecked user (not (member user model.leftChecked))
+
+                Right ->
+                    AddRightChecked user (not (member user model.rightChecked))
+
+        isChecked =
+            case pos of
+                Left ->
+                    member user model.leftChecked
+
+                Right ->
+                    member user model.rightChecked
+
+        content =
+            li [ class "li-box-content-user" ]
+                [ label [ style "vertical-align" "middle", style "display" "inline-block" ]
+                    [ if isEditActivate then
+                        input
+                            [ class "box-input-element center-box-element"
+                            , type_ "checkbox"
+                            , value user.username
+                            , checked isChecked
+                            ]
+                            []
+
+                      else
+                        div [ class "box-input-element center-box-element" ] []
+                    ]
+                , div [ class "center-box-element" ] [ text <| user.username ]
+                , if not user.isInFile then
+                    createInfoTootlip
+                        """
             The user <b> doesn't exist anymore </b> but they are still a validated user, delete them by removing them from the validated users.
             """
-             "auto"
-          else
-            div [][]
-      ]
-  in
+                        "auto"
+
+                  else
+                    div [] []
+                ]
+    in
     if isEditActivate then
-      if member user model.hasMoved then
-        if isChecked  then
-          div [class "users moved-checked", onClick sideChecked ] [ content ]
+        if member user model.hasMoved then
+            if isChecked then
+                div [ class "users moved-checked", onClick sideChecked ] [ content ]
+
+            else
+                div [ id "moved-user", class "users-clickable", onClick sideChecked ] [ content ]
+
+        else if user.isInFile then
+            if isChecked then
+                div [ class "users normal-checked", onClick sideChecked ] [ content ]
+
+            else
+                div [ id "normal-user", class "users-clickable", onClick sideChecked ] [ content ]
+
+        else if isChecked then
+            div [ class "users not-in-file-checked", onClick sideChecked ] [ content ]
+
         else
-          div [ id "moved-user", class "users-clickable", onClick sideChecked ] [ content ]
-      else if user.isInFile then
-        if isChecked then
-          div [class "users normal-checked", onClick sideChecked ] [ content ]
-        else
-          div [ id "normal-user", class "users-clickable", onClick sideChecked ] [ content ]
-      else
-        if isChecked then
-          div [class "users not-in-file-checked", onClick sideChecked ] [ content ]
-        else
-          div [ id "not-in-file-user", class "users-clickable", onClick sideChecked ] [ content ]
-    -- deactivate the ability to select users in edition mod "Off"
+            div [ id "not-in-file-user", class "users-clickable", onClick sideChecked ] [ content ]
+        -- deactivate the ability to select users in edition mod "Off"
+
+    else if user.isInFile then
+        div [ id "normal-user", class "users" ] [ content ]
+
     else
-      if user.isInFile then
-        div [ id "normal-user", class "users"] [ content ]
-      else
-        div [ id "not-in-file-user", class "users"] [ content ]
+        div [ id "not-in-file-user", class "users" ] [ content ]
+
+
 
 {--
   Display all users according to the box they belong
       Left  -> validated
       Right -> unvalidated
 --}
+
+
 renderUsers : UserList -> ColPos -> Model -> Html Msg
 renderUsers users pos model =
-  ul [ ] (List.map (\u -> renderUserHelper u pos model) users)
+    ul [] (List.map (\u -> renderUserHelper u pos model) users)
 
 
 displayArrows : Model -> Html Msg
 displayArrows model =
-  let
-    leftArrowBtnType  =
-      if (isEmpty model.rightChecked) then
-        "btn btn-sm move-left btn-default"
-      else
-        "btn btn-sm move-left btn-primary"
-    rightArrowBtnType =
-      if (isEmpty model.leftChecked) then
-        "btn btn-sm move-right btn-default"
-      else
-        "btn btn-sm move-right btn-primary"
-  in
-    div [ class "list-arrows arrows-validation"]
-      [
-        button [ onClick LeftToRight, class rightArrowBtnType, disabled (isEmpty model.leftChecked) ]
-        [
-          span [ class "fa fa-chevron-right" ][]
-        ],
-        br [] [],
-        br [] [],
-        button [ onClick RightToLeft,class leftArrowBtnType, disabled (isEmpty model.rightChecked)]
-        [
-          span [ class "fa fa-chevron-left" ] []
+    let
+        leftArrowBtnType =
+            if isEmpty model.rightChecked then
+                "btn btn-sm move-left btn-default"
+
+            else
+                "btn btn-sm move-left btn-primary"
+
+        rightArrowBtnType =
+            if isEmpty model.leftChecked then
+                "btn btn-sm move-right btn-default"
+
+            else
+                "btn btn-sm move-right btn-primary"
+    in
+    div [ class "list-arrows arrows-validation" ]
+        [ button [ onClick LeftToRight, class rightArrowBtnType, disabled (isEmpty model.leftChecked) ]
+            [ span [ class "fa fa-chevron-right" ] []
+            ]
+        , br [] []
+        , br [] []
+        , button [ onClick RightToLeft, class leftArrowBtnType, disabled (isEmpty model.rightChecked) ]
+            [ span [ class "fa fa-chevron-left" ] []
+            ]
         ]
-      ]
+
 
 
 {--
@@ -214,80 +252,89 @@ displayArrows model =
 
   The footer is displayed only in edition mod
 --}
+
+
 displayLeftCol : Model -> Html Msg
 displayLeftCol model =
-  let
-    cancelType =
-        if model.editMod == On && (isEmpty model.hasMoved) then
-          ExitEditMod
-        else
-          CallApi getUsers
-    actnBtnIfModif =
-      if model.editMod == Off then
-        div [] []
-      else
-        div []
-        [
-          button
-          [
-            id "cancel-workflow"
-          , class "btn btn-default btn-action-workflow"
-          , onClick cancelType
-          , type_ "button"
-          ] [text <| if cancelType == ExitEditMod then "Exit" else "Cancel"]
-          ,
-          if not (isEmpty model.hasMoved) then
-            button
-            [
-              id "save-workflow "
-            , class "btn btn-success btn-action-workflow"
-            , onClick (CallApi (saveWorkflow (getUsernames model.validatedUsers)))
-            , type_ "button"
-            ] [text <| "Save"]
-          else
-            div [] []
-        ]
-  in
+    let
+        cancelType =
+            if model.editMod == On && isEmpty model.hasMoved then
+                ExitEditMod
+
+            else
+                CallApi getUsers
+
+        actnBtnIfModif =
+            if model.editMod == Off then
+                div [] []
+
+            else
+                div []
+                    [ button
+                        [ id "cancel-workflow"
+                        , class "btn btn-default btn-action-workflow"
+                        , onClick cancelType
+                        , type_ "button"
+                        ]
+                        [ text <|
+                            if cancelType == ExitEditMod then
+                                "Exit"
+
+                            else
+                                "Cancel"
+                        ]
+                    , if not (isEmpty model.hasMoved) then
+                        button
+                            [ id "save-workflow "
+                            , class "btn btn-success btn-action-workflow"
+                            , onClick (CallApi (saveWorkflow (getUsernames model.validatedUsers)))
+                            , type_ "button"
+                            ]
+                            [ text <| "Save" ]
+
+                      else
+                        div [] []
+                    ]
+    in
     div []
-    [
-      div [ class "box-users-container "]
-      [
-        h5 [class "box-header"] [ b [][text "Validated users"]],
-        div  [class "box-users-content"]
-        [
-          if isEmpty model.validatedUsers then
-            div [style "text-align" "center"]
-            [
-              if model.editMod == Off then
-                i [class "fa fa-user-times empty-validated-user", style "margin-bottom" "10px"]
-                [
-                  br [][],
-                  p [class "empty-box-msg"] [text "No validated users found"]
+        [ div [ class "box-users-container " ]
+            [ h5 [ class "box-header" ] [ b [] [ text "Validated users" ] ]
+            , div [ class "box-users-content" ]
+                [ if isEmpty model.validatedUsers then
+                    div [ style "text-align" "center" ]
+                        [ if model.editMod == Off then
+                            i [ class "fa fa-user-times empty-validated-user", style "margin-bottom" "10px" ]
+                                [ br [] []
+                                , p [ class "empty-box-msg" ] [ text "No validated users found" ]
+                                ]
+
+                          else
+                            div [] []
+                        ]
+
+                  else
+                    renderUsers model.validatedUsers Left model
                 ]
-                else
-                  div [] []
+            , case model.editMod of
+                On ->
+                    div [] []
+
+                Off ->
+                    div [ class "circle-edit", onClick SwitchMode ]
+                        [ i [ class "edit-icon-validated-user fa fa-pencil", style "margin" "0" ] []
+                        ]
             ]
-          else
-           renderUsers model.validatedUsers Left model
-        ],
-        case model.editMod of
-          On ->
-            div [] []
-          Off ->
-            div [class "circle-edit", onClick SwitchMode]
-            [
-              i [class "edit-icon-validated-user fa fa-pencil", style "margin" "0"] []
+        , case model.editMod of
+            On ->
+                displayFooter model Left
+
+            Off ->
+                div [] []
+        , div [ class "action-button-container" ]
+            [ actnBtnIfModif
             ]
-      ],
-      case model.editMod of
-        On -> displayFooter model Left
-        Off -> div [][]
-      ,
-      div [class "action-button-container"]
-      [
-        actnBtnIfModif
-      ]
-    ]
+        ]
+
 
 view : Model -> Html Msg
 view model =

--- a/change-validation/src/main/elm/sources/View.elm
+++ b/change-validation/src/main/elm/sources/View.elm
@@ -379,7 +379,9 @@ view model =
                         ]
                     ]
                 , createRightInfoSection
-                    [ " Any change done by a validated user will be automatically deployed without validation needed by another user. " ]
+                    [ " Any modification made by a validated user will be automatically deployed, "
+                        ++ "without needing to be validated by another user first. "
+                    ]
                 ]
     in
     div
@@ -433,9 +435,9 @@ displayValidateAllForm model =
                         ]
                     ]
                 , createRightInfoSection
-                    [ " Any change done by a Validated User will be automatically approved no matter the nature of the change. "
-                    , " Configuring groups below will hence have no effect on validated users (in the list above), but will apply"
-                        ++ " to non-validated users, who will still need a change request to modify a node from a supervised group. "
+                    [ " Any modification made by a validated user will be automatically approved no matter the nature of the change. "
+                    , " Hence, configuring the groups below will have no effect on validated users (in the list above), but will apply"
+                        ++ " to non-validated users, who will still need to create a change request in order to modify a node from a supervised group. "
                     ]
                 ]
 

--- a/change-validation/src/main/elm/sources/View.elm
+++ b/change-validation/src/main/elm/sources/View.elm
@@ -3,7 +3,7 @@ module View exposing (..)
 import ApiCalls exposing (getUsers, saveWorkflow)
 import DataTypes exposing (ColPos(..), EditMod(..), Model, Msg(..), User, UserList, Username, getUsernames)
 import Html exposing (..)
-import Html.Attributes exposing (attribute, checked, class, disabled, id, style, type_, value)
+import Html.Attributes as Attr exposing (attribute, checked, class, disabled, id, style, type_, value)
 import Html.Events exposing (onCheck, onClick)
 import List exposing (isEmpty, length, member)
 import String exposing (fromInt)
@@ -291,19 +291,93 @@ displayLeftCol model =
 
 view : Model -> Html Msg
 view model =
-  div []
-  [
-    case model.editMod of
-      On ->
-        div [class "inner-portlet" ,style "display" "flex", style "justify-content" "center"]
-        [
-          displayLeftCol model
-        , displayArrows model
-        , displayRightCol model
+    let
+        validateAllForm =
+            if model.adminWrite then
+                [ Html.br [] [], displayValidateAllForm model ]
+
+            else
+                [ text "" ]
+    in
+    let
+        workflowUsers =
+            div [ Attr.class "section-with-doc" ]
+                [ div [ Attr.class "section-left" ]
+                    [ div
+                        []
+                        [ case model.editMod of
+                            On ->
+                                div [ class "inner-portlet", style "display" "flex", style "justify-content" "center", id "workflowUsers" ]
+                                    [ displayLeftCol model
+                                    , displayArrows model
+                                    , displayRightCol model
+                                    ]
+
+                            Off ->
+                                div [ class "inner-portlet", style "display" "flex", style "justify-content" "center" ]
+                                    [ displayLeftCol model
+                                    ]
+                        ]
+                    ]
+                , div [ Attr.class "section-right" ]
+                    [ div
+                        [ Attr.class "doc doc-info" ]
+                        [ div [ Attr.class "marker" ]
+                            [ span [ Attr.class "fa fa-info-circle" ] [] ]
+                        , p [] [ text " Any change done by a validated user will be automatically deployed without validation needed by another user. " ]
+                        ]
+                    ]
+                ]
+    in
+    div
+        [ Attr.id "workflowUsers" ]
+        (List.append [ workflowUsers ] validateAllForm)
+
+
+displayValidateAllForm : Model -> Html Msg
+displayValidateAllForm model =
+    div
+        [ Attr.class "section-with-doc" ]
+        [ div [ Attr.class "section-left" ]
+            [ form []
+                [ ul []
+                    [ li
+                        [ Attr.class "rudder-form" ]
+                        [ div [ Attr.class "input-group" ]
+                            [ label
+                                [ Attr.class "input-group-addon"
+                                , Attr.for "validationAutoValidatedUser"
+                                ]
+                                [ input
+                                    [ Attr.type_ "checkbox"
+                                    , Attr.value "Reload"
+                                    , Attr.id "validationAutoValidatedUser"
+                                    ]
+                                    []
+                                , label
+                                    [ Attr.for "validationAutoValidatedUser", Attr.class "label-radio" ]
+                                    [ span [ Attr.class "ion ion-checkmark-round" ] [] ]
+                                , span [ Attr.class "ion ion-checkmark-round check-icon" ] []
+                                ]
+                            , label
+                                [ Attr.class "form-control", Attr.for "validationAutoValidatedUser" ]
+                                [ text " Validate all changes " ]
+                            ]
+                        ]
+                    ]
+                , input
+                    [ Attr.type_ "submit"
+                    , Attr.value "Save change"
+                    , Attr.id "validationAutoSubmit"
+                    ]
+                    []
+                ]
+            ]
+        , div [ Attr.class "section-right" ]
+            [ div [ Attr.class "doc doc-info" ]
+                [ div [ Attr.class "marker" ] [ span [ Attr.class "fa fa-info-circle" ] [] ]
+                , p [] [ text " Any change done by a Validated User will be automatically approved no matter the nature of the change. " ]
+                , p [] [ text " Configuring groups below will hence have no effect on validated users (in the list above), but will apply to non-validated users, who will still need a change request to modify a node from a supervised group. " ]
+                ]
+            ]
         ]
-      Off ->
-        div [class "inner-portlet" ,style "display" "flex", style "justify-content" "center"]
-        [
-          displayLeftCol model
-        ]
-  ]

--- a/change-validation/src/main/elm/sources/View.elm
+++ b/change-validation/src/main/elm/sources/View.elm
@@ -3,7 +3,7 @@ module View exposing (..)
 import ApiCalls exposing (getUsers, saveValidateAllSetting, saveWorkflow)
 import DataTypes exposing (ColPos(..), EditMod(..), Model, Msg(..), User, UserList, Username, ViewState(..), getUsernames)
 import Html exposing (..)
-import Html.Attributes as Attr exposing (attribute, checked, class, disabled, id, style, type_, value)
+import Html.Attributes exposing (attribute, checked, class, disabled, for, id, style, type_, value)
 import Html.Events exposing (onCheck, onClick)
 import List exposing (isEmpty, length, member)
 import String exposing (fromInt)
@@ -26,9 +26,9 @@ createRightInfoSection paragraphs =
         paragraphElements =
             List.map (\paragraphContent -> p [] [ text paragraphContent ]) paragraphs
     in
-    div [ Attr.class "section-right" ]
-        [ div [ Attr.class "doc doc-info" ]
-            ([ div [ Attr.class "marker" ] [ span [ Attr.class "fa fa-info-circle" ] [] ] ] ++ paragraphElements)
+    div [ class "section-right" ]
+        [ div [ class "doc doc-info" ]
+            ([ div [ class "marker" ] [ span [ class "fa fa-info-circle" ] [] ] ] ++ paragraphElements)
         ]
 
 
@@ -352,16 +352,16 @@ view : Model -> Html Msg
 view model =
     let
         validateAllForm =
-            if model.adminWrite then
+            if model.hasWriteRights then
                 [ Html.br [] [], displayValidateAllForm model ]
 
             else
-                [ text "" ]
+                []
     in
     let
         workflowUsers =
-            div [ Attr.class "section-with-doc" ]
-                [ div [ Attr.class "section-left" ]
+            div [ class "section-with-doc" ]
+                [ div [ class "section-left" ]
                     [ div
                         []
                         [ case model.editMod of
@@ -385,8 +385,8 @@ view model =
                 ]
     in
     div
-        [ Attr.id "workflowUsers" ]
-        (List.append [ workflowUsers ] validateAllForm)
+        [ id "workflowUsers" ]
+        (workflowUsers :: validateAllForm)
 
 
 displayValidateAllForm : Model -> Html Msg
@@ -394,41 +394,41 @@ displayValidateAllForm model =
     case model.viewState of
         Form formState ->
             div
-                [ Attr.class "section-with-doc" ]
-                [ div [ Attr.class "section-left" ]
+                [ class "section-with-doc" ]
+                [ div [ class "section-left" ]
                     [ form []
                         [ ul []
                             [ li
-                                [ Attr.class "rudder-form" ]
-                                [ div [ Attr.class "input-group" ]
+                                [ class "rudder-form" ]
+                                [ div [ class "input-group" ]
                                     [ label
-                                        [ Attr.class "input-group-addon"
-                                        , Attr.for "validationAutoValidatedUser"
+                                        [ class "input-group-addon"
+                                        , for "validationAutoValidatedUser"
                                         ]
                                         [ input
-                                            [ Attr.type_ "checkbox"
-                                            , Attr.id "validationAutoValidatedUser"
-                                            , Attr.checked formState.formValues.validateAll
+                                            [ type_ "checkbox"
+                                            , id "validationAutoValidatedUser"
+                                            , checked formState.formValues.validateAll
                                             , onClick (ChangeValidateAllSetting (not formState.formValues.validateAll))
                                             ]
                                             []
                                         , label
-                                            [ Attr.for "validationAutoValidatedUser", Attr.class "label-radio" ]
-                                            [ span [ Attr.class "ion ion-checkmark-round" ] [] ]
-                                        , span [ Attr.class "ion ion-checkmark-round check-icon" ] []
+                                            [ for "validationAutoValidatedUser", class "label-radio" ]
+                                            [ span [ class "fa fa-check" ] [] ]
+                                        , span [ class "fa fa-check check-icon" ] []
                                         ]
                                     , label
-                                        [ Attr.class "form-control", Attr.for "validationAutoValidatedUser" ]
+                                        [ class "form-control", for "validationAutoValidatedUser" ]
                                         [ text " Validate all changes " ]
                                     ]
                                 ]
                             ]
                         , input
-                            [ Attr.type_ "submit"
-                            , Attr.value "Save change"
-                            , Attr.id "validationAutoSubmit"
-                            , Attr.class "btn btn-default"
-                            , Attr.disabled (formState.formValues.validateAll == formState.initValues.validateAll)
+                            [ type_ "submit"
+                            , value "Save change"
+                            , id "validationAutoSubmit"
+                            , class "btn btn-default"
+                            , disabled (formState.formValues.validateAll == formState.initValues.validateAll)
                             , onClick (CallApi (saveValidateAllSetting formState.formValues.validateAll))
                             ]
                             []

--- a/change-validation/src/main/elm/sources/WorkflowUsers.elm
+++ b/change-validation/src/main/elm/sources/WorkflowUsers.elm
@@ -21,11 +21,11 @@ filterUnvalidatedUsers users =
     filter (\u -> not u.isValidated) users
 
 
-mainInit : { contextPath : String, adminWrite : Bool } -> ( Model, Cmd Msg )
+mainInit : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 mainInit initValues =
     let
         m =
-            initModel initValues.contextPath initValues.adminWrite
+            initModel initValues.contextPath initValues.hasWriteRights
     in
     ( m, Cmd.batch [ getUsers m, getValidateAllSetting m ] )
 
@@ -167,7 +167,7 @@ update msg model =
         SaveValidateAllSetting result ->
             case result of
                 Ok newSetting ->
-                    ( { model | validateAll = newSetting, viewState = setValidateAllInView model.viewState newSetting }
+                    ( { model | viewState = initForm newSetting }
                     , successNotification "Successfully saved setting"
                     )
 
@@ -177,28 +177,26 @@ update msg model =
         GetValidateAllSetting result ->
             case result of
                 Ok setting ->
-                    ( { model | validateAll = setting, viewState = setValidateAllInView model.viewState setting }, Cmd.none )
+                    ( { model | viewState = initForm setting }, Cmd.none )
 
                 Err error ->
                     ( model, errorNotification ("An error occurred while trying to get validate_all_enabled setting :" ++ getErrorMessage error) )
 
         ChangeValidateAllSetting enable_validate_all ->
-            ( { model | viewState = updateValidateAllInView model.viewState enable_validate_all }, Cmd.none )
+            ( { model | viewState = setValidateAll enable_validate_all model.viewState }, Cmd.none )
 
 
-setValidateAllInView : ViewState -> Bool -> ViewState
-setValidateAllInView viewState value =
-    case viewState of
-        _ ->
-            let
-                formState =
-                    { validateAll = value }
-            in
-            Form { initValues = formState, formValues = formState }
+initForm : Bool -> ViewState
+initForm value =
+   let
+            formState =
+                { validateAll = value }
+   in
+       Form { initValues = formState, formValues = formState }
 
 
-updateValidateAllInView : ViewState -> Bool -> ViewState
-updateValidateAllInView viewState newValue =
+setValidateAll : Bool -> ViewState -> ViewState
+setValidateAll newValue viewState  =
     case viewState of
         Form formState ->
             let

--- a/change-validation/src/main/elm/sources/WorkflowUsers.elm
+++ b/change-validation/src/main/elm/sources/WorkflowUsers.elm
@@ -18,11 +18,11 @@ filterUnvalidatedUsers : UserList -> UserList
 filterUnvalidatedUsers users =
     filter (\u -> not u.isValidated) users
 
-mainInit : {contextPath : String} -> ( Model, Cmd Msg )
+mainInit : {contextPath : String, adminWrite: Bool} -> ( Model, Cmd Msg )
 mainInit initValues =
   let
     m =
-      initModel initValues.contextPath
+      initModel initValues.contextPath initValues.adminWrite
   in
     ( m, getUsers m )
 

--- a/change-validation/src/main/elm/sources/WorkflowUsers.elm
+++ b/change-validation/src/main/elm/sources/WorkflowUsers.elm
@@ -10,143 +10,156 @@ import Notifications exposing (errorNotification, successNotification)
 import String
 import View exposing (view)
 
+
 filterValidatedUsers : UserList -> UserList
 filterValidatedUsers users =
     filter (\u -> u.isValidated) users
+
 
 filterUnvalidatedUsers : UserList -> UserList
 filterUnvalidatedUsers users =
     filter (\u -> not u.isValidated) users
 
-mainInit : {contextPath : String, adminWrite: Bool} -> ( Model, Cmd Msg )
+
+mainInit : { contextPath : String, adminWrite : Bool } -> ( Model, Cmd Msg )
 mainInit initValues =
-  let
-    m =
-      initModel initValues.contextPath initValues.adminWrite
-  in
+    let
+        m =
+            initModel initValues.contextPath initValues.adminWrite
+    in
     ( m, getUsers m )
 
+
 main =
-  Browser.element
-  { init          = mainInit
-  , view          = view
-  , update        = update
-  , subscriptions = subscriptions
-  }
+    Browser.element
+        { init = mainInit
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-  case msg of
-    GetUsers result ->
-      case result of
-        Ok users  ->
-          (
-            { model
-            | users = users
-            , unvalidatedUsers = filterUnvalidatedUsers users
-            , validatedUsers   = filterValidatedUsers users
-            , leftChecked      = []
-            , rightChecked     = []
-            , hasMoved         = []
-            }
+    case msg of
+        GetUsers result ->
+            case result of
+                Ok users ->
+                    ( { model
+                        | users = users
+                        , unvalidatedUsers = filterUnvalidatedUsers users
+                        , validatedUsers = filterValidatedUsers users
+                        , leftChecked = []
+                        , rightChecked = []
+                        , hasMoved = []
+                      }
+                    , Cmd.none
+                    )
+
+                Err error ->
+                    ( model, errorNotification ("An error occurred while trying to get users:" ++ getErrorMessage error) )
+
+        RemoveUser result ->
+            case result of
+                Ok removeUser ->
+                    ( { model | users = filter (\m -> m.username /= removeUser) model.users }, Cmd.none )
+
+                Err error ->
+                    ( model, errorNotification ("An error occurred while trying to delete a validated users:" ++ getErrorMessage error) )
+
+        SaveWorkflow result ->
+            case result of
+                Ok updatedUsers ->
+                    ( { model
+                        | users = updatedUsers
+                        , unvalidatedUsers = filterUnvalidatedUsers updatedUsers
+                        , validatedUsers = filterValidatedUsers updatedUsers
+                        , leftChecked = []
+                        , rightChecked = []
+                        , hasMoved = []
+                      }
+                    , successNotification ""
+                    )
+
+                Err error ->
+                    ( model, errorNotification ("An error occurred while trying to save validated users:" ++ getErrorMessage error) )
+
+        CallApi call ->
+            ( model, call model )
+
+        RightToLeft ->
+            let
+                newUnvalidatedUsers =
+                    filter (\u -> not (member u model.rightChecked)) model.unvalidatedUsers
+
+                newValidatedUsers =
+                    model.rightChecked ++ model.validatedUsers
+            in
+            ( { model
+                | unvalidatedUsers = newUnvalidatedUsers
+                , hasMoved = model.hasMoved ++ model.rightChecked
+                , validatedUsers = newValidatedUsers
+                , leftChecked = []
+                , rightChecked = []
+              }
             , Cmd.none
-          )
-        Err error ->
-          ( model, errorNotification ("An error occurred while trying to get users:" ++ getErrorMessage error))
+            )
 
-    RemoveUser result ->
-      case result of
-        Ok removeUser ->
-          ( { model | users = filter  (\m -> m.username /= removeUser) model.users  }, Cmd.none )
-        Err error     ->
-          ( model, errorNotification ("An error occurred while trying to delete a validated users:" ++ getErrorMessage error))
+        LeftToRight ->
+            let
+                newValidatedUsers =
+                    filter (\u -> not (member u model.leftChecked)) model.validatedUsers
 
-    SaveWorkflow result ->
-      case result of
-        Ok updatedUsers ->
-          (
-            { model
-            | users = updatedUsers
-            , unvalidatedUsers = filterUnvalidatedUsers updatedUsers
-            , validatedUsers   = filterValidatedUsers updatedUsers
-            , leftChecked      = []
-            , rightChecked     = []
-            , hasMoved         = []
-            }
-            , successNotification ""
-          )
-        Err error       ->
-          ( model, errorNotification ("An error occurred while trying to save validated users:" ++ getErrorMessage error))
+                newUnvalidatedUsers =
+                    model.leftChecked ++ model.unvalidatedUsers
+            in
+            ( { model
+                | unvalidatedUsers = newUnvalidatedUsers
+                , hasMoved = model.hasMoved ++ model.leftChecked
+                , validatedUsers = newValidatedUsers
+                , leftChecked = []
+                , rightChecked = []
+              }
+            , Cmd.none
+            )
 
-    CallApi call ->
-      (model, call model)
+        AddLeftChecked user isChecked ->
+            if not (member user model.leftChecked) && isChecked then
+                ( { model | leftChecked = user :: model.leftChecked, rightChecked = [] }, Cmd.none )
 
-    RightToLeft ->
-      let
-        newUnvalidatedUsers =
-          filter (\u -> not (member u model.rightChecked)) model.unvalidatedUsers
-        newValidatedUsers   =
-          model.rightChecked ++ model.validatedUsers
-      in
-        (
-          { model
-          | unvalidatedUsers = newUnvalidatedUsers
-          , hasMoved         = model.hasMoved ++ model.rightChecked
-          , validatedUsers   = newValidatedUsers
-          , leftChecked      = []
-          , rightChecked     = []
-          }
-          , Cmd.none
-        )
+            else
+                ( { model | leftChecked = filter (\u -> user /= u) model.leftChecked }, Cmd.none )
 
-    LeftToRight ->
-      let
-        newValidatedUsers   =
-          filter (\u -> not (member u model.leftChecked)) model.validatedUsers
-        newUnvalidatedUsers =
-          model.leftChecked ++ model.unvalidatedUsers
-      in
-        (
-          { model
-          | unvalidatedUsers = newUnvalidatedUsers
-          , hasMoved         = model.hasMoved ++ model.leftChecked
-          , validatedUsers   = newValidatedUsers
-          , leftChecked      = []
-          , rightChecked     = []
-          }
-          , Cmd.none
-        )
+        AddRightChecked user isChecked ->
+            if not (member user model.rightChecked) && isChecked then
+                ( { model | rightChecked = user :: model.rightChecked, leftChecked = [] }, Cmd.none )
 
-    AddLeftChecked user isChecked ->
-      if  (not (member user model.leftChecked)) &&  isChecked  then
-        ({model | leftChecked = user :: model.leftChecked, rightChecked = []}, Cmd.none)
-      else
-        ({model | leftChecked = filter (\u -> user /= u) model.leftChecked}, Cmd.none)
+            else
+                ( { model | rightChecked = filter (\u -> user /= u) model.rightChecked }, Cmd.none )
 
+        CheckAll colPos isChecked ->
+            case colPos of
+                Left ->
+                    if isChecked then
+                        ( { model | leftChecked = model.validatedUsers, rightChecked = [] }, Cmd.none )
 
-    AddRightChecked user isChecked ->
-      if (not (member user model.rightChecked) ) &&  isChecked then
-        ({model | rightChecked = user :: model.rightChecked, leftChecked = []}, Cmd.none)
-      else
-        ({model | rightChecked = filter (\u -> user /= u) model.rightChecked}, Cmd.none)
+                    else
+                        ( { model | leftChecked = [] }, Cmd.none )
 
-    CheckAll colPos isChecked->
-      case colPos of
-        Left  ->
-          if  isChecked then
-            ({model | leftChecked = model.validatedUsers, rightChecked = []}, Cmd.none)
-          else
-            ({model | leftChecked = []}, Cmd.none)
-        Right ->
-          if  isChecked then
-            ({model | rightChecked = model.unvalidatedUsers, leftChecked = []}, Cmd.none)
-          else
-            ({model | rightChecked = []}, Cmd.none)
+                Right ->
+                    if isChecked then
+                        ( { model | rightChecked = model.unvalidatedUsers, leftChecked = [] }, Cmd.none )
 
-    SwitchMode ->
-      case model.editMod of
-        On  -> ({model | editMod = Off}, Cmd.none)
-        Off -> ({model | editMod = On}, Cmd.none)
+                    else
+                        ( { model | rightChecked = [] }, Cmd.none )
 
-    ExitEditMod ->
-      ({model | editMod = Off, leftChecked = [], rightChecked = []}, Cmd.none)
+        SwitchMode ->
+            case model.editMod of
+                On ->
+                    ( { model | editMod = Off }, Cmd.none )
+
+                Off ->
+                    ( { model | editMod = On }, Cmd.none )
+
+        ExitEditMod ->
+            ( { model | editMod = Off, leftChecked = [], rightChecked = [] }, Cmd.none )

--- a/change-validation/src/main/resources/template/ChangeValidationManagement.html
+++ b/change-validation/src/main/resources/template/ChangeValidationManagement.html
@@ -4,6 +4,7 @@
 	<head_merge>
 	  <link rel="stylesheet" type="text/css" href="/toserve/changevalidation/change-validation.css" media="screen"
 	  data-lift="with-cached-resource">
+	  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.css">
 	  <script src="/toserve/changevalidation/change-validation.js" data-lift="with-cached-resource"></script>
 	  <script src="/toserve/changevalidation/rudder-supervisedtargets.js" data-lift="with-cached-resource"></script>
 	  <script src="/toserve/changevalidation/rudder-workflowusers.js" data-lift="with-cached-resource"></script>
@@ -254,11 +255,11 @@
 					</div>
 
 					<script>
-					  var adminWrite = false;
+					  var hasWriteRights = false;
 					</script>
 					<lift:authz role="administration_write">
 					  <script>
-					    adminWrite = true;
+						hasWriteRights = true;
 					  </script>
 					</lift:authz>
 
@@ -268,7 +269,7 @@
                         var wu = document.getElementById("workflowUsers");
                         var initValues = {
 						  contextPath: contextPath,
-						  adminWrite: adminWrite
+						  hasWriteRights: hasWriteRights
                         };
                         var app = Elm.SupervisedTargets.init({node: main, flags: initValues});
                         var app2 = Elm.WorkflowUsers.init({node: wu, flags: initValues})

--- a/change-validation/src/main/resources/template/ChangeValidationManagement.html
+++ b/change-validation/src/main/resources/template/ChangeValidationManagement.html
@@ -180,24 +180,26 @@
 				</p>
 			  </div>
 			  <h3 class="page-subtitle">Configure users with change validation</h3>
-			  <div class="section-with-doc">
-				<div class="section-left">
-				  <div id="WorkflowUsers-app">
-					<div id="validated-users-management"></div>
+			  <div id="workflowUsers">
+				  <!--
+			    <div class="section-with-doc">
+				  <div class="section-left"></div>
+	    	 		<div class="section-right">
+			    	  <div class="doc doc-info">
+		    			<div class="marker">
+				    	  <span class="fa fa-info-circle"></span>
+		    			</div>
+			    		<p>
+				    	  Any change done by a validated user will be automatically deployed without validation needed
+					      by another user.
+					    </p>
+				      </div>
 				  </div>
-				</div>
-				<div class="section-right">
-				  <div class="doc doc-info">
-					<div class="marker">
-					  <span class="fa fa-info-circle"></span>
-					</div>
-					<p>
-					  Any change done by a validated user will be automatically deployed without validation needed
-					  by another user.
-					</p>
-				  </div>
-				</div>
+		    	</div>
+		    	-->
 			  </div>
+
+				<!--
 			  <lift:authz role="administration_write">
 			  <br>
 			  <div data-lift="ChangeValidationSettings.validation">
@@ -241,6 +243,8 @@
 
 			  </div>
 			  </lift:authz>
+
+			  -->
 			  <div>
 				<h3 class="page-subtitle">Configure groups with change validations</h3>
 				<div class="section-with-doc">
@@ -248,12 +252,23 @@
 					<div id="supervised-targets-app">
 					  <div id="list-groups-change-validation"></div>
 					</div>
+
+					<script>
+					  var adminWrite = false;
+					</script>
+					<lift:authz role="administration_write">
+					  <script>
+					    adminWrite = true;
+					  </script>
+					</lift:authz>
+
 					<script>
 					  $(document).ready(function () {
                         var main = document.getElementById("list-groups-change-validation");
-                        var wu = document.getElementById("validated-users-management");
+                        var wu = document.getElementById("workflowUsers");
                         var initValues = {
-						  contextPath: contextPath
+						  contextPath: contextPath,
+						  adminWrite: adminWrite
                         };
                         var app = Elm.SupervisedTargets.init({node: main, flags: initValues});
                         var app2 = Elm.WorkflowUsers.init({node: wu, flags: initValues})


### PR DESCRIPTION
https://issues.rudder.io/issues/26946

This is part of the plan to "merge" both existing Elm apps in the change-validation settings page, as well as migrate the `ChangeValidationSettings` snippet to Elm, so that the change-validation settings page contains a single Elm app that renders the whole page.
The first step is to merge the 'Validate all' checkbox and save button with the `WorkflowUsers` Elm app, as the former is currently being rendered by the `ChangeValidationSettings` snippet.

Commit history :
1. Changed the html structure of the settings page so that the `WorkflowUsers` app can contain the 'Validate all' checkbox and save button
2. Applied `elm-format` to all the elm source files that will be modified, no implementation changes (this should probably have been done first, oops)
3. Made the checkbox and save button functional
4. Edited the descriptions of the info sections on the right for clarity. Do let me know whether i should change them back/further.