### PR TITLE
Fixes #27032: Update plugins parent pom to use scala 3

### DIFF
--- a/api-authorizations/src/main/scala/com/normation/plugins/apiauthorizations/ApiAccountsExtension.scala
+++ b/api-authorizations/src/main/scala/com/normation/plugins/apiauthorizations/ApiAccountsExtension.scala
@@ -75,7 +75,7 @@ class ApiAccountsExtension(val status: PluginStatus)(implicit val ttag: ClassTag
    *   ...
    * ]
    */
-  def render(xml: NodeSeq) = {
+  def render(xml: NodeSeq): NodeSeq = {
     // get all apis and for public one, and create the structure
     import net.liftweb.http.js.JsCmds.*
     import net.liftweb.http.js.JE.*

--- a/api-authorizations/src/main/scala/com/normation/plugins/apiauthorizations/UserTokenApiDefinition.scala
+++ b/api-authorizations/src/main/scala/com/normation/plugins/apiauthorizations/UserTokenApiDefinition.scala
@@ -44,7 +44,6 @@ import com.normation.rudder.api.*
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.repository.ldap.JsonApiAuthz
 import com.normation.rudder.rest.*
-import com.normation.rudder.rest.UserApi
 import com.normation.rudder.rest.data.*
 import com.normation.rudder.rest.implicits.ToLiftResponseOne
 import com.normation.rudder.rest.lift.*

--- a/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/api/UserApiTest.scala
+++ b/api-authorizations/src/test/scala/com/normation/plugins/apiauthorizations/api/UserApiTest.scala
@@ -68,7 +68,7 @@ class UserApiTest extends ZIOSpecDefault {
     )
   )
 
-  val apiVersions            = ApiVersion(13, true) :: ApiVersion(14, false) :: Nil
+  val apiVersions: List[ApiVersion] = ApiVersion(13, true) :: ApiVersion(14, false) :: Nil
   val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(modules, apiVersions, Some(userService))
 
   val transformations: Map[String, String => String] = Map()

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/DataTypes.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/DataTypes.scala
@@ -127,10 +127,10 @@ object JsonSerialization {
  * - remove: completely remove the HTML for the form
  */
 sealed trait LoginFormRendering extends EnumEntry                { def name: String }
-final object LoginFormRendering extends Enum[LoginFormRendering] {
-  final case object Show   extends LoginFormRendering { val name = "show"   }
-  final case object Hide   extends LoginFormRendering { val name = "hide"   }
-  final case object Remove extends LoginFormRendering { val name = "remove" }
+object LoginFormRendering       extends Enum[LoginFormRendering] {
+  case object Show   extends LoginFormRendering { val name = "show"   }
+  case object Hide   extends LoginFormRendering { val name = "hide"   }
+  case object Remove extends LoginFormRendering { val name = "remove" }
 
   def values = findValues
 

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/api/AuthBackendsApi.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/api/AuthBackendsApi.scala
@@ -71,8 +71,8 @@ sealed trait AuthBackendsApi extends EnumEntry with EndpointSchema with Internal
 
 object AuthBackendsApi extends Enum[AuthBackendsApi] with ApiModuleProvider[AuthBackendsApi] {
 
-  final case object GetAuthenticationInformation extends AuthBackendsApi with ZeroParam with StartsAtVersion10 {
-    val z              = implicitly[Line].value
+  case object GetAuthenticationInformation extends AuthBackendsApi with ZeroParam with StartsAtVersion10 {
+    val z: Int = implicitly[Line].value
     val description    = "Get information about current authentication configuration"
     val (action, path) = GET / "authbackends" / "current-configuration"
 
@@ -80,8 +80,8 @@ object AuthBackendsApi extends Enum[AuthBackendsApi] with ApiModuleProvider[Auth
     override def dataContainer: Option[String]          = None
   }
 
-  def endpoints = values.toList.sortBy(_.z)
-  def values    = findValues
+  def endpoints: List[AuthBackendsApi] = values.toList.sortBy(_.z)
+  def values = findValues
 }
 
 class AuthBackendsApiImpl(
@@ -92,13 +92,7 @@ class AuthBackendsApiImpl(
   def schemas: ApiModuleProvider[AuthBackendsApi] = AuthBackendsApi
 
   def getLiftEndpoints(): List[LiftApiModule] = {
-    AuthBackendsApi.endpoints
-      .map(e => {
-        e match {
-          case AuthBackendsApi.GetAuthenticationInformation => GetAuthenticationInformation
-        }
-      })
-      .toList
+    AuthBackendsApi.endpoints.map { case AuthBackendsApi.GetAuthenticationInformation => GetAuthenticationInformation }
   }
 
   /*
@@ -110,7 +104,7 @@ class AuthBackendsApiImpl(
     val schema: AuthBackendsApi.GetAuthenticationInformation.type = AuthBackendsApi.GetAuthenticationInformation
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      import JsonSerialization.*
+      import com.normation.plugins.authbackends.JsonSerialization.*
 
       IOResult
         .attempt("Error when trying to get group information")(

--- a/branding/src/main/scala/com/normation/plugins/branding/BrandingConfService.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/BrandingConfService.scala
@@ -72,7 +72,7 @@ object BrandingConfService {
 
 class BrandingConfService(configFilePath: String) {
 
-  private[this] val cache: Ref[Either[RudderError, BrandingConf]] = (for {
+  private[this] lazy val cache: Ref[Either[RudderError, BrandingConf]] = (for {
     v <- Ref.make[Either[RudderError, BrandingConf]](Left(Unexpected("Cache is not yet initialized")))
     c <- reloadCacheInternal(true, v).either
   } yield v).runNow

--- a/branding/src/main/scala/com/normation/plugins/branding/snippet/CommonBranding.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/snippet/CommonBranding.scala
@@ -51,18 +51,18 @@ class CommonBranding(val status: PluginStatus)(implicit val ttag: ClassTag[Commo
     extends PluginExtensionPoint[CommonLayout] with Loggable {
 
   def pluginCompose(snippet: CommonLayout): Map[String, NodeSeq => NodeSeq] = Map(
-    "display" -> display _
+    "display" -> display
   )
 
   private[this] val confRepo = BrandingPluginConf.brandingConfService
 
-  def display(xml: NodeSeq) = {
+  def display(xml: NodeSeq): NodeSeq = {
     val data                                          = confRepo.getConf.either.runNow
     val bar                                           = data match {
       case Right(d) if (d.displayBar) =>
         <div id="headerBar">
         <div class="background">
-          <span>{if (d.displayLabel) d.labelText}</span>
+          <span>{if (d.displayLabel) d.labelText else ""}</span>
         </div>
         <style>
           .main-header {{top:30px }}
@@ -154,9 +154,9 @@ class CommonBranding(val status: PluginStatus)(implicit val ttag: ClassTag[Commo
     val commonBrandingCss: NodeSeq = data match {
       case Right(d) =>
         (d.wideLogo.enable, d.wideLogo.data, d.smallLogo.enable, d.smallLogo.data) match {
-          case (true, Some(wideLogoData), _, _)  => style
-          case (_, _, true, Some(smallLogoData)) => style
-          case _                                 => NodeSeq.Empty
+          case (true, Some(_), _, _) => style
+          case (_, _, true, Some(_)) => style
+          case _                     => NodeSeq.Empty
         }
       case _        => NodeSeq.Empty
     }

--- a/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
+++ b/branding/src/main/scala/com/normation/plugins/branding/snippet/LoginBranding.scala
@@ -56,17 +56,18 @@ class LoginBranding(val status: PluginStatus)(implicit val ttag: ClassTag[Login]
 
   private[this] val confRepo = BrandingPluginConf.brandingConfService
   def display(xml: NodeSeq)  = {
-    val data                      = confRepo.getConf.either.runNow
-    val bar                       = data match {
+    val data = confRepo.getConf.either.runNow
+    val bar  = data match {
       case Right(d) if (d.displayBarLogin) =>
         <div id="headerBar">
           <div class="background">
-            <span>{if (d.displayLabel) d.labelText}</span>
+            <span>{if (d.displayLabel) d.labelText else ""}</span>
           </div>
         </div>
       case _                               => NodeSeq.Empty
     }
-    var (customLogo, brandingCss) = data match {
+
+    val (customLogo, brandingCss) = data match {
       case Right(d) =>
         (
           d.wideLogo.loginLogo,
@@ -106,9 +107,9 @@ class LoginBranding(val status: PluginStatus)(implicit val ttag: ClassTag[Login]
       </div>
     }
     val motd                      = data match {
-      case Right(data) if (data.displayMotd) =>
-        <div class="motd enabled" style="margin-bottom: 20px; text-align: center;">{data.motd}</div>
-      case _                                 => <div class="motd"></div>
+      case Right(d) if (d.displayMotd) =>
+        <div class="motd enabled" style="margin-bottom: 20px; text-align: center;">{d.motd}</div>
+      case _                           => <div class="motd"></div>
     }
     (".logo-container" #> logoContainer &
     ".plugin-info" #> ((x: NodeSeq) => bar ++ x) &

--- a/branding/src/main/scala/com/normation/rudder/rest/BrandingApiSchema.scala
+++ b/branding/src/main/scala/com/normation/rudder/rest/BrandingApiSchema.scala
@@ -50,31 +50,31 @@ import sourcecode.Line
 sealed trait BrandingApiSchema extends EnumEntry with EndpointSchema with GeneralApi with SortIndex
 
 object BrandingApiEndpoints extends Enum[BrandingApiSchema] with ApiModuleProvider[BrandingApiSchema] {
-  import EndpointSchema.syntax.*
-  final case object GetBrandingConf extends BrandingApiSchema with ZeroParam with StartsAtVersion10 with SortIndex {
-    val z              = implicitly[Line].value
+  import com.normation.rudder.rest.EndpointSchema.syntax.*
+  case object GetBrandingConf extends BrandingApiSchema with ZeroParam with StartsAtVersion10 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Get branding plugin configuration"
     val (action, path) = GET / "branding"
     val dataContainer:  Option[String]          = None
     override def authz: List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
-  final case object UpdateBrandingConf extends BrandingApiSchema with ZeroParam with StartsAtVersion10 with SortIndex {
-    val z              = implicitly[Line].value
+  case object UpdateBrandingConf extends BrandingApiSchema with ZeroParam with StartsAtVersion10 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Update branding plugin configuration"
     val (action, path) = POST / "branding"
     val dataContainer: Option[String]          = None
     val authz:         List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object ReloadBrandingConf extends BrandingApiSchema with ZeroParam with StartsAtVersion10 with SortIndex {
-    val z              = implicitly[Line].value
+  case object ReloadBrandingConf extends BrandingApiSchema with ZeroParam with StartsAtVersion10 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Reload branding plugin configuration from config file"
     val (action, path) = POST / "branding" / "reload"
     val dataContainer: Option[String]          = None
     val authz:         List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  def endpoints = values.toList.sortBy(_.z)
-  def values    = findValues
+  def endpoints: List[BrandingApiSchema] = values.toList.sortBy(_.z)
+  def values = findValues
 }

--- a/branding/src/test/scala/com/normation/plugins/branding/BrandingConfServiceTest.scala
+++ b/branding/src/test/scala/com/normation/plugins/branding/BrandingConfServiceTest.scala
@@ -37,8 +37,6 @@
 package com.normation.plugins.branding
 
 import better.files.*
-import com.normation.plugins.branding.BrandingConf
-import com.normation.plugins.branding.BrandingConfService
 import com.normation.zio.UnsafeRun
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeRequestJson.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/ChangeRequestJson.scala
@@ -417,9 +417,9 @@ object DirectiveChangeJson {
   ): PartialTransformer[ChangeRequestDirectiveDiff, DirectiveChangeJson] = {
     PartialTransformer
       .define[ChangeRequestDirectiveDiff, DirectiveChangeJson]
-      .withCoproductInstance[AddDirectiveDiff](_.transformInto[DirectiveCreateChangeJson])
-      .withCoproductInstance[DeleteDirectiveDiff](_.transformInto[DirectiveDeleteChangeJson])
-      .withCoproductInstancePartial[ModifyToDirectiveDiff](_.transformIntoPartial[DirectiveModifyChangeJson])
+      .withSealedSubtypeHandled[AddDirectiveDiff](_.transformInto[DirectiveCreateChangeJson])
+      .withSealedSubtypeHandled[DeleteDirectiveDiff](_.transformInto[DirectiveDeleteChangeJson])
+      .withSealedSubtypeHandledPartial[ModifyToDirectiveDiff](_.transformIntoPartial[DirectiveModifyChangeJson])
       .buildTransformer
   }
 
@@ -554,9 +554,9 @@ object RuleChangeJson {
   ): PartialTransformer[ChangeRequestRuleDiff, RuleChangeJson] = {
     PartialTransformer
       .define[ChangeRequestRuleDiff, RuleChangeJson]
-      .withCoproductInstance[AddRuleDiff](_.transformInto[RuleCreateChangeJson])
-      .withCoproductInstance[DeleteRuleDiff](_.transformInto[RuleDeleteChangeJson])
-      .withCoproductInstancePartial[ModifyToRuleDiff](_.transformIntoPartial[RuleModifyChangeJson])
+      .withSealedSubtypeHandled[AddRuleDiff](_.transformInto[RuleCreateChangeJson])
+      .withSealedSubtypeHandled[DeleteRuleDiff](_.transformInto[RuleDeleteChangeJson])
+      .withSealedSubtypeHandledPartial[ModifyToRuleDiff](_.transformIntoPartial[RuleModifyChangeJson])
       .buildTransformer
   }
 
@@ -757,9 +757,9 @@ object GroupChangeJson {
   ): PartialTransformer[ChangeRequestNodeGroupDiff, GroupChangeJson] = {
     PartialTransformer
       .define[ChangeRequestNodeGroupDiff, GroupChangeJson]
-      .withCoproductInstance[AddNodeGroupDiff](_.transformInto[GroupCreateChangeJson])
-      .withCoproductInstance[DeleteNodeGroupDiff](_.transformInto[GroupDeleteChangeJson])
-      .withCoproductInstancePartial[ModifyToNodeGroupDiff](_.transformIntoPartial[GroupModifyChangeJson])
+      .withSealedSubtypeHandled[AddNodeGroupDiff](_.transformInto[GroupCreateChangeJson])
+      .withSealedSubtypeHandled[DeleteNodeGroupDiff](_.transformInto[GroupDeleteChangeJson])
+      .withSealedSubtypeHandledPartial[ModifyToNodeGroupDiff](_.transformIntoPartial[GroupModifyChangeJson])
       .buildTransformer
   }
 

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/NotificationService.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/NotificationService.scala
@@ -15,7 +15,6 @@ import com.normation.rudder.web.model.LinkUtil
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import jakarta.mail.*
-import jakarta.mail.Session
 import jakarta.mail.internet.InternetAddress
 import jakarta.mail.internet.MimeMessage
 import java.io.File

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsReposiory.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/UnsupervisedTargetsReposiory.scala
@@ -2,7 +2,6 @@ package com.normation.plugins.changevalidation
 
 import better.files.File
 import com.normation.errors.*
-import com.normation.plugins.changevalidation.ChangeValidationLoggerPure
 import com.normation.plugins.changevalidation.RudderJsonMapping.*
 import com.normation.rudder.domain.policies.SimpleTarget
 import com.normation.rudder.repository.FullNodeGroupCategory

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/SupervisedTargetsApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/SupervisedTargetsApi.scala
@@ -75,16 +75,16 @@ import zio.ZIO
 sealed trait SupervisedTargetsApi extends EnumEntry with EndpointSchema with InternalApi with SortIndex
 object SupervisedTargetsApi       extends Enum[SupervisedTargetsApi] with ApiModuleProvider[SupervisedTargetsApi] {
   val zz = 11
-  final case object GetAllTargets           extends SupervisedTargetsApi with ZeroParam with StartsAtVersion10 {
-    val z              = implicitly[Line].value
+  case object GetAllTargets           extends SupervisedTargetsApi with ZeroParam with StartsAtVersion10 {
+    val z: Int = implicitly[Line].value
     val description    = "Get all available node groups with their role in change request validation"
     val (action, path) = GET / "changevalidation" / "supervised" / "targets"
 
     override def dataContainer: Option[String]          = None
     override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
-  final case object UpdateSupervisedTargets extends SupervisedTargetsApi with ZeroParam with StartsAtVersion10 {
-    val z              = implicitly[Line].value
+  case object UpdateSupervisedTargets extends SupervisedTargetsApi with ZeroParam with StartsAtVersion10 {
+    val z: Int = implicitly[Line].value
     val description    = "Save the updated list of groups"
     val (action, path) = POST / "changevalidation" / "supervised" / "targets"
 
@@ -92,8 +92,8 @@ object SupervisedTargetsApi       extends Enum[SupervisedTargetsApi] with ApiMod
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  def endpoints = values.toList.sortBy(_.z)
-  def values    = findValues
+  def endpoints: List[SupervisedTargetsApi] = values.toList.sortBy(_.z)
+  def values = findValues
 }
 
 class SupervisedTargetsApiImpl(
@@ -104,14 +104,10 @@ class SupervisedTargetsApiImpl(
   override def schemas: ApiModuleProvider[SupervisedTargetsApi] = SupervisedTargetsApi
 
   def getLiftEndpoints(): List[LiftApiModule] = {
-    SupervisedTargetsApi.endpoints
-      .map(e => {
-        e match {
-          case SupervisedTargetsApi.GetAllTargets           => GetAllTargets
-          case SupervisedTargetsApi.UpdateSupervisedTargets => UpdateSupervisedTargets
-        }
-      })
-      .toList
+    SupervisedTargetsApi.endpoints.map {
+      case SupervisedTargetsApi.GetAllTargets           => GetAllTargets
+      case SupervisedTargetsApi.UpdateSupervisedTargets => UpdateSupervisedTargets
+    }
   }
 
   /*
@@ -170,7 +166,7 @@ class SupervisedTargetsApiImpl(
             .fromJson[SupervisedSimpleTargets]
             .toIO
             .chainError(
-              s"Error when trying to parse JSON content ${new String(req.body.getOrElse(Array.empty), StandardCharsets.UTF_8)} as a set of rule target."
+              s"Error when trying to parse JSON content ${new String(req.body.getOrElse(Array[Byte]()), StandardCharsets.UTF_8)} as a set of rule target."
             )
         groups  <- nodeGroupRepository.getFullGroupLibrary()
         saved   <- unsupervisedTargetsRepos.save(UnsupervisedTargetsRepository.invertTargets(targets.supervised, groups))

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ValidatedUserApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ValidatedUserApi.scala
@@ -63,16 +63,16 @@ import sourcecode.Line
 sealed trait ValidatedUserApi extends EnumEntry with EndpointSchema with GeneralApi with SortIndex
 object ValidatedUserApi       extends Enum[ValidatedUserApi] with ApiModuleProvider[ValidatedUserApi] {
 
-  final case object ListUsers                   extends ValidatedUserApi with ZeroParam with StartsAtVersion3 with SortIndex {
-    val z              = implicitly[Line].value
+  case object ListUsers                   extends ValidatedUserApi with ZeroParam with StartsAtVersion3 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "List all users"
     val (action, path) = GET / "users"
 
     override def dataContainer: Option[String]          = None
     override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
-  final case object DeleteValidatedUsersDetails extends ValidatedUserApi with OneParam with StartsAtVersion3 with SortIndex  {
-    val z              = implicitly[Line].value
+  case object DeleteValidatedUsersDetails extends ValidatedUserApi with OneParam with StartsAtVersion3 with SortIndex  {
+    val z: Int = implicitly[Line].value
     val description    = "Remove validated user"
     val (action, path) = DELETE / "validatedUsers" / "{username}"
 
@@ -80,8 +80,8 @@ object ValidatedUserApi       extends Enum[ValidatedUserApi] with ApiModuleProvi
     override def dataContainer: Option[String]          = None
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
-  final case object SaveWorkflowUsers           extends ValidatedUserApi with ZeroParam with StartsAtVersion3 with SortIndex {
-    val z              = implicitly[Line].value
+  case object SaveWorkflowUsers           extends ValidatedUserApi with ZeroParam with StartsAtVersion3 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "save list of workflow's users"
     val (action, path) = POST / "validatedUsers"
 
@@ -90,8 +90,8 @@ object ValidatedUserApi       extends Enum[ValidatedUserApi] with ApiModuleProvi
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  def endpoints = values.toList.sortBy(_.z)
-  def values    = findValues
+  def endpoints: List[ValidatedUserApi] = values.toList.sortBy(_.z)
+  def values = findValues
 }
 
 class ValidatedUserApiImpl(

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/WorkflowInternalApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/WorkflowInternalApi.scala
@@ -71,8 +71,8 @@ import zio.syntax.ToZio
 sealed trait WorkflowInternalApi extends EnumEntry with EndpointSchema with InternalApi with SortIndex
 object WorkflowInternalApi       extends Enum[WorkflowInternalApi] with ApiModuleProvider[WorkflowInternalApi] {
 
-  final case object PendingChangeRequestCount extends WorkflowInternalApi with ZeroParam with StartsAtVersion21 with SortIndex {
-    val z              = implicitly[Line].value
+  case object PendingChangeRequestCount extends WorkflowInternalApi with ZeroParam with StartsAtVersion21 with SortIndex {
+    val z: Int = implicitly[Line].value
     val (action, path) = GET / "changevalidation" / "workflow" / "pendingCountByStatus"
     val description    =
       "Get total count of change requests in each state, i.e. PendingValidation and PendingDeployment"

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestChangesForm.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestChangesForm.scala
@@ -56,7 +56,6 @@ import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.properties.*
-import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.workflows.*
 import com.normation.rudder.facts.nodes.QueryContext

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestDetails.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestDetails.scala
@@ -365,8 +365,6 @@ class ChangeRequestDetails extends DispatchSnippet with Loggable {
         case Disabled  => None
         case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
         case Optional  => Some(buildReasonField(false, "subContainerReasonField"))
-        // for non-exhaustiveness God - yes, enum were not very well designed before scala 3
-        case _         => throw new IllegalArgumentException(s"This case should not happen, please report to developers")
       }
     }
 

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestManagement.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/snippet/ChangeRequestManagement.scala
@@ -42,8 +42,6 @@ import bootstrap.rudder.plugin.ChangeValidationConf
 import com.normation.eventlog.EventLog
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.domain.workflows.*
-import com.normation.rudder.domain.workflows.ChangeRequestId
-import com.normation.rudder.domain.workflows.WorkflowNodeId
 import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.services.JsTableData
 import com.normation.rudder.web.services.JsTableLine
@@ -54,8 +52,6 @@ import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import net.liftweb.http.*
-import net.liftweb.http.DispatchSnippet
-import net.liftweb.http.SHtml
 import net.liftweb.http.SHtml.SelectableOption
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*

--- a/datasources/pom-template.xml
+++ b/datasources/pom-template.xml
@@ -54,33 +54,6 @@
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
-    <!-- Test: rudder -->
-    <dependency>
-      <groupId>com.normation.rudder</groupId>
-      <artifactId>rudder-web</artifactId>
-      <version>${rudder-build-version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.normation.rudder</groupId>
-      <artifactId>rudder-core</artifactId>
-      <version>${rudder-build-version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <!--
-      Aaaannnnd maven is horrible, so we need to put back needed dependencies, see:
-      https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.html
-      Perhaps it's time to quit maven.
-     -->
-     <!-- Testing Liftweb -->
-    <dependency>
-      <groupId>net.liftweb</groupId>
-      <artifactId>lift-testkit_${scala-binary-version}</artifactId>
-      <version>${lift-version}</version>
-      <scope>test</scope>
-    </dependency>
     <!-- YAML parser, for REST API test -->
     <dependency>
       <groupId>org.yaml</groupId>
@@ -89,20 +62,11 @@
       <scope>test</scope>
     </dependency>
 
-
     <!-- Tests: a rest server -->
     <dependency>
       <groupId>io.d11</groupId>
       <artifactId>zhttp_${scala-binary-version}</artifactId>
       <version>${zio-http-version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- zio tests -->
-    <dependency>
-      <groupId>dev.zio</groupId>
-      <artifactId>zio-test_${scala-binary-version}</artifactId>
-      <version>${dev-zio-version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/datasources/src/main/scala/com/normation/plugins/datasources/DataSourcesPluginDef.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/DataSourcesPluginDef.scala
@@ -42,7 +42,6 @@ import bootstrap.liftweb.ConfigResource
 import bootstrap.liftweb.MenuUtils
 import bootstrap.rudder.plugin.DatasourcesConf
 import com.normation.plugins.*
-import com.normation.plugins.PluginStatus
 import com.normation.rudder.AuthorizationType.Administration
 import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.lift.LiftApiModuleProvider

--- a/datasources/src/main/scala/com/normation/plugins/datasources/DataTypes.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/DataTypes.scala
@@ -43,17 +43,11 @@ import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.typesafe.config.ConfigValue
 import enumeratum.*
-import net.liftweb.common.Logger
-import org.slf4j.LoggerFactory
 import zio.*
 
 /**
  * Applicative log of interest for Rudder ops.
  */
-object DataSourceLogger extends Logger {
-  override protected def _logger = LoggerFactory.getLogger("datasources")
-}
-
 object DataSourceLoggerPure extends NamedZioLogger {
   override def loggerName: String = "datasources"
 
@@ -65,23 +59,23 @@ object DataSourceLoggerPure extends NamedZioLogger {
   }
 }
 
-final object DataSource {
-  val defaultDuration = 5.minutes
+object DataSource {
+  val defaultDuration: Duration = 5.minutes
 
-  val providerName = PropertyProvider("datasources")
+  val providerName: PropertyProvider = PropertyProvider("datasources")
 
   /*
    * Name used in both datasource id and "reload" place in
    * API, that must not be used as id.
    */
-  val reservedIds = Map(
+  val reservedIds: Map[DataSourceId, String] = Map(
     DataSourceId("reload") -> "That id would conflict with API path for reloading datasources"
   )
 
   /**
    * A node property with the correct DataSource metadata
    */
-  def nodeProperty(name: String, value: ConfigValue) = NodeProperty.apply(name, value, None, Some(providerName))
+  def nodeProperty(name: String, value: ConfigValue): NodeProperty = NodeProperty.apply(name, value, None, Some(providerName))
 }
 
 sealed trait DataSourceType {
@@ -93,17 +87,17 @@ sealed trait DataSourceType {
  * foreign server?
  */
 sealed trait HttpMethod extends EnumEntry        { def name: String }
-final object HttpMethod extends Enum[HttpMethod] {
+object HttpMethod       extends Enum[HttpMethod] {
 
-  final case object GET  extends HttpMethod { override val name = "GET"  }
-  final case object POST extends HttpMethod { override val name = "POST" }
+  case object GET  extends HttpMethod { override val name = "GET"  }
+  case object POST extends HttpMethod { override val name = "POST" }
 
   def values = findValues
 }
 
-final object DataSourceType {
+object DataSourceType {
 
-  final object HTTP {
+  object HTTP {
     val name                      = "HTTP"
     val defaultMaxParallelRequest = 10
   }
@@ -122,7 +116,7 @@ final object DataSourceType {
       requestTimeOut:      Duration,
       missingNodeBehavior: MissingNodeBehavior
   ) extends DataSourceType {
-    val name = HTTP.name
+    val name: String = HTTP.name
   }
 }
 
@@ -133,12 +127,12 @@ final object DataSourceType {
  */
 sealed trait HttpRequestMode { def name: String }
 
-final object HttpRequestMode {
-  final case object OneRequestByNode extends HttpRequestMode {
+object HttpRequestMode {
+  case object OneRequestByNode extends HttpRequestMode {
     val name = "byNode"
   }
 
-  final object OneRequestAllNodes {
+  object OneRequestAllNodes {
     val name = "allNodes"
   }
 
@@ -146,7 +140,7 @@ final object HttpRequestMode {
       matchingPath:  String,
       nodeAttribute: String
   ) extends HttpRequestMode {
-    val name = OneRequestAllNodes.name
+    val name: String = OneRequestAllNodes.name
   }
 }
 
@@ -158,12 +152,12 @@ final object HttpRequestMode {
  */
 sealed trait MissingNodeBehavior { def name: String }
 
-final object MissingNodeBehavior {
+object MissingNodeBehavior {
   // delete is the default behavior is not specified
-  final case object Delete   extends MissingNodeBehavior { val name = "delete"   }
-  final case object NoChange extends MissingNodeBehavior { val name = "noChange" }
-  final object DefaultValue { val name = "defaultValue" }
-  final case class DefaultValue(value: ConfigValue) extends MissingNodeBehavior { val name = DefaultValue.name }
+  case object Delete   extends MissingNodeBehavior { val name = "delete"   }
+  case object NoChange extends MissingNodeBehavior { val name = "noChange" }
+  object DefaultValue { val name = "defaultValue" }
+  final case class DefaultValue(value: ConfigValue) extends MissingNodeBehavior { val name: String = DefaultValue.name }
 }
 
 final case class DataSourceName(value: String)
@@ -173,11 +167,11 @@ sealed trait DataSourceSchedule {
   def duration: Duration
 }
 
-final object DataSourceSchedule {
+object DataSourceSchedule {
   final case class NoSchedule(
       savedDuration: Duration
   ) extends DataSourceSchedule {
-    val duration = savedDuration
+    val duration: Duration = savedDuration
   }
 
   final case class Scheduled(
@@ -185,7 +179,7 @@ final object DataSourceSchedule {
   ) extends DataSourceSchedule
 }
 
-final case class DataSourceRunParameters(
+case class DataSourceRunParameters(
     schedule:     DataSourceSchedule,
     onGeneration: Boolean,
     onNewNode:    Boolean
@@ -208,7 +202,7 @@ sealed trait NodeUpdateResult {
   def nodeId: NodeId
 }
 
-final object NodeUpdateResult {
+object NodeUpdateResult {
 
   // there was a difference between the saved value and the one available
   // on the remote data source

--- a/datasources/src/main/scala/com/normation/plugins/datasources/Repository.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/Repository.scala
@@ -38,7 +38,6 @@
 package com.normation.plugins.datasources
 
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
@@ -465,7 +464,7 @@ class DataSourceJdbcRepository(
       rowsAffected <- update.run
       result       <- rowsAffected match {
                         case 0 =>
-                          DataSourceLogger.debug(s"source ${source.id} is not present in database, creating it")
+                          DataSourceLoggerPure.logEffect.debug(s"source ${source.id} is not present in database, creating it")
                           insert.run
                         case 1 => 1.pure[ConnectionIO]
                         case n => throw new RuntimeException(s"Expected 0 or 1 change, not ${n} for ${source.id}")

--- a/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/api/DataSourceApi.scala
@@ -61,8 +61,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
    * And then the simpler on datasource CRUD
    */
 
-  final case object ReloadAllDatasourcesAllNodes extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object ReloadAllDatasourcesAllNodes extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Reload all datasources for all nodes"
     val (action, path) = POST / "datasources" / "reload" / "node"
 
@@ -70,8 +70,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object ReloadAllDatasourcesOneNode extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object ReloadAllDatasourcesOneNode extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Reload all datasources for the given node"
     val (action, path) = POST / "datasources" / "reload" / "node" / "{nodeid}"
 
@@ -79,8 +79,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object ReloadOneDatasourceAllNodes extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object ReloadOneDatasourceAllNodes extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Reload this given datasources for all nodes"
     val (action, path) = POST / "datasources" / "reload" / "{datasourceid}"
 
@@ -88,8 +88,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object ReloadOneDatasourceOneNode extends DataSourceApi with TwoParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object ReloadOneDatasourceOneNode extends DataSourceApi with TwoParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Reload the given datasource for the given node"
     val (action, path) = POST / "datasources" / "reload" / "{datasourceid}" / "node" / "{nodeid}"
 
@@ -97,8 +97,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object ClearValueOneDatasourceAllNodes extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object ClearValueOneDatasourceAllNodes extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Clear node property values on all nodes for given datasource"
     val (action, path) = POST / "datasources" / "clear" / "{datasourceid}"
 
@@ -106,8 +106,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object ClearValueOneDatasourceOneNode extends DataSourceApi with TwoParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object ClearValueOneDatasourceOneNode extends DataSourceApi with TwoParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Clear node property value set by given datasource on given node"
     val (action, path) = POST / "datasources" / "clear" / "{datasourceid}" / "node" / "{nodeid}"
 
@@ -115,8 +115,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object GetAllDataSources extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object GetAllDataSources extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Get the list of all defined datasources"
     val (action, path) = GET / "datasources"
 
@@ -124,8 +124,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
-  final case object GetDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object GetDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Get information about the given datasource"
     val (action, path) = GET / "datasources" / "{datasourceid}"
 
@@ -133,8 +133,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     override def authz:         List[AuthorizationType] = List(AuthorizationType.Administration.Read)
   }
 
-  final case object DeleteDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object DeleteDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Delete given datasource"
     val (action, path) = DELETE / "datasources" / "{datasourceid}"
 
@@ -142,8 +142,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object CreateDataSource extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object CreateDataSource extends DataSourceApi with ZeroParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Create given datasource"
     val (action, path) = PUT / "datasources"
 
@@ -151,8 +151,8 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object UpdateDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
-    val z              = implicitly[Line].value
+  case object UpdateDataSource extends DataSourceApi with OneParam with StartsAtVersion9 with SortIndex {
+    val z: Int = implicitly[Line].value
     val description    = "Update information about the given datasource"
     val (action, path) = POST / "datasources" / "{datasourceid}"
 
@@ -160,6 +160,6 @@ object DataSourceApi       extends Enum[DataSourceApi] with ApiModuleProvider[Da
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  def endpoints = values.toList.sortBy(_.z)
-  def values    = findValues
+  def endpoints: List[DataSourceApi] = values.toList.sortBy(_.z)
+  def values = findValues
 }

--- a/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/NodeExternalReportsPluginDef.scala
+++ b/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/NodeExternalReportsPluginDef.scala
@@ -40,7 +40,6 @@ import bootstrap.liftweb.ClassPathResource
 import bootstrap.liftweb.ConfigResource
 import bootstrap.liftweb.MenuUtils
 import com.normation.plugins.*
-import com.normation.plugins.PluginStatus
 import com.normation.plugins.nodeexternalreports.service.NodeExternalReportApi
 import net.liftweb.common.Loggable
 import net.liftweb.http.ClasspathTemplates

--- a/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/snippet/PluginInfo.scala
+++ b/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/snippet/PluginInfo.scala
@@ -38,7 +38,6 @@ package com.normation.plugins.nodeexternalreports.snippet
 
 import bootstrap.rudder.plugin.NodeExternalReportsConf
 import net.liftweb.common.*
-import net.liftweb.common.Loggable
 import net.liftweb.http.DispatchSnippet
 import net.liftweb.util.*
 import net.liftweb.util.Helpers.*

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/api/OpenScapApi.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/api/OpenScapApi.scala
@@ -47,11 +47,7 @@ import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction.GET
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.rest.*
-import com.normation.rudder.rest.ApiModuleProvider
-import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.EndpointSchema.syntax.*
-import com.normation.rudder.rest.GeneralApi
-import com.normation.rudder.rest.SortIndex
 import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
@@ -69,8 +65,8 @@ sealed trait OpenScapApi extends EnumEntry with EndpointSchema with GeneralApi w
 object OpenScapApi extends Enum[OpenScapApi] with ApiModuleProvider[OpenScapApi] {
 
   // use that endpoint to get the original report. Be careful, can XSS
-  final case object GetOpenScapReport extends OpenScapApi with OneParam with StartsAtVersion12 {
-    val z              = implicitly[Line].value
+  case object GetOpenScapReport extends OpenScapApi with OneParam with StartsAtVersion12 {
+    val z: Int = implicitly[Line].value
     val description    = "Get OpenSCAP report for a node"
     val (action, path) = GET / "openscap" / "report" / "{id}"
 
@@ -78,8 +74,8 @@ object OpenScapApi extends Enum[OpenScapApi] with ApiModuleProvider[OpenScapApi]
     override val authz:         List[AuthorizationType] = AuthorizationType.Node.Read :: Nil
   }
 
-  final case object GetSanitizedOpenScapReport extends OpenScapApi with OneParam with StartsAtVersion12 {
-    val z              = implicitly[Line].value
+  case object GetSanitizedOpenScapReport extends OpenScapApi with OneParam with StartsAtVersion12 {
+    val z: Int = implicitly[Line].value
     val description    = "Get sanitized OpenSCAP report for a node"
     val (action, path) = GET / "openscap" / "sanitized" / "{id}"
 
@@ -87,7 +83,7 @@ object OpenScapApi extends Enum[OpenScapApi] with ApiModuleProvider[OpenScapApi]
     override val authz:         List[AuthorizationType] = AuthorizationType.Node.Read :: Nil
   }
 
-  def endpoints = values.toList.sortBy(_.z)
+  def endpoints: List[OpenScapApi] = values.toList.sortBy(_.z)
   def values    = findValues
 }
 

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/extension/OpenScapNodeDetailsExtension.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/extension/OpenScapNodeDetailsExtension.scala
@@ -64,14 +64,14 @@ class OpenScapNodeDetailsExtension(
 )(implicit val ttag: ClassTag[ShowNodeDetailsFromNode])
     extends PluginExtensionPoint[ShowNodeDetailsFromNode] with Loggable {
 
-    def pluginCompose(snippet: ShowNodeDetailsFromNode): Map[String, NodeSeq => NodeSeq] = {
-      implicit val qc: QueryContext = CurrentUser.queryContext // bug https://issues.rudder.io/issues/26605
+  def pluginCompose(snippet: ShowNodeDetailsFromNode): Map[String, NodeSeq => NodeSeq] = {
+    implicit val qc: QueryContext = CurrentUser.queryContext // bug https://issues.rudder.io/issues/26605
 
-      Map(
-        "popupDetails" -> addOpenScapReportTab(snippet) _,
-        "mainDetails"  -> addOpenScapReportTab(snippet) _
-      )
-    }
+    Map(
+      "popupDetails" -> addOpenScapReportTab(snippet) _,
+      "mainDetails"  -> addOpenScapReportTab(snippet) _
+    )
+  }
 
   /**
    * Add a tab:

--- a/plugins-common/pom-template.xml
+++ b/plugins-common/pom-template.xml
@@ -59,7 +59,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>copy-build-conf</id>
@@ -128,7 +128,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <id>compile-elm-application</id>
@@ -157,7 +157,7 @@
           </execution>
 
 
-        
+
         </executions>
       </plugin>
       <plugin>
@@ -181,7 +181,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.27.2</version>
+        <version>2.43.0</version>
         <configuration>
           <scala>
             <includes>
@@ -249,28 +249,28 @@
      be imported in each plugin project.
     -->
     <dependency><groupId>antlr</groupId><artifactId>antlr</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>ca.mrvisser</groupId><artifactId>sealerate_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><scope>provided</scope><version>${logback-version}</version></dependency>
     <dependency><groupId>ch.qos.logback</groupId><artifactId>logback-core</artifactId><scope>provided</scope><version>${logback-version}</version></dependency>
-    <dependency><groupId>co.fs2</groupId><artifactId>fs2-core_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>co.fs2</groupId><artifactId>fs2-io_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.beachape</groupId><artifactId>enumeratum_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.beachape</groupId><artifactId>enumeratum-macros_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.comcast</groupId><artifactId>ip4s-core_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.github.alonsodomin.cron4s</groupId><artifactId>cron4s-core_${scala-binary-version}</artifactId><scope>provided</scope><version>${cron4s-version}</version></dependency>
+    <dependency><groupId>co.fs2</groupId><artifactId>fs2-core_3</artifactId><scope>provided</scope><version>${fs2-version}</version></dependency>
+    <dependency><groupId>co.fs2</groupId><artifactId>fs2-io_3</artifactId><scope>provided</scope><version>${fs2-version}</version></dependency>
+    <dependency><groupId>com.beachape</groupId><artifactId>enumeratum_3</artifactId><scope>provided</scope><version>${enumeratum-version}</version></dependency>
+    <dependency><groupId>com.beachape</groupId><artifactId>enumeratum-macros_3</artifactId><scope>provided</scope><version>${enumeratum-version}</version></dependency>
+    <dependency><groupId>com.comcast</groupId><artifactId>ip4s-core_3</artifactId><scope>provided</scope><version>${ip4s-version}</version></dependency>
+    <dependency><groupId>com.github.alonsodomin.cron4s</groupId><artifactId>cron4s-atto_3</artifactId><scope>provided</scope><version>${cron4s-version}</version></dependency>
+    <dependency><groupId>com.github.alonsodomin.cron4s</groupId><artifactId>cron4s-core_3</artifactId><scope>provided</scope><version>${cron4s-version}</version></dependency>
+    <dependency><groupId>com.github.alonsodomin.cron4s</groupId><artifactId>cron4s-parser_3</artifactId><scope>provided</scope><version>${cron4s-version}</version></dependency>
     <dependency><groupId>com.github.ben-manes.caffeine</groupId><artifactId>caffeine</artifactId><scope>provided</scope><version>${caffeine-version}</version></dependency>
-    <dependency><groupId>com.github.pathikrit</groupId><artifactId>better-files_${scala-binary-version}</artifactId><scope>provided</scope><version>${better-files-version}</version></dependency>
+    <dependency><groupId>com.github.pathikrit</groupId><artifactId>better-files_3</artifactId><scope>provided</scope><version>${better-files-version}</version></dependency>
+    <dependency><groupId>com.github.scopt</groupId><artifactId>scopt_3</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.github.seancfoley</groupId><artifactId>ipaddress</artifactId><scope>provided</scope><version>${ipaddress-version}</version></dependency>
     <dependency><groupId>com.google.code.findbugs</groupId><artifactId>jsr305</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.googlecode.javaewah</groupId><artifactId>JavaEWAH</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.google.errorprone</groupId><artifactId>error_prone_annotations</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.ibm.icu</groupId><artifactId>icu4j</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.jayway.jsonpath</groupId><artifactId>json-path</artifactId><scope>provided</scope><version>${json-path-version}</version></dependency>
-    <dependency><groupId>com.lihaoyi</groupId><artifactId>fastparse_${scala-binary-version}</artifactId><scope>provided</scope><version>${fastparse-version}</version></dependency>
-    <dependency><groupId>com.lihaoyi</groupId><artifactId>geny_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.lihaoyi</groupId><artifactId>sourcecode_${scala-binary-version}</artifactId><scope>provided</scope><version>${sourcecode-version}</version></dependency>
+    <dependency><groupId>com.lihaoyi</groupId><artifactId>fastparse_3</artifactId><scope>provided</scope><version>${fastparse-version}</version></dependency>
+    <dependency><groupId>com.lihaoyi</groupId><artifactId>geny_3</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>com.lihaoyi</groupId><artifactId>sourcecode_3</artifactId><scope>provided</scope><version>${sourcecode-version}</version></dependency>
     <dependency><groupId>commons-codec</groupId><artifactId>commons-codec</artifactId><scope>provided</scope><version>${commons-codec-version}</version></dependency>
-    <dependency><groupId>commons-fileupload</groupId><artifactId>commons-fileupload</artifactId><scope>provided</scope><version>${commons-fileupload}</version></dependency>
     <dependency><groupId>commons-io</groupId><artifactId>commons-io</artifactId><scope>provided</scope><version>${commons-io-version}</version></dependency>
     <dependency><groupId>com.normation</groupId><artifactId>scala-ldap</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.normation</groupId><artifactId>utils</artifactId><scope>provided</scope></dependency>
@@ -281,48 +281,56 @@
     <dependency><groupId>com.normation.rudder</groupId><artifactId>rudder-core</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.normation.rudder</groupId><artifactId>rudder-rest</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.normation.rudder</groupId><artifactId>rudder-templates</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.softwaremill.magnolia1_2</groupId><artifactId>magnolia_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>com.softwaremill.quicklens</groupId><artifactId>quicklens_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>com.softwaremill.magnolia1_3</groupId><artifactId>magnolia_3</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>com.softwaremill.quicklens</groupId><artifactId>quicklens_3</artifactId><scope>provided</scope><version>${quicklens-version}</version></dependency>
     <dependency><groupId>com.thoughtworks.paranamer</groupId><artifactId>paranamer</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>com.typesafe</groupId><artifactId>config</artifactId><scope>provided</scope><version>${config-version}</version></dependency>
     <dependency><groupId>com.unboundid</groupId><artifactId>unboundid-ldapsdk</artifactId><scope>provided</scope><version>${unboundid-version}</version></dependency>
     <dependency><groupId>com.zaxxer</groupId><artifactId>HikariCP</artifactId><scope>provided</scope><version>${hikaricp-version}</version></dependency>
     <dependency><groupId>com.zaxxer</groupId><artifactId>nuprocess</artifactId><scope>provided</scope><version>${nuprocess-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect-thirdparty-boopickle-shaded_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio_${scala-binary-version}</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio-concurrent_${scala-binary-version}</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio-internal-macros_${scala-binary-version}</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio-interop-cats_${scala-binary-version}</artifactId><scope>provided</scope><version>${zio-cats-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio-interop-tracer_${scala-binary-version}</artifactId><scope>provided</scope><version>${zio-cats-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio-json_${scala-binary-version}</artifactId><scope>provided</scope><version>${zio-json-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio-json-yaml_${scala-binary-version}</artifactId><scope>provided</scope><version>${zio-json-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio-stacktracer_${scala-binary-version}</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
-    <dependency><groupId>dev.zio</groupId><artifactId>zio-streams_${scala-binary-version}</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect_3</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>izumi-reflect-thirdparty-boopickle-shaded_3</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio_3</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-concurrent_3</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-internal-macros_3</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-interop-cats_3</artifactId><scope>provided</scope><version>${zio-cats-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-interop-tracer_3</artifactId><scope>provided</scope><version>${zio-cats-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-json_3</artifactId><scope>provided</scope><version>${zio-json-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-json-yaml_3</artifactId><scope>provided</scope><version>${zio-json-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-managed_3</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-stacktracer_3</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
+    <dependency><groupId>dev.zio</groupId><artifactId>zio-streams_3</artifactId><scope>provided</scope><version>${dev-zio-version}</version></dependency>
     <dependency><groupId>io.github.java-diff-utils</groupId><artifactId>java-diff-utils</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>io.scalaland</groupId><artifactId>chimney_${scala-binary-version}</artifactId><scope>provided</scope><version>${chimney-version}</version></dependency>
-    <dependency><groupId>io.scalaland</groupId><artifactId>chimney-macro-commons_${scala-version}</artifactId><scope>provided</scope><version>${chimney-version}</version></dependency>
-    <dependency><groupId>jakarta.servlet</groupId><artifactId>jakarta.servlet-api</artifactId><scope>provided</scope><version>${servlet-version}</version></dependency>
+    <dependency><groupId>io.micrometer</groupId><artifactId>micrometer-commons</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>io.micrometer</groupId><artifactId>micrometer-observation</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>io.scalaland</groupId><artifactId>chimney_3</artifactId><scope>provided</scope><version>${chimney-version}</version></dependency>
+    <dependency><groupId>io.scalaland</groupId><artifactId>chimney-cats_3</artifactId><scope>provided</scope><version>${chimney-version}</version></dependency>
+    <dependency><groupId>io.scalaland</groupId><artifactId>chimney-macro-commons_3</artifactId><scope>provided</scope><version>${chimney-version}</version></dependency>
+    <dependency><groupId>jakarta.servlet</groupId><artifactId>jakarta.servlet-api</artifactId><version>${servlet-version}</version><scope>provided</scope></dependency>
     <dependency><groupId>joda-time</groupId><artifactId>joda-time</artifactId><scope>provided</scope><version>${jodatime-version}</version></dependency>
     <dependency><groupId>net.java.dev.jna</groupId><artifactId>jna</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>net.liftweb</groupId><artifactId>lift-actor_${scala-binary-version}</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
-    <dependency><groupId>net.liftweb</groupId><artifactId>lift-common_${scala-binary-version}</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
-    <dependency><groupId>net.liftweb</groupId><artifactId>lift-json_${scala-binary-version}</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
-    <dependency><groupId>net.liftweb</groupId><artifactId>lift-json-ext_${scala-binary-version}</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
-    <dependency><groupId>net.liftweb</groupId><artifactId>lift-markdown_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>net.liftweb</groupId><artifactId>lift-util_${scala-binary-version}</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
-    <dependency><groupId>net.liftweb</groupId><artifactId>lift-webkit_${scala-binary-version}</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
+    <dependency><groupId>net.liftweb</groupId><artifactId>lift-actor_2.13</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
+    <dependency><groupId>net.liftweb</groupId><artifactId>lift-common_2.13</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
+    <dependency><groupId>net.liftweb</groupId><artifactId>lift-json_2.13</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
+    <dependency><groupId>net.liftweb</groupId><artifactId>lift-json-ext_2.13</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
+    <dependency><groupId>net.liftweb</groupId><artifactId>lift-markdown_2.13</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
+    <dependency><groupId>net.liftweb</groupId><artifactId>lift-util_2.13</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
+    <dependency><groupId>net.liftweb</groupId><artifactId>lift-webkit_2.13</artifactId><scope>provided</scope><version>${lift-version}</version></dependency>
     <dependency><groupId>net.minidev</groupId><artifactId>accessors-smart</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>net.minidev</groupId><artifactId>json-smart</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>nu.validator</groupId><artifactId>htmlparser</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.antlr</groupId><artifactId>stringtemplate</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.apache.commons</groupId><artifactId>commons-csv</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.apache.commons</groupId><artifactId>commons-fileupload2-core</artifactId><scope>provided</scope><version>${commons-fileupload}</version></dependency>
+    <dependency><groupId>org.apache.commons</groupId><artifactId>commons-fileupload2-jakarta-servlet5</artifactId><scope>provided</scope><version>${commons-fileupload}</version></dependency>
     <dependency><groupId>org.apache.commons</groupId><artifactId>commons-lang3</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.bouncycastle</groupId><artifactId>bcpkix-${bouncycastle-compat}</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
-    <dependency><groupId>org.bouncycastle</groupId><artifactId>bcprov-${bouncycastle-compat}</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
-    <dependency><groupId>org.bouncycastle</groupId><artifactId>bcutil-${bouncycastle-compat}</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
+    <dependency><groupId>org.apache.commons</groupId><artifactId>commons-text</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.apfloat</groupId><artifactId>apfloat</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.bouncycastle</groupId><artifactId>bcpkix-jdk18on</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
+    <dependency><groupId>org.bouncycastle</groupId><artifactId>bcprov-jdk18on</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
+    <dependency><groupId>org.bouncycastle</groupId><artifactId>bcutil-jdk18on</artifactId><scope>provided</scope><version>${bouncycastle-version}</version></dependency>
+    <dependency><groupId>org.codehaus.janino</groupId><artifactId>commons-compiler</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.codehaus.janino</groupId><artifactId>janino</artifactId><scope>provided</scope><version>${janino-version}</version></dependency>
-    <dependency><groupId>org.checkerframework</groupId><artifactId>checker-qual</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.eclipse.jgit</groupId><artifactId>org.eclipse.jgit</artifactId><scope>provided</scope><version>${jgit-version}</version></dependency>
     <dependency><groupId>org.graalvm.js</groupId><artifactId>js-language</artifactId><scope>provided</scope><version>${graalvm-version}</version></dependency>
     <dependency><groupId>org.graalvm.js</groupId><artifactId>js-scriptengine</artifactId><scope>provided</scope><version>${graalvm-version}</version></dependency>
@@ -332,28 +340,31 @@
     <dependency><groupId>org.graalvm.sdk</groupId><artifactId>nativeimage</artifactId><scope>provided</scope><version>${graalvm-version}</version></dependency>
     <dependency><groupId>org.graalvm.sdk</groupId><artifactId>word</artifactId><scope>provided</scope><version>${graalvm-version}</version></dependency>
     <dependency><groupId>org.graalvm.shadowed</groupId><artifactId>icu4j</artifactId><scope>provided</scope><version>${graalvm-version}</version></dependency>
+    <dependency><groupId>org.graalvm.shadowed</groupId><artifactId>xz</artifactId><scope>provided</scope><version>${graalvm-version}</version></dependency>
     <dependency><groupId>org.graalvm.truffle</groupId><artifactId>truffle-api</artifactId><scope>provided</scope><version>${graalvm-version}</version></dependency>
     <dependency><groupId>org.javassist</groupId><artifactId>javassist</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.jgrapht</groupId><artifactId>jgrapht-core</artifactId><scope>provided</scope><version>${jgrapht-version}</version></dependency>
     <dependency><groupId>org.jheaps</groupId><artifactId>jheaps</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.jline</groupId><artifactId>jline</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.joda</groupId><artifactId>joda-convert</artifactId><scope>provided</scope><version>${jodaconvert-version}</version></dependency>
+    <dependency><groupId>org.jspecify</groupId><artifactId>jspecify</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.mindrot</groupId><artifactId>jbcrypt</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.mozilla</groupId><artifactId>rhino</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.openjdk.jol</groupId><artifactId>jol-core</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.ow2.asm</groupId><artifactId>asm</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><scope>provided</scope><version>${postgresql-version}</version></dependency>
     <dependency><groupId>org.reflections</groupId><artifactId>reflections</artifactId><scope>provided</scope><version>${reflections-version}</version></dependency>
-    <dependency><groupId>org.scalaj</groupId><artifactId>scalaj-http_${scala-binary-version}</artifactId><scope>provided</scope><version>${scalaj-version}</version></dependency>
+    <dependency><groupId>org.scalaj</groupId><artifactId>scalaj-http_2.13</artifactId><scope>provided</scope><version>${scalaj-version}</version></dependency>
+    <dependency><groupId>org.scala-lang</groupId><artifactId>scala3-library_3</artifactId><scope>provided</scope><version>${scala-version}</version></dependency>
     <dependency><groupId>org.scala-lang</groupId><artifactId>scala-compiler</artifactId><scope>provided</scope><version>${scala-version}</version></dependency>
-    <dependency><groupId>org.scala-lang</groupId><artifactId>scala-library</artifactId><scope>provided</scope><version>${scala-version}</version></dependency>
+    <dependency><groupId>org.scala-lang</groupId><artifactId>scala-library</artifactId><scope>provided</scope><version>${scala2-version}</version></dependency>
     <dependency><groupId>org.scala-lang</groupId><artifactId>scalap</artifactId><scope>provided</scope><version>${scala-version}</version></dependency>
     <dependency><groupId>org.scala-lang</groupId><artifactId>scala-reflect</artifactId><scope>provided</scope><version>${scala-version}</version></dependency>
-    <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-collection-compat_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-parallel-collections_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-parser-combinators_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-xml_${scala-binary-version}</artifactId><scope>provided</scope><version>${scala-xml-version}</version></dependency>
-    <dependency><groupId>org.scodec</groupId><artifactId>scodec-bits_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-collection-compat_3</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-parallel-collections_2.13</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-parser-combinators_2.13</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.scala-lang.modules</groupId><artifactId>scala-xml_2.13</artifactId><scope>provided</scope><version>${scala-xml-version}</version></dependency>
+    <dependency><groupId>org.scodec</groupId><artifactId>scodec-bits_3</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId><scope>provided</scope><version>${slf4j-version}</version></dependency>
     <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId><scope>provided</scope><version>${slf4j-version}</version></dependency>
     <dependency><groupId>org.springframework</groupId><artifactId>spring-aop</artifactId><scope>provided</scope><version>${spring-version}</version></dependency>
@@ -364,23 +375,25 @@
     <dependency><groupId>org.springframework</groupId><artifactId>spring-jcl</artifactId><scope>provided</scope><version>${spring-version}</version></dependency>
     <dependency><groupId>org.springframework</groupId><artifactId>spring-tx</artifactId><scope>provided</scope><version>${spring-version}</version></dependency>
     <dependency><groupId>org.springframework</groupId><artifactId>spring-web</artifactId><scope>provided</scope><version>${spring-version}</version></dependency>
-    <dependency><groupId>org.springframework.ldap</groupId><artifactId>spring-ldap-core</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.springframework.ldap</groupId><artifactId>spring-ldap-core</artifactId><scope>provided</scope><version>${spring-version}</version></dependency>
     <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-config</artifactId><scope>provided</scope><version>${spring-security-version}</version></dependency>
     <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-core</artifactId><scope>provided</scope><version>${spring-security-version}</version></dependency>
     <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-crypto</artifactId><scope>provided</scope><version>${spring-security-version}</version></dependency>
     <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-ldap</artifactId><scope>provided</scope><version>${spring-security-version}</version></dependency>
     <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-web</artifactId><scope>provided</scope><version>${spring-security-version}</version></dependency>
-    <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-core_${scala-binary-version}</artifactId><scope>provided</scope><version>${doobie-version}</version></dependency>
-    <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-free_${scala-binary-version}</artifactId><scope>provided</scope><version>${doobie-version}</version></dependency>
-    <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-postgres_${scala-binary-version}</artifactId><scope>provided</scope><version>${doobie-version}</version></dependency>
-    <dependency><groupId>org.tpolecat</groupId><artifactId>typename_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
-    <dependency><groupId>org.typelevel</groupId><artifactId>cats-core_${scala-binary-version}</artifactId><scope>provided</scope><version>${cats-version}</version></dependency>
-    <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect_${scala-binary-version}</artifactId><scope>provided</scope><version>${cats-effect-version}</version></dependency>
-    <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect-kernel_${scala-binary-version}</artifactId><scope>provided</scope><version>${cats-effect-version}</version></dependency>
-    <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect-std_${scala-binary-version}</artifactId><scope>provided</scope><version>${cats-effect-version}</version></dependency>
-    <dependency><groupId>org.typelevel</groupId><artifactId>cats-free_${scala-binary-version}</artifactId><scope>provided</scope><version>${cats-version}</version></dependency>
-    <dependency><groupId>org.typelevel</groupId><artifactId>cats-kernel_${scala-binary-version}</artifactId><scope>provided</scope><version>${cats-version}</version></dependency>
-    <dependency><groupId>org.typelevel</groupId><artifactId>literally_${scala-binary-version}</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.tpolecat</groupId><artifactId>atto-core_3</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-core_3</artifactId><scope>provided</scope><version>${doobie-version}</version></dependency>
+    <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-free_3</artifactId><scope>provided</scope><version>${doobie-version}</version></dependency>
+    <dependency><groupId>org.tpolecat</groupId><artifactId>doobie-postgres_3</artifactId><scope>provided</scope><version>${doobie-version}</version></dependency>
+    <dependency><groupId>org.tpolecat</groupId><artifactId>typename_3</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-core_3</artifactId><scope>provided</scope><version>${cats-version}</version></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect_3</artifactId><scope>provided</scope><version>${cats-effect-version}</version></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect-kernel_3</artifactId><scope>provided</scope><version>${cats-effect-version}</version></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-effect-std_3</artifactId><scope>provided</scope><version>${cats-effect-version}</version></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-free_3</artifactId><scope>provided</scope><version>${cats-version}</version></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-kernel_3</artifactId><scope>provided</scope><version>${cats-version}</version></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>cats-mtl_3</artifactId><scope>provided</scope></dependency>
+    <dependency><groupId>org.typelevel</groupId><artifactId>literally_3</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>org.yaml</groupId><artifactId>snakeyaml</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>xerces</groupId><artifactId>xercesImpl</artifactId><scope>provided</scope></dependency>
     <dependency><groupId>xml-apis</groupId><artifactId>xml-apis</artifactId><scope>provided</scope></dependency>
@@ -393,6 +406,11 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
+      <version>${scala2-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala3-library_3</artifactId>
       <version>${scala-version}</version>
     </dependency>
 
@@ -427,6 +445,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.typelevel</groupId>
+      <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
+      <version>${cats-effect-version}</version>
+      <scope>test</scope>
+    </dependency>
     <!--
       Aaaannnnd maven is horrible, so we need to put back needed dependencies, see:
       https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.html
@@ -435,7 +459,7 @@
      <!-- Testing Liftweb -->
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-testkit_${scala-binary-version}</artifactId>
+      <artifactId>lift-testkit_2.13</artifactId>
       <version>${lift-version}</version>
       <scope>test</scope>
     </dependency>

--- a/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApi.scala
+++ b/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApi.scala
@@ -26,15 +26,15 @@ sealed trait ScaleOutRelayApi extends EnumEntry with EndpointSchema with General
 
 object ScaleOutRelayApi extends Enum[ScaleOutRelayApi] with ApiModuleProvider[ScaleOutRelayApi] {
 
-  final case object PromoteToRelay extends ScaleOutRelayApi with OneParam with StartsAtVersion10 {
-    val z              = implicitly[Line].value
+  case object PromoteToRelay extends ScaleOutRelayApi with OneParam with StartsAtVersion10 {
+    val z: Int = implicitly[Line].value
     val description    = "Promote a node to relay"
     val (action, path) = POST / "scaleoutrelay" / "promote" / "{nodeId}"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object DemoteToNode extends ScaleOutRelayApi with OneParam with StartsAtVersion14 {
-    val z              = implicitly[Line].value
+  case object DemoteToNode extends ScaleOutRelayApi with OneParam with StartsAtVersion14 {
+    val z: Int = implicitly[Line].value
     val description    = "Demote a relay to a simple node"
     val (action, path) = POST / "scaleoutrelay" / "demote" / "{nodeId}"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil


### PR DESCRIPTION
https://issues.rudder.io/issues/27032

Almost went smootly. We get the usual syntatic changes, and a couple of less nice ones. 

# Plugin dependencies / pom.xml

This went better than I thought, with some "I have no idea how maven resolves things at all". 

- I chose to use the numbered version of scala binary directly in the package name. Using `_${scala-binary-version}` is getting really confusing given we have two now, and it's not like we are changing again in near future. So we now have `_3` and `_2.13` in package names. 
- I added the second scala lib (one for each version). This mimics the main pom, I'm not absolutly sure we need it repeatead, but we are sure we need it, so... 
- we find back changes from core dep:
    - `sealarate` is removed
    - `cron4s` get the `atto` backend to avoid pb with scala parser used in liftweb
-  `cats-effect-std` is needed for tests using something related to database (doobie indrirectly), I made it provided at that level


# Syntatic and trivial changes

- some type asciption as always
- removing final for objects
- adding `then` part on if
- removing unused variables in pattern matching/for loops
- renaming shadowed variables
- `withCoproductInstance` => `withSealedSubtypeHandled`

# Better type resolution

There is several place where the type resolution is better and we are forced to be more sincere about what we do. 
For example, in `datasources/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala` there is several places where we were throwing exception in place of dealing with error. This need to be a real `die()` now. 

# ChangeValidation: Doobie implicits and `extends AnyVal`

As in https://github.com/Normation/rudder/pull/6369 we have some `case class ... extends AnyVal` that is not supported anymore. We need to implement the related codec and base check. 
Identified case are: 
- `WorkflowNodeId`
- `ChangeRequestId`

# Datasource: invalidate state in macro with `PatcherConfiguration`

I had an error about invalidate state for `patchCfg`, and not understanding it at all. It seems that the macro resolution does not support that anymore. 
Resolved by having the configuration `.ignoreNoneInPatch` used at each call site. 

