### PR TITLE
Fixes #28622: Unchecking the \"Label text\" check box in the settings…

### DIFF
--- a/branding/src/main/elm/sources/Branding.elm
+++ b/branding/src/main/elm/sources/Branding.elm
@@ -190,6 +190,7 @@ update msg model =
                         bgColor         = Color.toCssString settings.bgColorValue
                         txtColor        = Color.toCssString settings.labelColorValue
                         labelTxt        = settings.labelTxt
+                        displayLabel    = settings.displayLabel
                         wideLogoData    = case settings.wideLogo.data of
                           Just d  -> d
                           Nothing -> ""
@@ -198,7 +199,7 @@ update msg model =
                           Just d  -> d
                           Nothing -> ""
                         smallLogoEnable = settings.smallLogo.enable
-                        cssObj = CssObj bgColor txtColor labelTxt --wideLogoEnable wideLogoData smallLogoEnable smallLogoData
+                        cssObj = CssObj bgColor txtColor labelTxt displayLabel --wideLogoEnable wideLogoData smallLogoEnable smallLogoData
 
                     in
                     ( model, Cmd.batch[applyCss ( cssObj ), successNotification ""] )

--- a/branding/src/main/elm/sources/DataTypes.elm
+++ b/branding/src/main/elm/sources/DataTypes.elm
@@ -48,6 +48,7 @@ type alias CssObj =
   { bgColor           : String
   , txtColor          : String
   , labelTxt          : String
+  , displayLabel      : Bool
   }
 
 --- UPDATE ---

--- a/branding/src/main/elm/sources/View.elm
+++ b/branding/src/main/elm/sources/View.elm
@@ -179,8 +179,8 @@ barStyle bgColor txtColor =
         ]
 
 
-customBar : Settings -> String -> String -> Html msg
-customBar settings barClass labelClass =
+customBar : Settings -> String -> List (Attribute msg) -> Html msg
+customBar settings barClass labelAttr =
     let
         bgColor =
             settings.bgColorValue
@@ -192,7 +192,7 @@ customBar settings barClass labelClass =
             settings.labelTxt
     in
     div (class ("custom-bar " ++ barClass) :: barStyle bgColor txtColor)
-        [ span [ class labelClass ] [ text labelTxt ] ]
+        [ span labelAttr [ text labelTxt ] ]
 
 
 
@@ -205,13 +205,13 @@ customBarPreview settings =
         True  -> ""
         False -> "hidden"
 
-    labelClass =
+    labelAttr =
       case settings.displayLabel of
-        True  -> ""
-        False -> "hidden"
+        True  -> []
+        False -> [attribute "hidden" "true"]
   in
     div [ class "preview-window" ]
-      [ customBar settings customBarClass labelClass
+      [ customBar settings customBarClass labelAttr
       , div [ class "top-menu"  ]
         [ div []
           [ span[style "background-image" (logoUrl settings False)][]
@@ -237,7 +237,7 @@ loginPagePreview settings =
       [ div [ class "login-container" ]
         [ div [ class "logo-container" ][ div [style "background-image" (logoUrl settings True)][] ]
         , div [ class "fake-form" ]
-          [ customBar settings customBarClass ""
+          [ customBar settings customBarClass []
           , div [ class "text-motd" ] [ span [ class customMotdClass ] [ text settings.motd ] ]
           , div [ class "fake-input" ] []
           , div [ class "fake-input" ] []

--- a/branding/src/main/resources/template/brandingManagement.html
+++ b/branding/src/main/resources/template/brandingManagement.html
@@ -17,7 +17,7 @@
      var app          = Elm.Branding.init({ node : main, flags: flags});
      app.ports.applyCss.subscribe(function(settings) {
        $('#headerBar > .background').css('background-color', settings.bgColor).css('color', settings.txtColor);
-       $('#headerBar > .background > span').text(settings.labelTxt);
+       $('#headerBar > .background > span').text(settings.labelTxt).attr('hidden', (! settings.displayLabel));
      });
      app.ports.successNotification.subscribe(function (str) {
        createSuccessNotification(str)


### PR DESCRIPTION
https://issues.rudder.io/issues/28622

This PR aims to 
* hide the banner label when the "Label text" checkbox is unchecked without needing to reload the page (previously, the page would have needed to be reloaded for the change to be taken into account)
* hide the banner label on the preview if the "Label text" checkbox is unchecked (previously, unchecking the checkbox had no effect on the preview which was confusing)