### PR TITLE
Fixes #27149: Enable spotless for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 */*/*/gulpfile.mjs
 **/toserve/*/*.css
 **/toserve/*/*.scss
+*/dependency-reduced-pom.xml

--- a/datasources/src/main/scala/com/normation/plugins/datasources/QueryService.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/QueryService.scala
@@ -327,7 +327,8 @@ class HttpQueryDataSourceService(
                         .timeout(timeout)
                         .notOptional(
                           s"Timeout error after ${zio.Duration.fromJava(timeout).render}"
-                        ).timed
+                        )
+                        .timed
       _            <- DataSourceLoggerPure.trace(s"Done querying data for ${nodes.size} nodes in ${updated._1.toString}")
       // execute hooks
       _            <- onUpdatedHook(updated._2.collect { case Right(NodeUpdateResult.Updated(id)) => id }.toSet, cause)

--- a/datasources/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/UpdateHttpDatasetTest.scala
@@ -332,7 +332,8 @@ object CmdbServer {
       val headerId = r.headers.toList.toMap.get("nodeId")
 
       for {
-        body   <- r.body.asString.orDie // we should correctly decode POST form data, but here we only have one field nodeId=nodexxxx
+        body   <-
+          r.body.asString.orDie // we should correctly decode POST form data, but here we only have one field nodeId=nodexxxx
         formId <- (body.split('=').toList match {
                     case _ :: nodeId :: Nil => ZIO.succeed(Some(nodeId))
                     case _                  => ZIO.die(throw new IllegalArgumentException(s"Error, can't decode POST form data body: ${body}"))

--- a/openscap/src/main/scala/com/normation/plugins/openscappolicies/api/OpenScapApi.scala
+++ b/openscap/src/main/scala/com/normation/plugins/openscappolicies/api/OpenScapApi.scala
@@ -84,7 +84,7 @@ object OpenScapApi extends Enum[OpenScapApi] with ApiModuleProvider[OpenScapApi]
   }
 
   def endpoints: List[OpenScapApi] = values.toList.sortBy(_.z)
-  def values    = findValues
+  def values = findValues
 }
 
 class OpenScapApiImpl(

--- a/plugins-common/pom-template.xml
+++ b/plugins-common/pom-template.xml
@@ -182,6 +182,7 @@
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>2.43.0</version>
+        <inherited>true</inherited>
         <configuration>
           <scala>
             <includes>
@@ -201,7 +202,7 @@
             <goals>
               <goal>check</goal>
             </goals>
-            <phase>verify</phase> <!-- verify: default value -->
+            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>
@@ -221,7 +222,10 @@
         </configuration>
         <executions>
           <execution>
-            <phase>none</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
https://issues.rudder.io/issues/27149

We are forced to duplicate in `<plugin-management>` and `<plugin>` the same things, I'm not sure why but let's say it's the way of maven. 

Also, add  `dependency-reduced-pom.xml` to git ignore. It looks like it's produced by modern maven to help reducing the number of dependencies, but it doesn't fit well with our parent pom bringing a lot of things. 