### PR TITLE
Fixes #28657: Relay-to-node operation succeeds even if some nodes still depend on relay

### DIFF
--- a/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/ScaleOutRelayService.scala
+++ b/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/ScaleOutRelayService.scala
@@ -132,13 +132,40 @@ class ScaleOutRelayService(
     implicit val qr: QueryContext = cc.toQuery
     for {
       _        <- ScaleOutRelayLoggerPure.debug(s"Start of demoting relay '${nodeId.value}' to node")
+      _        <- if (nodeId == NodeId("root")) {
+                    Inconsistency("Demoting node with id 'root' to simple node is forbidden.").fail
+                  } else ().succeed
       nodeInfo <- nodeFactRepository
                     .get(nodeId)
                     .notOptional(s"Relay with UUID ${nodeId.value} is missing and can not be demoted to node")
+      nodes    <- nodeFactRepository.getAll()
       _        <- if (nodeInfo.rudderSettings.isPolicyServer) {
-                    val configObjects = PolicyServerConfigurationObjects.getConfigurationObject(nodeInfo.id)
-                    demoteRelay(nodeInfo, configObjects).unit *>
-                    actionLogger.saveDemoteToNode(cc.modId, cc.actor, nodeInfo.toNodeInfo, cc.message)
+                    val managedNodes = {
+                      Set
+                        .from(
+                          nodes
+                            .filter((_, nodeFact) => nodeFact.rudderSettings.policyServerId == nodeId)
+                            .keySet
+                        )
+                        .excl(nodeId) // node is managed by itself
+                    }
+
+                    if (managedNodes.isEmpty) {
+                      val configObjects = PolicyServerConfigurationObjects.getConfigurationObject(nodeInfo.id)
+                      demoteRelay(nodeInfo, configObjects).unit *>
+                      actionLogger.saveDemoteToNode(cc.modId, cc.actor, nodeInfo.toNodeInfo, cc.message)
+                    } else {
+                      val targets = managedNodes.map(n => s"'${n.value}'").mkString(", ")
+                      val errMsg  = s"Relay '${nodeId.value}' cannot be demoted to simple node " +
+                        s"because it is the policy server of the following nodes : \n" +
+                        s"${targets} \n" +
+                        s"These nodes must be assigned to a different policy server before relay '${nodeId.value}' can be demoted."
+
+                      ScaleOutRelayLoggerPure.debug(errMsg) *>
+                      Inconsistency(errMsg).fail
+
+                    }
+
                   } else {
                     ScaleOutRelayLoggerPure.debug(s"Node '${nodeId.value}' is already a simple node, nothing to do.") *>
                     ZIO.unit

--- a/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApi.scala
+++ b/scale-out-relay/src/main/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApi.scala
@@ -107,7 +107,7 @@ class ScaleOutRelayApiImpl(
       )
       scaleOutRelayService
         .demoteRelayToNode(NodeId(nodeId))
-        .chainError(s"Error when trying to demote mode $nodeId")
+        .chainError(s"Error when trying to demote node $nodeId")
         .as(nodeId)
         .toLiftResponseOne(params, schema, None)
     }

--- a/scale-out-relay/src/test/resources/scaleoutrelay_api/api_scaleoutrelay.yml
+++ b/scale-out-relay/src/test/resources/scaleoutrelay_api/api_scaleoutrelay.yml
@@ -55,5 +55,35 @@ response:
     {
       "action": "demoteToNode",
       "result": "error",
-      "errorDetails": "Error when trying to demote mode node_void123; cause was: Inconsistency: Relay with UUID node_void123 is missing and can not be demoted to node"
+      "errorDetails": "Error when trying to demote node node_void123; cause was: Inconsistency: Relay with UUID node_void123 is missing and can not be demoted to node"
+    }
+---
+description: Fail to demote root node
+method: POST
+url: /api/latest/scaleoutrelay/demote/root
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 500
+  type: json
+  content: >-
+    {
+      "action": "demoteToNode",
+      "result": "error",
+      "errorDetails": "Error when trying to demote node root; cause was: Inconsistency: Demoting node with id 'root' to simple node is forbidden."
+    }
+---
+description: Fail to demote a relay that is not root to a simple node when the relay is the policy server of one or more nodes
+method: POST
+url: /api/latest/scaleoutrelay/demote/node-dsc
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 500
+  type: json
+  content: >-
+    {
+      "action": "demoteToNode",
+      "result": "error",
+      "errorDetails": "Error when trying to demote node node-dsc; cause was: Inconsistency: Relay 'node-dsc' cannot be demoted to simple node because it is the policy server of the following nodes : \n'node3' \nThese nodes must be assigned to a different policy server before relay 'node-dsc' can be demoted."
     }

--- a/scale-out-relay/src/test/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApiTest.scala
+++ b/scale-out-relay/src/test/scala/com/normation/plugins/scaleoutrelay/api/ScaleOutRelayApiTest.scala
@@ -3,12 +3,15 @@ package com.normation.plugins.scaleoutrelay.api
 import better.files.*
 import com.normation.errors.IOResult
 import com.normation.errors.effectUioUnit
+import com.normation.inventory.domain.FullInventory
 import com.normation.inventory.domain.NodeId
 import com.normation.plugins.AlwaysEnabledPluginStatus
 import com.normation.plugins.scaleoutrelay.DeleteNodeEntryService
 import com.normation.plugins.scaleoutrelay.MockServices
 import com.normation.plugins.scaleoutrelay.ScaleOutRelayService
 import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.rest.RestTestSetUp
 import com.normation.rudder.rest.TraitTestApiFromYamlFiles
 import java.nio.file.Files
@@ -26,7 +29,8 @@ class ScaleOutRelayApiTest extends ZIOSpecDefault {
   val yamlDestTmpDirectory = tmpDir / "templates"
 
   val mockServices = new MockServices(Map.empty)
-  val modules      = List(
+
+  val modules = List(
     new ScaleOutRelayApiImpl(
       new ScaleOutRelayService(
         mockServices.woLDAPNodeGroupRepository,
@@ -58,17 +62,29 @@ class ScaleOutRelayApiTest extends ZIOSpecDefault {
     (suite("All REST tests defined in files") {
 
       for {
-        s <- TraitTestApiFromYamlFiles.doTest(
-               yamlSourceDirectory,
-               yamlDestTmpDirectory,
-               liftRules,
-               Nil,
-               transformations
-             )
-        _ <- effectUioUnit(
-               if (java.lang.System.getProperty("tests.clean.tmp") != "false") IOResult.attempt(restTestSetUp.cleanup())
-               else ZIO.unit
-             )
+        node1 <- restTestSetUp.mockNodes.nodeFactStorage
+                   .getAccepted(NodeId("node1"))
+                   .notOptional("node with id 'node1' cannot be missing")
+        node3  = NodeFact.fromCompat(
+                   node1
+                     .copy(id = NodeId("node3"), rudderSettings = node1.rudderSettings.copy(policyServerId = NodeId("node-dsc")))
+                     .toNodeInfo,
+                   Right(FullInventory(node1.toFullInventory.node, None)),
+                   List(),
+                   None
+                 )
+        _     <- restTestSetUp.mockNodes.nodeFactRepo.save(node3)(using ChangeContext.newForRudder())
+        s     <- TraitTestApiFromYamlFiles.doTest(
+                   yamlSourceDirectory,
+                   yamlDestTmpDirectory,
+                   liftRules,
+                   Nil,
+                   transformations
+                 )
+        _     <- effectUioUnit(
+                   if (java.lang.System.getProperty("tests.clean.tmp") != "false") IOResult.attempt(restTestSetUp.cleanup())
+                   else ZIO.unit
+                 )
       } yield s
     })
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/28657

This PR aims to make the `relay-to-node` command fail if it is run on a relay that is currently managing one or more nodes. Additionally, the change in this PR forbids the `relay-to-node` from being run on the node that has the `root` id.