### PR TITLE
Fixes #27029: Change request count Elm WorkflowInformation app needs a loader  

### DIFF
--- a/change-validation/src/main/elm/sources/WorkflowInformation.elm
+++ b/change-validation/src/main/elm/sources/WorkflowInformation.elm
@@ -222,32 +222,27 @@ update msg model =
 
 view : Model -> Html Msg
 view model =
-    case model.pendingCount of
-        PendingCountWithTotal pc ->
-            li
-                [ Attr.class "nav-item dropdown notifications-menu"
-                , Attr.id "workflow-app"
-                ]
-                [ a
-                    [ Attr.href "#"
-                    , Attr.class "dropdown-toggle"
-                    , Attr.attribute "data-bs-toggle" "dropdown"
-                    , Attr.attribute "role" "button"
-                    , Attr.attribute "aria-expanded" "false"
-                    ]
-                    [ span []
-                        [ text "CR" ]
-                    , viewDropdownToggle pc.totalCount
-                    ]
-                , ul
-                    [ Attr.class "dropdown-menu"
-                    , Attr.attribute "role" "menu"
-                    ]
-                    [ li [] [ viewDropDownMenu model ] ]
-                ]
+    let
+        viewDropdown =
+            case model.pendingCount of
+                NotSet ->
+                    viewDropdownToggle True "-"
 
-        NotSet ->
-            text ""
+                PendingCountWithTotal pc ->
+                    viewDropdownToggle False ( String.fromInt pc.totalCount )
+    in
+    li
+        [ Attr.class "nav-item dropdown notifications-menu"
+        , Attr.id "workflow-app"
+        ]
+        [ viewDropdown
+        , ul
+            [ Attr.class "dropdown-menu"
+            , Attr.attribute "role" "menu"
+            ]
+            [ li [] [ viewDropDownMenu model ] ]
+        ]
+
 
 
 viewDropDownMenu : Model -> Html Msg
@@ -263,13 +258,22 @@ viewDropDownMenu model =
                 ]
 
 
-viewDropdownToggle : Int -> Html Msg
-viewDropdownToggle totalCount =
-    span
-        [ Attr.id "number"
-        , Attr.class "badge rudder-badge"
+viewDropdownToggle : Bool -> String -> Html Msg
+viewDropdownToggle isLoading displayedCount =
+    a
+        [ Attr.href "#"
+        , Attr.class ( "dropdown-toggle " ++ if isLoading then "placeholder-glow" else "" )
+        , Attr.attribute "data-bs-toggle" "dropdown"
+        , Attr.attribute "role" "button"
+        , Attr.attribute "aria-expanded" "false"
         ]
-        [ Html.text (String.fromInt totalCount) ]
+        [ span [] [ text "CR" ]
+        , span
+            [ Attr.id "number"
+            , Attr.class ( "badge rudder-badge " ++ if isLoading then "placeholder" else "" )
+            ]
+            [ Html.text displayedCount ]
+        ]
 
 
 displayPendingCount : Maybe Int -> String -> String -> String -> Html Msg

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/TopBarExtension.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/TopBarExtension.scala
@@ -2,12 +2,17 @@ package com.normation.plugins.changevalidation
 
 import com.normation.plugins.PluginExtensionPoint
 import com.normation.plugins.PluginStatus
+import com.normation.rudder.AuthorizationType
+import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.snippet.CommonLayout
 import net.liftweb.common.Loggable
 import net.liftweb.util.Helpers.*
 import scala.reflect.ClassTag
 import scala.xml.NodeSeq
 
+/**
+ * Load the change-validation scripts, css and async comet actor : to display it in the top bar
+ */
 class TopBarExtension(val status: PluginStatus)(implicit val ttag: ClassTag[CommonLayout])
     extends PluginExtensionPoint[CommonLayout] with Loggable {
 
@@ -15,10 +20,24 @@ class TopBarExtension(val status: PluginStatus)(implicit val ttag: ClassTag[Comm
     "display" -> render _
   )
 
+  /**
+   * User must have either or both of the Validator.Read and Deployer.Read authorizations
+   * in order to display this.
+   */
   def render(xml: NodeSeq) = {
-    (
-      "#rudder-navbar -*" #> <li class="lift:comet?type=WorkflowInformation" name="workflowInfo" ></li>
-    ).apply(xml)
+    val isValidator = CurrentUser.checkRights(AuthorizationType.Validator.Read)
+    val isDeployer  = CurrentUser.checkRights(AuthorizationType.Deployer.Read)
+    if (isValidator || isDeployer) {
+      (
+        "#rudder-navbar -*" #>
+        <head_merge>
+          <script type="text/javascript" data-lift="with-cached-resource" src="/toserve/changevalidation/rudder-workflowinformation.js"></script>
+          <link rel="stylesheet" type="text/css" href="/toserve/changevalidation/change-validation.css" media="screen" data-lift="with-cached-resource" />
+        </head_merge>
+        & "#rudder-navbar -*" #>
+        <li class="lift:comet?type=WorkflowInformation" name="workflowInfo" ></li>
+      ).apply(xml)
+    } else xml
   }
 
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/27029
![Peek 2025-06-03 15-45](https://github.com/user-attachments/assets/9499f155-6fd5-4541-9af7-88c16df5987b)


There is some refactoring that justify that we need to add a loader :
* we need to change the initialization of the Elm app to be in an AJAX, instead of in a `<script/>` using the actor's `partialUpdate` (as in https://github.com/Normation/rudder/pull/5966), because script tags are annoying within actors and when we add CSP headers (see https://github.com/Normation/rudder-plugins/pull/837)
* the AJAX is a bit slower which makes it noticeable, so we need to add placeholders for display, [using bootstrap classes](https://getbootstrap.com/docs/5.1/components/placeholders/)
* the access checks, when moved to the snippet of the plugin extension `TopBarExtension`, simplifies the code in the actor a lot