### PR TITLE
Fixes #28890: Reverse entitlements mapping does not support attribution to all tenants

### DIFF
--- a/auth-backends/README.adoc
+++ b/auth-backends/README.adoc
@@ -513,7 +513,7 @@ Make sure that the parameter `rudder.auth.oauth2.provider.registrations` is set 
 You can configure an `OAuth2` or `OIDC` provider so that it informs Rudder of the roles the user need to have, and the tenants they belong to. This allows to centrally
 manage both user and authorization in the same place.
 
-This feature works with built-in roles or custom roles defined in the users definition XML file. Please see the xref:administration:users.adoc#_user_roles_and_fine_grained_authorizations[linked documentation] for more information about authorizations in Rudder.
+This feature works with **built-in roles or custom roles** defined in the users definition XML file. Please see the xref:administration:users.adoc#_user_roles_and_fine_grained_authorizations[linked documentation] for more information about authorizations in Rudder.
 
 [WARNING]
 
@@ -528,6 +528,28 @@ You need three additional properties to enable and configure that property for a
 - the second, `roles.attribute` defines the name of the OIDC token attribute which holds the list of roles,
 - the third, `roles.override` defines if the OIDC provided roles must be the only one the user get, or if they
   are merged with the `rudder-users.xml` ones.
+
+
+The same structure of properties applies to **tenants**:
+- `tenants.enabled` allows to enable the tenants mapping, provided that the multi-tenants plugin is enabled,
+- `tenants.attribute` defines the name of the OIDC token attribute which holds the list of tenants,
+- `tenants.override` defines if the OIDC provided tenants must be the only one the user get, or if they
+  are merged with the `rudder-users.xml` ones.
+
+[INFO]
+
+====
+
+xref:administration:multi-tenants.adoc[Multi-tenants plugin] documentation explains more details about tenants configuration.
+
+The special `*` and `-` can be used for tenants mapping, the following way (notice the additional quotes for reverse mapping):
+
+```
+rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_all=*
+rudder.auth.oauth2.provider.someidp.tenants.mapping.reverseEntitlements."*"=rudder_all
+```
+
+====
 
 See the example configuration file below for details about these property values.
 

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/Oauth2Authentication.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/Oauth2Authentication.scala
@@ -367,15 +367,23 @@ object RudderRegistrationPropertyCommon {
     for {
       keySet <- IOResult
                   .attempt(s"Missing key '${path}' for OAUTH2 registration '${base.id}' (${registrationAttributes(key)})")(
-                    config.getConfig(path).entrySet().asScala.map(_.getKey()).toList
+                    config.getObject(path).keySet().asScala.toList
                   )
-                  .catchAll(_ =>
-                    List().succeed
-                  ) // in that case, we suppose that the key is just missing so we return a default empty value for mapping
+                  // in that case, we suppose that the key is just missing so we return a default empty value for mapping
+                  .catchAll(_ => List().succeed)
       values <- ZIO.foreach(keySet) { key =>
                   val wholeKey = path + "." + key
                   IOResult.attempt(s"Error when reading role entitlement mapping '${wholeKey}'") {
-                    (key, config.getString(wholeKey))
+                    val (k, v) = {
+                      // see https://issues.rudder.io/issues/28890:
+                      // tenants can use special config for 'reverseEntitlements."*"' (resp. '-') key, but typesafe config would keep the double quotes
+                      key match {
+                        case "\"*\"" => ("*", config.getObject(path).get("\"*\"").unwrapped().asInstanceOf[String])
+                        case "\"-\"" => ("-", config.getObject(path).get("\"-\"").unwrapped().asInstanceOf[String])
+                        case _       => (key, config.getString(wholeKey))
+                      }
+                    }
+                    (k, v)
                   }
                 }
     } yield values.toMap

--- a/auth-backends/src/test/resources/oidc/oidc_reverse_role_mapping.properties
+++ b/auth-backends/src/test/resources/oidc/oidc_reverse_role_mapping.properties
@@ -25,7 +25,11 @@ rudder.auth.oauth2.provider.someidp.tenants.enabled=true
 rudder.auth.oauth2.provider.someidp.tenants.attribute=customtenants
 rudder.auth.oauth2.provider.someidp.tenants.override=true
 rudder.auth.oauth2.provider.someidp.tenants.mapping.enforced=true
+rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_all=*
+rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_none=-
 rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_TA=TA
 rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_TB=TB
+rudder.auth.oauth2.provider.someidp.tenants.mapping.reverseEntitlements."*"=CN=AAAA-BBBBB,OU=Groups,OU=_IT,OU=BB-DD,OU=Admin
+rudder.auth.oauth2.provider.someidp.tenants.mapping.reverseEntitlements."-"=CN=CCCC-DDDDD,OU=Groups,OU=_IT,OU=BB-DD,OU=Nobody
 rudder.auth.oauth2.provider.someidp.tenants.mapping.reverseEntitlements.TB_OVERRIDDEN=rudder_TB
 rudder.auth.oauth2.provider.someidp.tenants.mapping.reverseEntitlements.TA=CN=AAAA-BBBBB,OU=Groups,OU=_IT,OU=BB-DD,OU=UUU-XXXX-YY,DC=ee,DC=if,DC=ttttt,DC=uuu

--- a/auth-backends/src/test/scala/com/normation/plugins/authbackends/TestReadOidcConfig.scala
+++ b/auth-backends/src/test/scala/com/normation/plugins/authbackends/TestReadOidcConfig.scala
@@ -87,10 +87,16 @@ class TestReadOidcConfig extends Specification {
         "rudder_readonly"                                                                    -> "readonlyOVERRIDDEN",
         "CN=AAAA-BBBBB,OU=Groups,OU=_IT,OU=BB-DD,OU=UUU-XXXX-YY,DC=ee,DC=if,DC=ttttt,DC=uuu" -> "administrator"
       )) and (
-        regs("someidp").tenants.mapping === Map(
-          "rudder_TA"                                                                          -> "TA",
-          "rudder_TB"                                                                          -> "TB_OVERRIDDEN",
-          "CN=AAAA-BBBBB,OU=Groups,OU=_IT,OU=BB-DD,OU=UUU-XXXX-YY,DC=ee,DC=if,DC=ttttt,DC=uuu" -> "TA"
+        regs("someidp").tenants.mapping.toList must containTheSameElementsAs(
+          List(
+            "rudder_all"                                                                         -> "*",
+            "rudder_none"                                                                        -> "-",
+            "rudder_TA"                                                                          -> "TA",
+            "rudder_TB"                                                                          -> "TB_OVERRIDDEN",
+            "CN=AAAA-BBBBB,OU=Groups,OU=_IT,OU=BB-DD,OU=UUU-XXXX-YY,DC=ee,DC=if,DC=ttttt,DC=uuu" -> "TA",
+            "CN=AAAA-BBBBB,OU=Groups,OU=_IT,OU=BB-DD,OU=Admin"                                   -> "*",
+            "CN=CCCC-DDDDD,OU=Groups,OU=_IT,OU=BB-DD,OU=Nobody"                                  -> "-"
+          )
         )
       )
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/28890

Typesafe config :
* will only allow `reverseEntitlements."*"` with quotes because `*` is a special configuration character
* but it will have the key `"\"*\""`

So, we need a special case for the extra quotes in the key: we can only parse it by using `config.getObject`, and we will also need to remap the key to remove the extra quotes.

I also added some documentation regarding that