### PR TITLE
Fixes #29141: Lift 2.13 test kit still referenced in plugin pom

### DIFF
--- a/plugins-common/pom-template.xml
+++ b/plugins-common/pom-template.xml
@@ -460,7 +460,7 @@
      <!-- Testing Liftweb -->
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-testkit_2.13</artifactId>
+      <artifactId>lift-testkit_3</artifactId>
       <version>${lift-version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
https://issues.rudder.io/issues/29141