### PR TITLE
Fixes #28784: Header buttons are wrapped when change request name is too long on medium screen

### DIFF
--- a/change-validation/src/main/elm/sources/ChangeRequestDetails.elm
+++ b/change-validation/src/main/elm/sources/ChangeRequestDetails.elm
@@ -489,13 +489,14 @@ bannerView model cr =
                 |> Maybe.withDefault ("Error: no action was recorded for change request with id" ++ String.fromInt cr.changeRequest.id)
     in
     div [ class "main-header", id "changeRequestHeader" ]
-        [ div [ class "header-title" ]
-            [ h1 [] [ span [ id "nameTitle" ] [ text cr.changeRequest.title ] ]
-            , div [ class "flex-container" ]
-                [ div [ id "CRStatus" ] [ text cr.changeRequest.state ]
-                , actionButtons model cr.changeRequest.id canChangeStep cr.prevStatus cr.reachableNextSteps
-                ]
-            ]
+        [ div [ class "d-table col-12" ]
+            [div [class "header-title d-table-row"]
+                [ div [class "d-table-cell"] [h1 [] [ span [ id "nameTitle" ] [ text cr.changeRequest.title ] ]]
+                , div [ class "flex-container" ]
+                    [ div [ id "CRStatus" ] [ text cr.changeRequest.state ]
+                    , actionButtons model cr.changeRequest.id canChangeStep cr.prevStatus cr.reachableNextSteps
+                    ]
+                ]]
         , div
             [ class "header-description" ]
             [ p [ id "CRLastAction" ] [ text lastLog ]


### PR DESCRIPTION
https://issues.rudder.io/issues/28784

### before : 
<img width="2753" height="1568" alt="image" src="https://github.com/user-attachments/assets/88b1c436-f95b-41ce-879c-ba2694b88f9d" />

---

### after : 

<img width="1067" height="523" alt="image" src="https://github.com/user-attachments/assets/89bfcee6-b044-45dc-a733-ff68555d8c25" />

<img width="723" height="523" alt="image" src="https://github.com/user-attachments/assets/de961067-7fe2-4060-bf03-c206749ba015" />

