### PR TITLE
Fixes #29173: There is a space above change request header buttons since #28784

### DIFF
--- a/change-validation/src/main/elm/sources/ChangeRequestDetails.elm
+++ b/change-validation/src/main/elm/sources/ChangeRequestDetails.elm
@@ -490,8 +490,8 @@ bannerView model cr =
     in
     div [ class "main-header", id "changeRequestHeader" ]
         [ div [ class "d-table col-12" ]
-            [div [class "header-title d-table-row"]
-                [ div [class "d-table-cell"] [h1 [] [ span [ id "nameTitle" ] [ text cr.changeRequest.title ] ]]
+            [div [class "header-title flex-nowrap"]
+                [ div [class "d-flex"] [h1 [] [ span [ id "nameTitle" ] [ text cr.changeRequest.title ] ]]
                 , div [ class "flex-container" ]
                     [ div [ id "CRStatus" ] [ text cr.changeRequest.state ]
                     , actionButtons model cr.changeRequest.id canChangeStep cr.prevStatus cr.reachableNextSteps
@@ -559,7 +559,7 @@ actionButtons model crId canChangeStep backStatus allNextSteps =
                     []
     in
     div [ id "actionBtns" ]
-        [ div [ class "header-buttons", id "workflowActionButtons" ] buttons
+        [ div [ class "header-buttons flex-nowrap", id "workflowActionButtons" ] buttons
         , changeStepPopupView model.changeStepPopup model.changeMessageSettings.changeMessageEnabled crId
         ]
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29173

Using flex prevents the misalignment, and makes the header take full space (and flex-nowrap prevents surprising wraps).

It now looks like:
<img width="2056" height="1182" alt="image" src="https://github.com/user-attachments/assets/e5cc1b63-d876-43e6-8c53-61453e5b415c" />
 