### PR TITLE
Fixes #27091: Missing clean in build command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,7 +152,7 @@ pipeline {
                         ) {
                             // we need to use $MVN_COMMAND to get the settings file path
                             sh script: 'make generate-pom'
-                            sh script: '$MVN_CMD --update-snapshots clean install package deploy', label: "common deploy"
+                            sh script: '$MVN_CMD --update-snapshots clean deploy', label: "common deploy"
                         }
                     }
                 }
@@ -164,7 +164,7 @@ pipeline {
                         ) {
                             // we need to use $MVN_COMMAND to get the settings file path
                             sh script: 'make generate-pom'
-                            sh script: '$MVN_CMD --update-snapshots install package deploy', label: "private common deploy"
+                            sh script: '$MVN_CMD --update-snapshots clean deploy', label: "private common deploy"
                         }
                     }
                 }


### PR DESCRIPTION
https://issues.rudder.io/issues/27091

`deploy` implies `package` and `install`, but not `clean`