### PR TITLE
Fixes #27064: Change validation settings page has contradictory documentation

### DIFF
--- a/change-validation/src/main/resources/template/ChangeValidationManagement.html
+++ b/change-validation/src/main/resources/template/ChangeValidationManagement.html
@@ -193,7 +193,8 @@
                     </ul>
                     <p>Be careful: a change request is created when <b>at least one</b> predicate matches, so an
                       exempted user
-                      still need a change request to modify a node from a supervised group.
+                      still needs a change request in order to edit a node from a supervised group -
+					  unless the <b>Validate all changes</b> setting is enabled (see below).
                     </p>
                   </div>
                   <h3 class="page-subtitle">Configure users with change validation</h3>


### PR DESCRIPTION
https://issues.rudder.io/issues/27064

The `Configure change request triggers` section of the` change-validation` settings page has two sections that contradict each other. This PR is a backport of the fix in the 9.0 version, see https://github.com/Normation/rudder-plugins/pull/832/commits/31ed45f4680680ca119c7db5dfe5f3bcf7890b13 