### PR TITLE
Fixes #29144: Switch to SBT 2.0 (plugins)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,38 @@
+import Dependencies.servletProvided
+
+// ============================================================================
+// rudder-plugins build — sbt port of the Maven `plugins-parent` reactor.
+// Shared logic lives in project/PluginBuild.scala (reused by rudder-plugins-private).
+// Two build modes, driven exactly like Maven by `-Dlimited`:
+//   - default  : `make` / `sbt "<plugin>/assembly"`            (unlicensed, OSS)
+//   - licensed : `make licensed` / `sbt -Dlimited ... "<plugin>/assembly"`
+// ============================================================================
+
+PluginBuild.commonBuildSettings
+
+// plugins-common-private: private code lib (LicensedPluginCheck); needs com.normation:license-lib
+// from the private nexus. Only used in licensed mode; not part of the default aggregate.
+lazy val pluginsCommonPrivate = Project("plugins-common-private", file("plugins-common-private"))
+  .settings(PluginBuild.commonSettings)
+  .settings(
+    name    := "plugins-common-private",
+    version := PluginBuild.privateLibVersion, // RUDDER_VERSION-PRIVATE_VERSION (main-build.conf)
+    libraryDependencies ++= Dependencies.pluginBase,
+    libraryDependencies += "com.normation" % "license-lib" % "2.4.0" // fixed private artifact (nexus)
+  )
+
+// ---- the 8 Scala plugins ------------------------------------------------------------------
+lazy val apiAuthorizations   = PluginBuild.pluginProject("api-authorizations",   "apiauthorizations",   hasElm = true,  Seq(servletProvided))
+lazy val authBackends        = PluginBuild.pluginProject("auth-backends",        "authbackends",        hasElm = true,  servletProvided +: Dependencies.authBackends)
+lazy val branding            = PluginBuild.pluginProject("branding",             "branding",            hasElm = true,  Seq(servletProvided))
+lazy val changeValidation    = PluginBuild.pluginProject("change-validation",    "changevalidation",    hasElm = true,  servletProvided +: Dependencies.changeValidation)
+lazy val datasourcesPlugin   = PluginBuild.pluginProject("datasources",          "datasources",         hasElm = true,  servletProvided +: Dependencies.datasources)
+lazy val nodeExternalReports = PluginBuild.pluginProject("node-external-reports","nodeexternalreports", hasElm = false)
+lazy val openscapPlugin      = PluginBuild.pluginProject("openscap",             "openscappolicies",    hasElm = false, servletProvided +: Dependencies.openscap)
+lazy val scaleOutRelay       = PluginBuild.pluginProject("scale-out-relay",      "scaleoutrelay",       hasElm = false, Seq(servletProvided))
+
+// root aggregates only the OSS plugins (private lib excluded — it needs the private repo)
+lazy val root = (project in file("."))
+  .settings(name := "rudder-plugins", publish / skip := true)
+  .aggregate(apiAuthorizations, authBackends, branding, changeValidation,
+             datasourcesPlugin, nodeExternalReports, openscapPlugin, scaleOutRelay)

--- a/makefiles/common-scala-plugin.mk
+++ b/makefiles/common-scala-plugin.mk
@@ -24,16 +24,20 @@ plugins-common-private:plugins-common
 	cd ../plugins-common-private && make
 	cd ../$(NAME)
 
-build-files:   
-	$(MVN_CMD) package
+# unlicensed (OSS) build: sbt assembly without -Dlimited (Maven profile internal-default).
+# sbt runs from the repo root and writes <plugin>/target/<name>-<version>-jar-with-dependencies.jar.
+build-files:
+	cd .. && $(SBT_CMD) "$(NAME)/assembly"
 	mkdir -p target/$(NAME)
 	mv target/$(NAME)-*-jar-with-dependencies.jar target/$(NAME)/$(NAME).jar
 
 std-files: plugins-common generate-pom build-files
 	echo "${VERSION}"
 
+# licensed build: same flags Maven received (-Dlimited + the three resource properties), which
+# the sbt license toggle (project/PluginBuild.scala) reads (Maven profile internal-limited).
 build-licensed-files:
-	$(MVN_CMD) -Dlimited -Dplugin-resource-publickey=$(TARGET_KEY_PATH) -Dplugin-resource-license=$(TARGET_LICENSE_PATH) -Dplugin-declared-version=$(VERSION) package
+	cd .. && $(SBT_CMD) -Dlimited -Dplugin-resource-publickey=$(TARGET_KEY_PATH) -Dplugin-resource-license=$(TARGET_LICENSE_PATH) -Dplugin-declared-version=$(VERSION) "$(NAME)/assembly"
 	mkdir -p target/$(NAME)
 	mv target/$(NAME)-*-jar-with-dependencies.jar target/$(NAME)/$(NAME).jar
 

--- a/makefiles/common-scala-plugin.mk
+++ b/makefiles/common-scala-plugin.mk
@@ -24,10 +24,16 @@ plugins-common-private:plugins-common
 	cd ../plugins-common-private && make
 	cd ../$(NAME)
 
+# `$(SBT_SHUTDOWN)` (defined in global-vars.mk) brackets each build: before, so the sbtn quick-start
+# client doesn't reuse a server with stale -D / -Dlimited (sbt 2.0 binds -D at server startup); after,
+# to leave a clean state. Its output is suppressed (it hides a benign sbtn JNI shutdown race).
+#
 # unlicensed (OSS) build: sbt assembly without -Dlimited (Maven profile internal-default).
 # sbt runs from the repo root and writes <plugin>/target/<name>-<version>-jar-with-dependencies.jar.
 build-files:
+	$(SBT_SHUTDOWN)
 	cd .. && $(SBT_CMD) "$(NAME)/assembly"
+	$(SBT_SHUTDOWN)
 	mkdir -p target/$(NAME)
 	mv target/$(NAME)-*-jar-with-dependencies.jar target/$(NAME)/$(NAME).jar
 
@@ -37,7 +43,9 @@ std-files: plugins-common generate-pom build-files
 # licensed build: same flags Maven received (-Dlimited + the three resource properties), which
 # the sbt license toggle (project/PluginBuild.scala) reads (Maven profile internal-limited).
 build-licensed-files:
+	$(SBT_SHUTDOWN)
 	cd .. && $(SBT_CMD) -Dlimited -Dplugin-resource-publickey=$(TARGET_KEY_PATH) -Dplugin-resource-license=$(TARGET_LICENSE_PATH) -Dplugin-declared-version=$(VERSION) "$(NAME)/assembly"
+	$(SBT_SHUTDOWN)
 	mkdir -p target/$(NAME)
 	mv target/$(NAME)-*-jar-with-dependencies.jar target/$(NAME)/$(NAME).jar
 

--- a/makefiles/global-vars.mk
+++ b/makefiles/global-vars.mk
@@ -38,7 +38,19 @@ MVN_CMD = mvn $(MVN_PARAMS) --batch-mode -Djansi.passthrough=true -Dstyle.color=
 
 # sbt build (replaces maven). Invoked from the repo root (where build.sbt lives). A UTF-8 locale
 # is required (assembly fails on non-ASCII classfile names otherwise). Extra args via SBT_PARAMS.
+# Used as `cd .. && $(SBT_CMD) <-D opts> "<task>"`. Runs through the native client (sbtn) for fast
+# start-up — we do NOT pass --server (that would boot a full foreground JVM and defeat the quick start).
 SBT_CMD = LANG=C.UTF-8 LC_ALL=C.UTF-8 sbt -batch $(SBT_PARAMS)
+
+# Shut the sbt server down. Run as its OWN recipe line both BEFORE a build (so this invocation's -D —
+# incl. -Dlimited / -Dplugin-resource-* — take effect on a fresh server: sbt 2.0 binds -D at server
+# startup, and the sbtn quick-start client otherwise reuses a running server with stale -D) and AFTER it
+# (leave a clean state, no lingering server). Output is discarded on purpose: shutting the server down
+# makes the sbtn native client print a benign `ArrayIndexOutOfBoundsException` (a GraalVM-native-image
+# JNI race in ipcsocket while reading the socket the server is closing) — harmless noise, exit code is
+# fine, so we send it to /dev/null instead of switching off the quick-start client. `--no-server` keeps
+# it from spawning a JVM just to discover there is no server to stop (fast no-op when already clean).
+SBT_SHUTDOWN = cd .. && (LANG=C.UTF-8 LC_ALL=C.UTF-8 sbt --no-server -batch shutdown >/dev/null 2>&1 || true)
 
 RANDOM := $(shell bash -c 'echo $$RANDOM')
 

--- a/makefiles/global-vars.mk
+++ b/makefiles/global-vars.mk
@@ -36,6 +36,10 @@ endif
 # if you want to add maven command line parameter, add them with MVN_PARAMS
 MVN_CMD = mvn $(MVN_PARAMS) --batch-mode -Djansi.passthrough=true -Dstyle.color=always
 
+# sbt build (replaces maven). Invoked from the repo root (where build.sbt lives). A UTF-8 locale
+# is required (assembly fails on non-ASCII classfile names otherwise). Extra args via SBT_PARAMS.
+SBT_CMD = LANG=C.UTF-8 LC_ALL=C.UTF-8 sbt -batch $(SBT_PARAMS)
+
 RANDOM := $(shell bash -c 'echo $$RANDOM')
 
 generate-pom:

--- a/makefiles/make-plugins-common.mk
+++ b/makefiles/make-plugins-common.mk
@@ -17,7 +17,9 @@ VERSION = $(LIB_$(LIB_TYPE)_VERSION)
 # so licensed plugin builds can resolve it (needs the private license-lib from nexus.normation.com).
 ifeq ($(LIB_TYPE),PRIVATE)
 std:
+	$(SBT_SHUTDOWN)
 	cd .. && $(SBT_CMD) -Dlimited "plugins-common-private/publishM2"
+	$(SBT_SHUTDOWN)
 else
 std:
 	@echo "plugins-common is the sbt parent settings (no artifact to install)"

--- a/makefiles/make-plugins-common.mk
+++ b/makefiles/make-plugins-common.mk
@@ -7,23 +7,21 @@ include ../makefiles/global-vars.mk
 #LIB_TYPE = COMMON or PRIVATE
 
 
-# maven local repo
-MAVEN_LOCAL_REPO =  $(shell $(MVN_PARAMS) ../makefiles/find_m2_repo.sh)
-
 NAME = $(LIB_$(LIB_TYPE)_NAME)
 VERSION = $(LIB_$(LIB_TYPE)_VERSION)
-#PLUGINS_JAR_PATH = $(MAVEN_LOCAL_REPO)/com/normation/plugins/$(NAME)/$(RUDDER_POM_VERSION)-$(LIB_$(LIB_TYPE)_VERSION)/$(RUDDER_POM_VERSION)-$(LIB_$(LIB_TYPE)_VERSION).jar
-PLUGINS_JAR_PATH = $(MAVEN_LOCAL_REPO)/com/normation/plugins/$(NAME)/$(RUDDER_POM_VERSION)-$(VERSION)/$(NAME)-$(RUDDER_POM_VERSION)-$(VERSION).pom
 
 .DEFAULT_GOAL := std
 
-std: generate-pom $(PLUGINS_JAR_PATH)
-
-# maven is such a pain that "mvn install" can't be used with parametrized version (it
-# uses the literal '${plugin-version}' string in path). So we are doing installation by 
-# hand. Yep, most beautiful tool.
-$(PLUGINS_JAR_PATH):
-	$(MVN_CMD) clean install
+# PUBLIC (plugins-common) is just the sbt parent settings now -> nothing to install.
+# PRIVATE (plugins-common-private) is a real sbt module -> publish it to the local Maven repo,
+# so licensed plugin builds can resolve it (needs the private license-lib from nexus.normation.com).
+ifeq ($(LIB_TYPE),PRIVATE)
+std:
+	cd .. && $(SBT_CMD) -Dlimited "plugins-common-private/publishM2"
+else
+std:
+	@echo "plugins-common is the sbt parent settings (no artifact to install)"
+endif
 
 clean:
 	rm -f  pom.xml

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,86 @@
+import sbt._
+
+/**
+ * Versions + ModuleIDs for the plugins build.
+ *
+ * The Maven `plugins-parent` POM lists ~150 transitive deps of rudder-web explicitly as
+ * `provided` so the shade plugin keeps them out of the fat jar. In sbt we instead depend on
+ * `rudder-web` (classes) as `Provided`: its whole transitive closure is then provided, and
+ * sbt-assembly (which bundles the Runtime classpath) excludes it — same result, no big list.
+ *
+ * Only genuinely plugin-specific, non-rudder libraries are bundled (normal compile scope).
+ */
+object Dependencies {
+
+  // version of rudder artifacts to build against — read from main-build.conf (single source of
+  // truth), exactly what `make generate-pom` used to inject. See PluginBuild.rudderBuildVersion.
+  val rudderVersion = PluginBuild.rudderBuildVersion
+
+  object V {
+    val scala          = "3.8.4"
+    val springSecurity = "7.1.0"
+    val servlet        = "6.1.0"
+    val lift           = "4.0.0"
+    val snakeyaml      = "2.6"
+    val zioHttp        = "2.0.0-RC11"
+    // plugin-specific bundled libs
+    val jacksonDatabind = "2.20.1"
+    val nimbusJoseJwt   = "10.5"
+    val jakartaMail     = "2.0.2"
+    val subethasmtp     = "7.2.0"
+    val mustache        = "0.9.14"   // change-validation "compiler" (Mustache.java)
+    val jsoup           = "1.21.2"
+    // test stack (same as rudder-parent inherited <dependencies>)
+    val specs2     = "4.23.0"
+    val zio        = "2.1.26"
+    val catsEffect = "3.7.0"
+  }
+
+  // ---- rudder provided (classes jar) + transitive closure (excluded from assembly) ----------
+  val rudderWebProvided =
+    ("com.normation.rudder" % "rudder-web" % rudderVersion).classifier("classes") % Provided
+
+  // ---- test deps (rudder test-jars + common test stack) -------------------------------------
+  val testDeps: Seq[ModuleID] = Seq(
+    ("com.normation.rudder" % "rudder-core" % rudderVersion).classifier("tests") % Test,
+    ("com.normation.rudder" % "rudder-rest" % rudderVersion).classifier("tests") % Test,
+    ("com.normation.rudder" % "rudder-web"  % rudderVersion).classifier("tests") % Test,
+    "org.typelevel"       %% "cats-effect-std" % V.catsEffect % Test,
+    "net.liftweb"         %% "lift-testkit" % V.lift % Test, // _3 (the Maven parent's _2.13 is a bug)
+    "org.specs2"          %% "specs2-core"          % V.specs2 % Test,
+    "org.specs2"          %% "specs2-junit"         % V.specs2 % Test,
+    "org.specs2"          %% "specs2-matcher-extra" % V.specs2 % Test,
+    "dev.zio"             %% "zio-test"             % V.zio    % Test,
+    "dev.zio"             %% "zio-test-junit"       % V.zio    % Test
+  )
+
+  // base set shared by every plugin
+  val pluginBase: Seq[ModuleID] = rudderWebProvided +: testDeps
+
+  // ---- plugin-specific bundled (non-provided) deps -----------------------------------------
+  val servletProvided = "jakarta.servlet" % "jakarta.servlet-api" % V.servlet % Provided
+
+  val authBackends: Seq[ModuleID] = Seq(
+    "org.springframework.security" % "spring-security-oauth2-core"            % V.springSecurity,
+    "org.springframework.security" % "spring-security-oauth2-client"          % V.springSecurity,
+    "org.springframework.security" % "spring-security-oauth2-resource-server" % V.springSecurity,
+    "org.springframework.security" % "spring-security-oauth2-jose"            % V.springSecurity,
+    "com.fasterxml.jackson.core"   % "jackson-databind"                       % V.jacksonDatabind,
+    "com.nimbusds"                 % "nimbus-jose-jwt"                        % V.nimbusJoseJwt
+  )
+
+  val changeValidation: Seq[ModuleID] = Seq(
+    "com.github.spullara.mustache.java" % "compiler"     % V.mustache,
+    "com.sun.mail"                      % "jakarta.mail" % V.jakartaMail,
+    "com.github.davidmoten"             % "subethasmtp"  % V.subethasmtp
+  )
+
+  val datasources: Seq[ModuleID] = Seq(
+    "org.yaml" % "snakeyaml" % V.snakeyaml,
+    "io.d11"  %% "zhttp"     % V.zioHttp
+  )
+
+  val openscap: Seq[ModuleID] = Seq(
+    "org.jsoup" % "jsoup" % V.jsoup
+  )
+}

--- a/project/PluginBuild.scala
+++ b/project/PluginBuild.scala
@@ -1,0 +1,221 @@
+import sbt._
+import sbt.Keys._
+import sbtassembly.AssemblyPlugin
+import sbtassembly.AssemblyPlugin.autoImport._
+import scala.sys.process._
+
+/**
+ * Shared build glue for the Scala plugins, ported from the Maven `plugins-parent` POM +
+ * `pom-template.xml`. This object lives in `rudder-plugins` and is REUSED by the downstream
+ * `rudder-plugins-private` build, which symlinks this file from its `rudder-plugins` submodule
+ * (the same way the repo already symlinks `makefiles`, `main-build.conf`, `plugins-common*`).
+ * Centralising the logic here keeps the two repos' `build.sbt` to just a list of modules.
+ *
+ * The two build modes are driven exactly like Maven, by the *presence* of `-Dlimited`:
+ *   - UNLICENSED (no `-Dlimited`, profile `internal-default`): compile
+ *     `src/main/scala-templates/default` (OSS PluginEnableImpl, no license check).
+ *   - LICENSED (`-Dlimited`, profile `internal-limited`): template-filter
+ *     `src/main/scala-templates/limited` (LicensedPluginCheck), substituting the same
+ *     placeholders Maven filled from `-Dplugin-resource-*` / `-Dplugin-declared-version`, and
+ *     add the `plugins-common-private` dependency.
+ */
+object PluginBuild {
+
+  /** licensed build iff `-Dlimited` is present (Maven activates by property presence). */
+  val licensed: Boolean = sys.props.contains("limited")
+
+  // ---- build.conf / main-build.conf parsing ------------------------------------------------
+  private def parseConf(f: File): Map[String, String] =
+    if (!f.exists) Map.empty
+    else
+      IO.readLines(f).iterator
+        .map(_.trim)
+        .filterNot(l => l.isEmpty || l.startsWith("#"))
+        .flatMap(l => l.split("=", 2) match { case Array(k, v) => Some(k.trim -> v.trim); case _ => None })
+        .toMap
+
+  /** plugin-name from a plugin's build.conf. */
+  def pluginName(base: File): String =
+    parseConf(base / "build.conf").getOrElse("plugin-name", base.getName)
+
+  /** full plugin id, e.g. rudder-plugin-api-authorizations. */
+  def pluginFullName(base: File): String = s"rudder-plugin-${pluginName(base)}"
+
+  /** plugin-version from build.conf (e.g. 2.2). */
+  def pluginVersion(base: File): String =
+    parseConf(base / "build.conf").getOrElse("plugin-version", "0.0")
+
+  // ---- main-build.conf : the single source of truth for rudder + lib versions ---------------
+  // sbt reads it directly (it is just Scala) — no `generate-pom` / pom-template needed, which only
+  // existed because Maven resolves parent <version> before property interpolation. Resolved at the
+  // build root (sbt cwd): in rudder-plugins-private this is a symlink to the submodule's file.
+  private val mainBuild   = parseConf(file("main-build.conf"))
+  val rudderVersion       = mainBuild.getOrElse("rudder-version", "0.0.0") // e.g. 9.2.0~alpha1
+  val branchType          = mainBuild.getOrElse("branch-type", "")
+  val commonVersion       = mainBuild.getOrElse("common-version", "")
+  val privateVersion      = mainBuild.getOrElse("private-version", "")
+
+  /** version of the rudder artifacts plugins build against (global-vars.mk RUDDER_BUILD_VERSION). */
+  val rudderBuildVersion: String = branchType match {
+    case "next" => s"$rudderVersion-SNAPSHOT"
+    case _      => rudderVersion
+  }
+
+  /** a plugin's published version (global-vars.mk PLUGIN_POM_VERSION). */
+  def pluginPomVersion(base: File): String = branchType match {
+    case "next" | "nightly" => s"$rudderVersion-${pluginVersion(base)}-SNAPSHOT"
+    case _                  => s"$rudderVersion-${pluginVersion(base)}"
+  }
+
+  /** plugins-common-private published version (RUDDER_VERSION-PRIVATE_VERSION, SNAPSHOT on next/nightly). */
+  def privateLibVersion: String = branchType match {
+    case "next" | "nightly" => s"$rudderVersion-$privateVersion-SNAPSHOT"
+    case _                  => s"$rudderVersion-$privateVersion"
+  }
+
+  // ---- build-wide settings (was the ThisBuild block of build.sbt) ---------------------------
+  def commonBuildSettings: Seq[Setting[?]] = Seq(
+    ThisBuild / scalaVersion     := Dependencies.V.scala,
+    ThisBuild / organization     := "com.normation.plugins",
+    // keep unsuffixed artifactIds (api-authorizations, not api-authorizations_3), Maven parity.
+    ThisBuild / crossPaths       := false,
+    ThisBuild / autoScalaLibrary := false, // scala lib comes (provided) via rudder-web
+    ThisBuild / resolvers ++= Seq(
+      Resolver.mavenLocal, // rudder-web/core/rest published by the webapp build (honors -Dmaven.repo.local)
+      "rudder-release"  at "https://repository.rudder.io/maven/releases/",
+      "rudder-snapshot" at "https://repository.rudder.io/maven/snapshots/"
+    ),
+    // scalacOptions inherited from rudder-parent (same strict set as the webapp build)
+    ThisBuild / scalacOptions ++= Seq(
+      "-release:17", "-deprecation", "-explain-types", "-feature", "-unchecked",
+      "-language:existentials", "-language:higherKinds", "-language:implicitConversions",
+      "-Xmax-inlines", "100",
+      "-Wconf:msg=An existential type that came from a Scala-2 classfile for trait BoxTrait:s",
+      "-Werror", "-Wunused:imports", "-Wunused:locals", "-Wunused:implicits", "-Wunused:privates",
+      "-Ycheck-all-patmat", "-Ysemanticdb"
+    ),
+    ThisBuild / javacOptions ++= Seq("--release", "17", "-encoding", "UTF-8")
+  )
+
+  // ---- per-module common settings (the Maven `plugins-parent`) ------------------------------
+  def commonSettings: Seq[Setting[?]] = Seq(
+    // version = RUDDER_VERSION (main-build.conf) - plugin-version (build.conf), like PLUGIN_POM_VERSION.
+    version := pluginPomVersion(baseDirectory.value),
+    // run tests against class dirs (sbt 2.0 exportJars=true otherwise breaks logback/resources)
+    exportJars := false,
+    Test / fork := true,
+    Test / parallelExecution := false,
+    Test / javaOptions += "-Dspecs2.commandline=console",
+    Compile / packageDoc / publishArtifact := false,
+    // local publish -> ~/.m2 (honors -Dmaven.repo.local), like the webapp build
+    publishMavenStyle := true,
+    publishLocal := publishM2.value
+  )
+
+  // ---- the fat-jar (Maven maven-shade-plugin): own classes + non-provided deps --------------
+  def assemblySettings(jarBase: String): Seq[Setting[?]] = Seq(
+    assembly / assemblyJarName    := s"$jarBase-${version.value}-jar-with-dependencies.jar",
+    // land it in <plugin>/target/ so the Makefile's `mv target/<name>-*-jar-with-dependencies.jar` works
+    assembly / assemblyOutputPath := Def.uncached { baseDirectory.value / "target" / (assembly / assemblyJarName).value },
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", _*) => MergeStrategy.discard
+      case "module-info.class"      => MergeStrategy.discard
+      case _                        => MergeStrategy.first
+    }
+  )
+
+  // ---- license source-template toggle ------------------------------------------------------
+  private val placeholders = Seq("plugin-resource-publickey", "plugin-resource-license", "plugin-declared-version")
+
+  /** Generate the filtered `limited` sources into sourceManaged, substituting the 4 placeholders. */
+  private def filterLimitedSources = Def.task {
+    val base    = baseDirectory.value
+    val srcDir  = base / "src" / "main" / "scala-templates" / "limited"
+    val outDir  = (Compile / sourceManaged).value / "scala-templates-limited"
+    val subst: Map[String, String] =
+      placeholders.map(k => k -> sys.props.getOrElse(k, "")).toMap +
+        ("plugin-fullname" -> pluginFullName(base))
+    IO.delete(outDir)
+    if (!srcDir.exists) Seq.empty[File]
+    else
+      (srcDir ** "*.scala").get().map { src =>
+        val rel     = srcDir.toPath.relativize(src.toPath).toString
+        val out     = outDir / rel
+        val content = subst.foldLeft(IO.read(src)) { case (c, (k, v)) => c.replace("${" + k + "}", v) }
+        IO.write(out, content)
+        out
+      }
+  }
+
+  /** Settings selecting default vs limited sources, like the two Maven profiles. */
+  def licenseSettings: Seq[Setting[?]] =
+    if (licensed)
+      Seq(
+        Compile / sourceGenerators += filterLimitedSources.taskValue,
+        libraryDependencies += "com.normation.plugins" % "plugins-common-private" % privateLibVersion
+      )
+    else
+      Seq(
+        Compile / unmanagedSourceDirectories += baseDirectory.value / "src" / "main" / "scala-templates" / "default"
+      )
+
+  // ---- build.conf copied into the jar (Maven copy-build-conf), for runtime plugin id -------
+  def buildConfResource(destDirectory: String) = Def.task {
+    val base    = baseDirectory.value
+    val outDir  = (Compile / resourceManaged).value / "com" / "normation" / "plugins" / destDirectory
+    val pn      = pluginName(base)
+    def filter(s: String) = s.replace("${plugin-name}", pn)
+    val gen = Seq(base / "build.conf" -> "build.conf", base / ".." / "main-build.conf" -> "main-build.conf")
+    gen.collect { case (src, name) if src.exists =>
+      val out = outDir / name
+      IO.write(out, filter(IO.read(src)))
+      out
+    }
+  }
+
+  // ---- Elm frontend (build.sh + elm-review), like the webapp ------------------------------
+  val elmBuild  = taskKey[Seq[File]]("Build the plugin Elm frontend and stage css/js under toserve/")
+  val elmReview = taskKey[Unit]("Run elm-review for this plugin")
+
+  def elmSettings(destDirectory: String): Seq[Setting[?]] = Seq(
+    elmBuild := Def.uncached {
+      val mainDir = baseDirectory.value / "src" / "main"
+      streams.value.log.info(s"Building Elm frontend (build.sh --release) for ${name.value}")
+      val rc = Process(Seq("./build.sh", "--release"), mainDir).!
+      if (rc != 0) sys.error(s"Elm build.sh failed with exit code $rc")
+      val gen     = mainDir / "elm" / "generated"
+      val outBase = (Compile / resourceManaged).value / "toserve" / destDirectory
+      (gen * ("*.css" | "*.js")).get().map { src =>
+        val target = outBase / src.getName
+        IO.copyFile(src, target)
+        target
+      }
+    },
+    Compile / resourceGenerators += elmBuild.taskValue,
+    elmReview := {
+      val rc = Process(Seq("npx", "elm-review"), baseDirectory.value / "src" / "main" / "elm").!
+      if (rc != 0) sys.error(s"elm-review failed with exit code $rc")
+    },
+    Test / test := (Test / test).dependsOn(elmReview).evaluated
+  )
+
+  /**
+   * One Scala plugin module. `dir` is also the Maven artifactId and the sbt project id (so
+   * `sbt "<dir>/assembly"` works from the Makefile). `destDirectory` is the plugin POM's
+   * `destDirectory` (base package / toserve dir). `hasElm` toggles the frontend build.
+   */
+  def pluginProject(dir: String, destDirectory: String, hasElm: Boolean, extra: Seq[ModuleID] = Nil): Project = {
+    val p = Project(dir, file(dir))
+      .enablePlugins(AssemblyPlugin)
+      .settings(commonSettings)
+      .settings(assemblySettings(dir))
+      .settings(
+        name := dir,
+        libraryDependencies ++= Dependencies.pluginBase ++ extra,
+        // copy build.conf into the jar for runtime plugin identification (Maven copy-build-conf)
+        Compile / resourceGenerators += buildConfResource(destDirectory).taskValue
+      )
+      .settings(licenseSettings*)
+    if (hasElm) p.settings(elmSettings(destDirectory)*) else p
+  }
+}

--- a/project/PluginBuild.scala
+++ b/project/PluginBuild.scala
@@ -85,15 +85,20 @@ object PluginBuild {
       "rudder-release"  at "https://repository.rudder.io/maven/releases/",
       "rudder-snapshot" at "https://repository.rudder.io/maven/snapshots/"
     ),
-    // scalacOptions inherited from rudder-parent (same strict set as the webapp build)
+    // scalacOptions inherited from rudder-parent (same strict set as the webapp build). NOTE: the
+    // Maven `-Ysemanticdb` is intentionally NOT here — it is replaced by `semanticdbEnabled := true`
+    // below (sbt-managed semanticdb, which passes `-Xsemanticdb -semanticdb-target:<managed dir>`).
+    // The raw flag writes .semanticdb under the class output, which on a cold compile crashes the
+    // ExtractSemanticDB phase (NoSuchFileException) and leaks semanticdb into the assembled jars.
     ThisBuild / scalacOptions ++= Seq(
       "-release:17", "-deprecation", "-explain-types", "-feature", "-unchecked",
       "-language:existentials", "-language:higherKinds", "-language:implicitConversions",
       "-Xmax-inlines", "100",
       "-Wconf:msg=An existential type that came from a Scala-2 classfile for trait BoxTrait:s",
       "-Werror", "-Wunused:imports", "-Wunused:locals", "-Wunused:implicits", "-Wunused:privates",
-      "-Ycheck-all-patmat", "-Ysemanticdb"
+      "-Ycheck-all-patmat"
     ),
+    ThisBuild / semanticdbEnabled := true,
     ThisBuild / javacOptions ++= Seq("--release", "17", "-encoding", "UTF-8")
   )
 
@@ -127,31 +132,36 @@ object PluginBuild {
   // ---- license source-template toggle ------------------------------------------------------
   private val placeholders = Seq("plugin-resource-publickey", "plugin-resource-license", "plugin-declared-version")
 
-  /** Generate the filtered `limited` sources into sourceManaged, substituting the 4 placeholders. */
-  private def filterLimitedSources = Def.task {
-    val base    = baseDirectory.value
-    val srcDir  = base / "src" / "main" / "scala-templates" / "limited"
-    val outDir  = (Compile / sourceManaged).value / "scala-templates-limited"
-    val subst: Map[String, String] =
-      placeholders.map(k => k -> sys.props.getOrElse(k, "")).toMap +
-        ("plugin-fullname" -> pluginFullName(base))
-    IO.delete(outDir)
-    if (!srcDir.exists) Seq.empty[File]
-    else
-      (srcDir ** "*.scala").get().map { src =>
-        val rel     = srcDir.toPath.relativize(src.toPath).toString
-        val out     = outDir / rel
-        val content = subst.foldLeft(IO.read(src)) { case (c, (k, v)) => c.replace("${" + k + "}", v) }
-        IO.write(out, content)
-        out
-      }
-  }
+  // The limited license-checker source generator. It MUST be `Def.uncached` (a taskKey assigned with
+  // Def.uncached — the only form `.taskValue` accepts): it reads `sys.props` (the -Dplugin-resource-*
+  // / -Dplugin-declared-version passed by `make licensed`), which sbt 2.0 does NOT track as task
+  // inputs. If cached, a stale generation sticks across runs (e.g. empty paths from a build without
+  // the -D) -> the runtime "key file '' was not found" error. Uncached re-reads the props every build.
+  val limitedSources = taskKey[Seq[File]]("Generate the filtered `limited` license-checker sources")
 
   /** Settings selecting default vs limited sources, like the two Maven profiles. */
   def licenseSettings: Seq[Setting[?]] =
     if (licensed)
       Seq(
-        Compile / sourceGenerators += filterLimitedSources.taskValue,
+        limitedSources := Def.uncached {
+          val base   = baseDirectory.value
+          val srcDir = base / "src" / "main" / "scala-templates" / "limited"
+          val outDir = (Compile / sourceManaged).value / "scala-templates-limited"
+          val subst: Map[String, String] =
+            placeholders.map(k => k -> sys.props.getOrElse(k, "")).toMap +
+              ("plugin-fullname" -> pluginFullName(base))
+          IO.delete(outDir)
+          if (!srcDir.exists) Seq.empty[File]
+          else
+            (srcDir ** "*.scala").get().map { src =>
+              val rel     = srcDir.toPath.relativize(src.toPath).toString
+              val out     = outDir / rel
+              val content = subst.foldLeft(IO.read(src)) { case (c, (k, v)) => c.replace("${" + k + "}", v) }
+              IO.write(out, content)
+              out
+            }
+        },
+        Compile / sourceGenerators += limitedSources.taskValue,
         libraryDependencies += "com.normation.plugins" % "plugins-common-private" % privateLibVersion
       )
     else

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+// Fat-jar per plugin (replaces maven-shade-plugin / maven-assembly jar-with-dependencies).
+// Provided-scope deps (all of rudder-web's closure) are excluded from the assembly, like Maven.
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
 // Fat-jar per plugin (replaces maven-shade-plugin / maven-assembly jar-with-dependencies).
 // Provided-scope deps (all of rudder-web's closure) are excluded from the assembly, like Maven.
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+
+// OSV (Open Source Vulnerabilities) dependency scan — replaces the Maven CI vulnerability check.
+// 0.2.0 is published for sbt 2.x (sbt-osv_sbt2_3).
+addSbtPlugin("net.nmoncho" % "sbt-osv" % "0.2.0")


### PR DESCRIPTION
https://issues.rudder.io/issues/29144

Based on https://github.com/Normation/rudder/pull/7251

Main change: 
- everything is run from root. For `Makefile` in projects, they actually do a `cd .. &&`
- no more template
- provided dependencies seems to just work correctly

There is a lot of cleaning that will be possible since we just have code (more common definition, passing parameters in properties files, etc) but the first step was just to make it work. 