### PR TITLE
Fixes #28491: Accepting a change request that deletes a group results in a dead link in the change request's details page

### DIFF
--- a/change-validation/src/main/elm/sources/ChangeRequestChangesForm.elm
+++ b/change-validation/src/main/elm/sources/ChangeRequestChangesForm.elm
@@ -1,4 +1,4 @@
-module ChangeRequestChangesForm exposing (Changes, Diff, Directive, DirectiveDiff, GlobalParameter, GlobalParameterDiff, Model, Msg, NodeGroup, NodeGroupDiff, ResourceDiff, Rule, RuleDiff, initModel, update, updateChangeRequestDetails, view)
+module ChangeRequestChangesForm exposing (Changes, Diff, Directive, DirectiveChange, DirectiveDiff, GlobalParameter, GlobalParameterDiff, Model, Msg, NodeGroup, NodeGroupChange, NodeGroupDiff, ParameterChange, ResourceDiff, Rule, RuleChange, RuleDiff, initModel, update, updateChangeRequestDetails, view)
 
 import ErrorMessages exposing (getErrorMessage)
 import Html exposing (Attribute, Html, button, div, h4, li, pre, table, text, ul)
@@ -88,8 +88,7 @@ type alias DiffChange ty =
 
 
 type alias Directive =
-    { id : String
-    , displayName : String
+    { reference : ResourceReference
     , shortDescription : String
     , techniqueName : String
     , techniqueVersion : String
@@ -121,8 +120,7 @@ type alias DirectiveDiff =
 
 
 type alias Rule =
-    { id : String
-    , displayName : String
+    { reference : ResourceReference
     , shortDescription : String
     , longDescription : String
     , targets : TargetList -- List of targets
@@ -150,8 +148,7 @@ type alias RuleDiff =
 
 
 type alias NodeGroup =
-    { id : String
-    , displayName : String
+    { reference : ResourceReference
     , description : String
     , enabled : Bool
     , dynamic : Bool
@@ -179,7 +176,7 @@ type alias NodeGroupDiff =
 
 
 type alias GlobalParameter =
-    { name : String
+    { reference : ResourceReference
     , value : Value
     , description : String
     }
@@ -201,11 +198,27 @@ type ResourceDiff resource modifyDiff
     | Modify modifyDiff
 
 
+type alias DirectiveChange =
+    ResourceDiff Directive DirectiveDiff
+
+
+type alias RuleChange =
+    ResourceDiff Rule RuleDiff
+
+
+type alias NodeGroupChange =
+    ResourceDiff NodeGroup NodeGroupDiff
+
+
+type alias ParameterChange =
+    ResourceDiff GlobalParameter GlobalParameterDiff
+
+
 type alias Changes =
-    { directives : List (ResourceDiff Directive DirectiveDiff)
-    , rules : List (ResourceDiff Rule RuleDiff)
-    , groups : List (ResourceDiff NodeGroup NodeGroupDiff)
-    , parameters : List (ResourceDiff GlobalParameter GlobalParameterDiff)
+    { directives : List DirectiveChange
+    , rules : List RuleChange
+    , groups : List NodeGroupChange
+    , parameters : List ParameterChange
     }
 
 
@@ -305,14 +318,14 @@ update msg model =
 ------------------------------
 
 
-getChangeRequestChanges : Int -> Model -> Cmd Msg
-getChangeRequestChanges crId model =
+getChangeRequestChanges : Int -> String -> Model -> Cmd Msg
+getChangeRequestChanges crId status model =
     request
         { method = "GET"
         , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
         , url = getApiUrl model.contextPath ("changevalidation/workflow/changeRequestChanges/" ++ String.fromInt crId)
         , body = emptyBody
-        , expect = expectJson GetChangeRequestChanges decodeChanges
+        , expect = expectJson GetChangeRequestChanges (decodeChanges status)
         , timeout = Nothing
         , tracker = Nothing
         }
@@ -324,8 +337,8 @@ getChangeRequestChanges crId model =
 ------------------------------
 
 
-decodeDirectiveDiff : Decoder (ResourceDiff Directive DirectiveDiff)
-decodeDirectiveDiff =
+decodeDirectiveDiff : String -> Decoder DirectiveChange
+decodeDirectiveDiff changeRequestStatus =
     let
         decodePolicyMode : Decoder String
         decodePolicyMode =
@@ -339,11 +352,10 @@ decodeDirectiveDiff =
                             fail "Invalid policy mode"
                     )
 
-        decodeDirective : Decoder Directive
-        decodeDirective =
+        decodeDirective : Action -> Decoder Directive
+        decodeDirective action =
             succeed Directive
-                |> requiredAt [ "change", "id" ] string
-                |> requiredAt [ "change", "displayName" ] string
+                |> required "change" (decodeResourceReference "displayName" changeRequestStatus action)
                 |> requiredAt [ "change", "shortDescription" ] string
                 |> requiredAt [ "change", "techniqueName" ] string
                 |> requiredAt [ "change", "techniqueVersion" ] string
@@ -359,10 +371,10 @@ decodeDirectiveDiff =
             (\action ->
                 case action of
                     "create" ->
-                        map Create decodeDirective
+                        map Create (decodeDirective CreateAction)
 
                     "delete" ->
-                        map Delete decodeDirective
+                        map Delete (decodeDirective DeleteAction)
 
                     "modify" ->
                         map Modify
@@ -385,14 +397,13 @@ decodeDirectiveDiff =
             )
 
 
-decodeRuleDiff : Decoder (ResourceDiff Rule RuleDiff)
-decodeRuleDiff =
+decodeRuleDiff : String -> Decoder RuleChange
+decodeRuleDiff changeRequestStatus =
     let
-        decodeRule : Decoder Rule
-        decodeRule =
+        decodeRule : Action -> Decoder Rule
+        decodeRule action =
             succeed Rule
-                |> requiredAt [ "change", "id" ] string
-                |> requiredAt [ "change", "displayName" ] string
+                |> required "change" (decodeResourceReference "displayName" changeRequestStatus action)
                 |> requiredAt [ "change", "shortDescription" ] string
                 |> requiredAt [ "change", "longDescription" ] string
                 |> required "ruleTargetInfo" decodeTargetList
@@ -406,10 +417,10 @@ decodeRuleDiff =
             (\action ->
                 case action of
                     "create" ->
-                        map Create decodeRule
+                        map Create (decodeRule CreateAction)
 
                     "delete" ->
-                        map Delete decodeRule
+                        map Delete (decodeRule DeleteAction)
 
                     "modify" ->
                         map Modify
@@ -430,14 +441,13 @@ decodeRuleDiff =
             )
 
 
-decodeGroupDiff : Decoder (ResourceDiff NodeGroup NodeGroupDiff)
-decodeGroupDiff =
+decodeGroupDiff : String -> Decoder NodeGroupChange
+decodeGroupDiff changeRequestStatus =
     let
-        decodeNodeGroup : Decoder NodeGroup
-        decodeNodeGroup =
+        decodeNodeGroup : Action -> Decoder NodeGroup
+        decodeNodeGroup action =
             succeed NodeGroup
-                |> requiredAt [ "change", "id" ] string
-                |> requiredAt [ "change", "displayName" ] string
+                |> required "change" (decodeResourceReference "displayName" changeRequestStatus action)
                 |> requiredAt [ "change", "description" ] string
                 |> requiredAt [ "change", "enabled" ] bool
                 |> requiredAt [ "change", "dynamic" ] bool
@@ -451,10 +461,10 @@ decodeGroupDiff =
             (\action ->
                 case action of
                     "create" ->
-                        map Create decodeNodeGroup
+                        map Create (decodeNodeGroup CreateAction)
 
                     "delete" ->
-                        map Delete decodeNodeGroup
+                        map Delete (decodeNodeGroup DeleteAction)
 
                     "modify" ->
                         map Modify
@@ -475,14 +485,14 @@ decodeGroupDiff =
             )
 
 
-decodeParameterDiff : Decoder (ResourceDiff GlobalParameter GlobalParameterDiff)
-decodeParameterDiff =
+decodeParameterDiff : String -> Decoder ParameterChange
+decodeParameterDiff changeRequestStatus =
     let
-        decodeGlobalParameter : Decoder GlobalParameter
-        decodeGlobalParameter =
+        decodeGlobalParameter : Action -> Decoder GlobalParameter
+        decodeGlobalParameter action =
             map3
                 GlobalParameter
-                (field "id" string)
+                (decodeResourceReference "id" changeRequestStatus action)
                 (field "value" value)
                 (field "description" string)
     in
@@ -501,10 +511,10 @@ decodeParameterDiff =
                                 )
 
                         "create" ->
-                            map Create decodeGlobalParameter
+                            map Create (decodeGlobalParameter CreateAction)
 
                         "delete" ->
-                            map Delete decodeGlobalParameter
+                            map Delete (decodeGlobalParameter DeleteAction)
 
                         _ ->
                             fail "Invalid action type"
@@ -512,18 +522,18 @@ decodeParameterDiff =
             )
 
 
-decodeChanges : Decoder Changes
-decodeChanges =
+decodeChanges : String -> Decoder Changes
+decodeChanges changeRequestStatus =
     at [ "data" ]
         (field "workflow"
             (index 0
                 (field "changes"
                     (map4
                         Changes
-                        (field "directives" (list decodeDirectiveDiff))
-                        (field "rules" (list decodeRuleDiff))
-                        (field "groups" (list decodeGroupDiff))
-                        (field "parameters" (list decodeParameterDiff))
+                        (field "directives" (list (decodeDirectiveDiff changeRequestStatus)))
+                        (field "rules" (list (decodeRuleDiff changeRequestStatus)))
+                        (field "groups" (list (decodeGroupDiff changeRequestStatus)))
+                        (field "parameters" (list (decodeParameterDiff changeRequestStatus)))
                     )
                 )
             )
@@ -543,7 +553,7 @@ view model =
         getDiff =
             case ( model.changeRequestView, model.changesView ) of
                 ( Success cr, NoView ) ->
-                    [ onClick (CallApi (getChangeRequestChanges cr.changeRequest.id)) ]
+                    [ onClick (CallApi (getChangeRequestChanges cr.changeRequest.id cr.changeRequest.state)) ]
 
                 ( _, _ ) ->
                     []
@@ -601,7 +611,7 @@ view model =
                         , attribute "role" "tabpanel"
                         , id "diffTab"
                         ]
-                        [ div [ id "diff" ] [ diff model ] ]
+                        [ div [ id "diff" ] [ displayDiffTab model ] ]
                     ]
                 ]
             ]
@@ -618,33 +628,37 @@ viewChangesTable table =
     Html.map ChangesTableMsg (RudderDataTable.view table)
 
 
-diff : Model -> Html Msg
-diff model =
+displayDiffTab : Model -> Html Msg
+displayDiffTab model =
     case model.changesView of
         Success data ->
             let
-                defaultOrDiff f1 f2 contextPath resource =
+                displayChange displaySimple displayWithDiff resource =
+                    let
+                        contextPath =
+                            model.contextPath
+                    in
                     case resource of
                         Create r ->
-                            f1 contextPath r
+                            displaySimple contextPath r
 
                         Delete r ->
-                            f1 contextPath r
+                            displaySimple contextPath r
 
                         Modify r ->
-                            f2 contextPath r
+                            displayWithDiff contextPath r
 
                 directives =
-                    List.map (defaultOrDiff displayDirective displayDirectiveDiff model.contextPath) data.directives
+                    List.map (displayChange displayDirective displayDirectiveDiff) data.directives
 
                 groups =
-                    List.map (defaultOrDiff displayGroup displayGroupDiff model.contextPath) data.groups
+                    List.map (displayChange displayGroup displayGroupDiff) data.groups
 
                 rules =
-                    List.map (defaultOrDiff displayRule displayRuleDiff model.contextPath) data.rules
+                    List.map (displayChange displayRule displayRuleDiff) data.rules
 
                 params =
-                    List.map (defaultOrDiff displayParameter displayParameterDiff model.contextPath) data.parameters
+                    List.map (displayChange displayParameter displayParameterDiff) data.parameters
 
                 changes =
                     List.map (\change -> li [] [ change ]) (directives ++ groups ++ rules ++ params)
@@ -665,11 +679,62 @@ diffDefault diffVal =
             diffChange.from
 
 
+displayResourceName : ResourceReference -> Html msg
+displayResourceName reference =
+    displayStringField "Name"
+        (case reference of
+            PlainText name ->
+                name
+
+            Link { resourceName } ->
+                resourceName
+        )
+
+
+displayResourceLink : ContextPath -> ResourceType -> ResourceReference -> Html Msg
+displayResourceLink contextPath resourceType reference =
+    let
+        field =
+            case reference of
+                PlainText displayName ->
+                    text displayName
+
+                Link { resourceId, resourceName } ->
+                    case resourceType of
+                        DirectiveRes ->
+                            directiveLinkWithId contextPath resourceId resourceName
+
+                        NodeGroupRes ->
+                            groupLinkWithId contextPath resourceId resourceName
+
+                        RuleRes ->
+                            ruleLinkWithId contextPath resourceId resourceName
+
+                        GlobalParameterRes ->
+                            paramLink contextPath resourceName
+
+        resourceTypeStr =
+            case resourceType of
+                DirectiveRes ->
+                    "Directive"
+
+                NodeGroupRes ->
+                    "Group"
+
+                RuleRes ->
+                    "Rule"
+
+                GlobalParameterRes ->
+                    "Global Parameter"
+    in
+    displayField resourceTypeStr field
+
+
 displayDirective : ContextPath -> Directive -> Html Msg
 displayDirective contextPath directive =
     displayResourceDiff "Directive"
-        [ displayField "Directive" (directiveLinkWithId contextPath directive.id directive.displayName)
-        , displayStringField "Name" directive.displayName
+        [ displayResourceLink contextPath GlobalParameterRes directive.reference
+        , displayResourceName directive.reference
         , displayStringField "Short description" directive.shortDescription
         , displayStringField "Technique name" directive.techniqueName
         , displayStringField "Technique version" directive.techniqueVersion
@@ -695,15 +760,15 @@ displayDirectiveDiff contextPath directive =
         , displayBoolField "System" directive.system
         , displayStringDiff "Long description" directive.longDescription
         , displayDiffField (displayMaybe text) "Policy Mode" directive.policyMode
-        , displayDirectiveParametersDiff  "Parameters" directive.parameters
+        , displayDirectiveParametersDiff "Parameters" directive.parameters
         ]
 
 
 displayGroup : ContextPath -> NodeGroup -> Html Msg
 displayGroup contextPath group =
     displayResourceDiff "Node Group"
-        [ displayField "Group" (groupLinkWithId contextPath group.id group.displayName)
-        , displayStringField "Name" group.displayName
+        [ displayResourceLink contextPath NodeGroupRes group.reference
+        , displayResourceName group.reference
         , displayStringField "Description" group.description
         , displayBoolField "Enabled" group.enabled
         , displayBoolField "Dynamic" group.dynamic
@@ -732,8 +797,8 @@ displayGroupDiff contextPath group =
 displayRule : ContextPath -> Rule -> Html Msg
 displayRule contextPath rule =
     displayResourceDiff "Rule"
-        [ displayField "Rule" (ruleLinkWithId contextPath rule.id rule.displayName)
-        , displayStringField "Name" rule.displayName
+        [ displayResourceLink contextPath RuleRes rule.reference
+        , displayResourceName rule.reference
         , displayStringField "Category" rule.categoryName
         , displayStringField "Short description" rule.shortDescription
         , displayRuleTarget "Target" contextPath rule.targets
@@ -762,8 +827,8 @@ displayRuleDiff contextPath rule =
 displayParameter : ContextPath -> GlobalParameter -> Html Msg
 displayParameter contextPath param =
     displayResourceDiff "Global parameter"
-        [ displayField "Global Parameter" (paramLink contextPath param.name)
-        , displayStringField "Name" param.name
+        [ displayResourceLink contextPath GlobalParameterRes param.reference
+        , displayResourceName param.reference
         , displayValueField "Value" param.value
         , displayStringField "Description" param.description
         ]
@@ -794,18 +859,43 @@ displayEventAction contextPath action =
             text event
 
         ResourceChangeEvent change ->
-            case change.resourceType of
-                DirectiveRes ->
-                    Html.span [] [ text (change.action ++ " directive "), directiveLink contextPath change.resourceId change.resourceName ]
+            let
+                resourceType =
+                    change.typedReference.resourceType
 
-                NodeGroupRes ->
-                    Html.span [] [ text (change.action ++ " group "), groupLink contextPath change.resourceId change.resourceName ]
+                actionSummary =
+                    (change.action |> actionToString) ++ " " ++ resourceTypeWithIdToString resourceType ++ " "
+            in
+            case ( change.typedReference.reference, resourceType ) of
+                ( Link { resourceId, resourceName }, DirectiveRes ) ->
+                    Html.span []
+                        [ text actionSummary
+                        , directiveLink contextPath resourceId resourceName
+                        ]
 
-                RuleRes ->
-                    Html.span [] [ text (change.action ++ " rule "), ruleLink contextPath change.resourceId change.resourceName ]
+                ( Link { resourceId, resourceName }, NodeGroupRes ) ->
+                    Html.span []
+                        [ text actionSummary
+                        , groupLink contextPath resourceId resourceName
+                        ]
 
-                GlobalParameterRes ->
-                    Html.span [] [ text (change.action ++ " parameter "), paramLink contextPath change.resourceName ]
+                ( Link { resourceId, resourceName }, RuleRes ) ->
+                    Html.span []
+                        [ text actionSummary
+                        , ruleLink contextPath resourceId resourceName
+                        ]
+
+                ( Link { resourceId, resourceName }, GlobalParameterRes ) ->
+                    Html.span []
+                        [ text actionSummary
+                        , paramLink contextPath resourceName
+                        ]
+
+                ( PlainText resourceName, _ ) ->
+                    Html.span []
+                        [ text actionSummary
+                        , resourceName |> text
+                        ]
 
 
 eventActionText : Event -> String
@@ -814,16 +904,14 @@ eventActionText e =
         ChangeLogEvent event ->
             event
 
-        ResourceChangeEvent { action, resourceName, resourceType } ->
-            case resourceType of
-                DirectiveRes ->
-                    action ++ " directive " ++ resourceName
+        ResourceChangeEvent { typedReference, action } ->
+            let
+                summary resourceName =
+                    (action |> actionToString) ++ " " ++ (typedReference.resourceType |> resourceTypeWithIdToString) ++ " " ++ resourceName
+            in
+            case typedReference.reference of
+                PlainText resourceName ->
+                    summary resourceName
 
-                NodeGroupRes ->
-                    action ++ " group " ++ resourceName
-
-                RuleRes ->
-                    action ++ " rule " ++ resourceName
-
-                GlobalParameterRes ->
-                    action ++ " global parameter " ++ resourceName
+                Link { resourceName } ->
+                    summary resourceName

--- a/change-validation/src/main/elm/sources/RudderDataTypes.elm
+++ b/change-validation/src/main/elm/sources/RudderDataTypes.elm
@@ -1,4 +1,4 @@
-module RudderDataTypes exposing (AllNextSteps, AllStepChanges(..), BackStatus(..), ChangeRequestDetails, ChangeRequestFormDetails, ChangeRequestMainDetails, ChangeRequestMainDetailsMetadata, ChangesSummary, Event(..), EventLog, NextStatus(..), ResourceChange, ResourceIdent, ResourceType(..), SimpleTarget, StepChange(..), Target(..), TargetComposition(..), TargetExclusion, TargetList(..), TargetType(..), ViewState(..), decodeChangeRequestMainDetails, decodeFormDetails, decodeResourceIdent, decodeTargetList)
+module RudderDataTypes exposing (Action(..), AllNextSteps, AllStepChanges(..), BackStatus(..), ChangeRequestDetails, ChangeRequestFormDetails, ChangeRequestMainDetails, ChangeRequestMainDetailsMetadata, ChangesSummary, Event(..), EventLog, LinkWithId, NextStatus(..), ResourceChange, ResourceIdent, ResourceReference(..), ResourceType(..), SimpleTarget, StepChange(..), Target(..), TargetComposition(..), TargetExclusion, TargetList(..), TargetType(..), TypedResourceReference, ViewState(..), actionToString, decodeAction, decodeChangeRequestMainDetails, decodeFormDetails, decodeResourceIdent, decodeResourceReference, decodeTargetList, resourceTypeWithIdToString)
 
 import Json.Decode exposing (Decoder, andThen, at, bool, fail, field, index, int, lazy, list, map, map2, map4, map5, map6, maybe, string, succeed)
 import Json.Decode.Pipeline exposing (hardcoded, required)
@@ -115,11 +115,30 @@ type ResourceType
     | GlobalParameterRes
 
 
-type alias ResourceChange =
+type alias LinkWithId =
+    { resourceId : String, resourceName : String }
+
+
+type ResourceReference
+    = PlainText String
+    | Link LinkWithId
+
+
+type alias TypedResourceReference =
     { resourceType : ResourceType
-    , resourceName : String
-    , resourceId : String
-    , action : String
+    , reference : ResourceReference
+    }
+
+
+type Action
+    = CreateAction
+    | DeleteAction
+    | ModifyAction
+
+
+type alias ResourceChange =
+    { typedReference : TypedResourceReference
+    , action : Action
     }
 
 
@@ -154,6 +173,40 @@ type alias ChangeRequestFormDetails =
 ------------------------------
 -- JSON DECODERS
 ------------------------------
+
+
+{-| Decoder for ResourceReferences that are found in the change request changes.
+This function's behavior is analogous to the decodeDisplayLink function.
+-}
+decodeResourceReference : String -> String -> Action -> Decoder ResourceReference
+decodeResourceReference nameFieldLabel changeRequestStatus actionType =
+    case ( changeRequestStatus, actionType ) of
+        ( "Deployed", DeleteAction ) ->
+            succeed PlainText |> required nameFieldLabel string
+
+        _ ->
+            map Link
+                (succeed LinkWithId
+                    |> required "id" string
+                    |> required nameFieldLabel string
+                )
+
+
+{-| Decoder for ResourceReferences that are found in the event logs list.
+This function's behavior is analogous to the decodeResourceReference function.
+-}
+decodeDisplayLink : String -> Action -> Decoder ResourceReference
+decodeDisplayLink changeRequestStatus actionType =
+    case ( changeRequestStatus, actionType ) of
+        ( "Deployed", DeleteAction ) ->
+            map PlainText (field "resourceName" string)
+
+        _ ->
+            map Link
+                (map2 LinkWithId
+                    (field "resourceId" string)
+                    (field "resourceName" string)
+                )
 
 
 decodeTarget : Decoder Target
@@ -216,56 +269,62 @@ compositionDec =
     map Composition (lazy (\_ -> targetCompositionDec))
 
 
-decodeEventLog : Decoder EventLog
-decodeEventLog =
+decodeEventLog : String -> Decoder EventLog
+decodeEventLog changeRequestStatus =
     map4
         EventLog
-        (field "action" decodeEvent)
+        (field "action" (decodeEvent changeRequestStatus))
         (field "actor" string)
         (field "date" string)
         (maybe (field "reason" string))
 
 
-decodeEvent : Decoder Event
-decodeEvent =
+decodeAction : Decoder Action
+decodeAction =
+    string
+        |> andThen
+            (\s ->
+                case s of
+                    "create" ->
+                        succeed CreateAction
+
+                    "delete" ->
+                        succeed DeleteAction
+
+                    "modify" ->
+                        succeed ModifyAction
+
+                    _ ->
+                        fail "Invalid action type"
+            )
+
+
+decodeEvent : String -> Decoder Event
+decodeEvent changeRequestStatus =
     let
-        decodeResourceType =
-            string
+        decodeResourceRef action =
+            field "resourceType" string
                 |> andThen
                     (\s ->
+                        let
+                            link =
+                                decodeDisplayLink changeRequestStatus action
+                        in
                         case s of
                             "directive" ->
-                                succeed DirectiveRes
+                                map2 TypedResourceReference (succeed DirectiveRes) link
 
                             "node group" ->
-                                succeed NodeGroupRes
+                                map2 TypedResourceReference (succeed NodeGroupRes) link
 
                             "rule" ->
-                                succeed RuleRes
+                                map2 TypedResourceReference (succeed RuleRes) link
 
                             "global parameter" ->
-                                succeed GlobalParameterRes
+                                map2 TypedResourceReference (succeed GlobalParameterRes) link
 
                             _ ->
                                 fail "Invalid resource type"
-                    )
-
-        decodeAction =
-            string
-                |> andThen
-                    (\s ->
-                        case s of
-                            "create" ->
-                                succeed "Create"
-
-                            "delete" ->
-                                succeed "Delete"
-
-                            "modify" ->
-                                succeed "Modify"
-
-                            _ ->
-                                fail "Invalid action"
                     )
     in
     field "type" string
@@ -276,13 +335,15 @@ decodeEvent =
                         map ChangeLogEvent (field "action" string)
 
                     "ResourceChangeEvent" ->
-                        map ResourceChangeEvent
-                            (map4 ResourceChange
-                                (field "resourceType" decodeResourceType)
-                                (field "resourceName" string)
-                                (field "resourceId" string)
-                                (field "action" decodeAction)
-                            )
+                        field "action" decodeAction
+                            |> andThen
+                                (\action ->
+                                    map ResourceChangeEvent
+                                        (map2 ResourceChange
+                                            (decodeResourceRef action)
+                                            (succeed action)
+                                        )
+                                )
 
                     _ ->
                         fail "Invalid event log type"
@@ -373,17 +434,25 @@ decodeChangeRequestMainDetails =
                             _ ->
                                 fail "Invalid next status"
                     )
+
+        decodeEventLogList : String -> Decoder (List EventLog)
+        decodeEventLogList changeRequestStatus =
+            list (decodeEventLog changeRequestStatus)
     in
     at
         [ "data" ]
         (field "workflow"
             (index 0
-                (map5 ChangeRequestMainDetailsMetadata
-                    (field "changeRequest" decodeChangeRequestDetails)
-                    (field "isPending" bool)
-                    (field "eventLogs" (list decodeEventLog))
-                    (maybe (field "backStatus" decodePrevStatus))
-                    (field "allNextSteps" (list decodeNextStatus))
+                (field "changeRequest" decodeChangeRequestDetails
+                    |> andThen
+                        (\changeRequestDetails ->
+                            map5 ChangeRequestMainDetailsMetadata
+                                (succeed changeRequestDetails)
+                                (field "isPending" bool)
+                                (field "eventLogs" (decodeEventLogList changeRequestDetails.state))
+                                (maybe (field "backStatus" decodePrevStatus))
+                                (field "allNextSteps" (list decodeNextStatus))
+                        )
                 )
             )
         )
@@ -403,3 +472,38 @@ decodeFormDetails =
                 )
             )
         )
+
+
+
+------------------------------
+-- UTIL
+------------------------------
+
+
+actionToString : Action -> String
+actionToString action =
+    case action of
+        CreateAction ->
+            "create"
+
+        DeleteAction ->
+            "delete"
+
+        ModifyAction ->
+            "modify"
+
+
+resourceTypeWithIdToString : ResourceType -> String
+resourceTypeWithIdToString resourceType =
+    case resourceType of
+        DirectiveRes ->
+            "directive"
+
+        NodeGroupRes ->
+            "group"
+
+        RuleRes ->
+            "rule"
+
+        GlobalParameterRes ->
+            "parameter"


### PR DESCRIPTION
https://issues.rudder.io/issues/28491

This PR aims to remove links to resources (groups, directives, parameters, rules) that have been deleted in a change request in that change request's page if this change request has been deployed.
This change affects the change request's "Change History" tab as well as the "Diff" tab.

Hence, if the change request has not been deployed yet, the link to the resource will be displayed as before :
<img width="853" height="278" alt="image" src="https://github.com/user-attachments/assets/a9617930-572b-43e1-9020-5eeebc4e9b1e" />
 
<img width="1013" height="328" alt="image" src="https://github.com/user-attachments/assets/0823a499-3183-4f65-9648-7e90f027c3ef" />



However, if the change request has been deployed, the links to the resource will be removed : 
<img width="1046" height="298" alt="image" src="https://github.com/user-attachments/assets/90db5acf-fd7f-4580-b3aa-663172bd4af5" />

<img width="999" height="349" alt="image" src="https://github.com/user-attachments/assets/0e0ac310-3b24-4bbe-8509-673bdab659a3" />
