### PR TITLE
Fixes #27289: Change request page is not updated directly after using the form to edit the title/description 

### DIFF
--- a/change-validation/src/main/elm/sources/ChangeRequestDetails.elm
+++ b/change-validation/src/main/elm/sources/ChangeRequestDetails.elm
@@ -294,10 +294,15 @@ update msg model =
 
         EditFormMsg editFormMsg ->
             let
-                ( efModel, efCmd ) =
+                ( efModel, efCmd, efOutcome ) =
                     EditForm.update editFormMsg model.editForm
             in
-            ( { model | editForm = efModel }, Cmd.map EditFormMsg efCmd )
+            case efOutcome of
+                EditForm.OutcomeNone ->
+                    ( { model | editForm = efModel }, Cmd.map EditFormMsg efCmd )
+
+                EditForm.OutcomeFormModified crId ->
+                    ( { model | editForm = efModel }, Cmd.batch [ Cmd.map EditFormMsg efCmd, getChangeRequestMainDetails model crId ] )
 
         ChangesFormMsg changesFormMsg ->
             let


### PR DESCRIPTION
https://issues.rudder.io/issues/27289

Previously, the banner and changes table of a given change request were not updated directly after the user had used the edit form in order to modify the title or description of the change request.
The banner and changes table are now updated without needing to refresh the page.

Note : After editing the title or description of a change request, no new log will appear in the logs table - the issue is on the API side (modifying a change request's info by using the public API does not create a new log). Hence, the update of the changes table is not visible in this case.