### PR TITLE
Fixes #29240: self-validation parameter is ignored

### DIFF
--- a/change-validation/src/main/scala/bootstrap/rudder/plugin/ChangeValidationConf.scala
+++ b/change-validation/src/main/scala/bootstrap/rudder/plugin/ChangeValidationConf.scala
@@ -315,7 +315,9 @@ object ChangeValidationConf extends RudderPluginModule {
       roWorkflowRepository,
       workflowLevelService,
       commitAndDeployChangeRequest,
-      RudderConfig.userPropertyService
+      RudderConfig.userPropertyService,
+      () => RudderConfig.configService.rudder_workflow_self_validation(),
+      () => RudderConfig.configService.rudder_workflow_self_deployment()
     )
     val api3 = new ValidatedUserApiImpl(
       roValidatedUserRepository,

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowService.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/WorkflowService.scala
@@ -41,7 +41,6 @@ import com.normation.errors.*
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.AuthorizationType
-import com.normation.rudder.Role
 import com.normation.rudder.batch.AsyncWorkflowInfo
 import com.normation.rudder.domain.eventlog.AddChangeRequestDiff
 import com.normation.rudder.domain.eventlog.ChangeRequestDiff
@@ -52,6 +51,7 @@ import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.services.eventlog.ChangeRequestEventLogService
 import com.normation.rudder.services.eventlog.WorkflowEventLogService
+import com.normation.rudder.services.workflows.ChangeRequestAuthorship
 import com.normation.rudder.services.workflows.CommitAndDeployChangeRequestService
 import com.normation.rudder.services.workflows.NoWorkflowAction
 import com.normation.rudder.services.workflows.WorkflowAction
@@ -65,6 +65,24 @@ import java.time.Instant
 import zio.*
 import zio.syntax.ToZio
 
+/*
+ * Central decision for the self-validation / self-deployment control (segregation of duties),
+ * shared by the workflow service (which offers or omits transitions) and the API guard (which
+ * denies them). It is the single source of truth for the rule so both enforcement layers stay
+ * consistent:
+ * - acting on a change request one did NOT author is never a self-action -> always allowed;
+ * - acting on one's OWN change request is allowed only when the relevant setting is enabled.
+ * Fails closed: if reading the setting errors, the self-action is treated as forbidden.
+ */
+object SelfActionControl {
+  def isAllowed(authorship: ChangeRequestAuthorship, settingEnabled: () => IOResult[Boolean]): IOResult[Boolean] = {
+    authorship match {
+      case ChangeRequestAuthorship.NotAuthor => true.succeed
+      case ChangeRequestAuthorship.Author    => settingEnabled().orElseSucceed(false)
+    }
+  }
+}
+
 /**
  * A proxy workflow service based on a runtime choice
  */
@@ -77,32 +95,32 @@ class EitherWorkflowService(cond: () => IOResult[Boolean], whenTrue: WorkflowSer
 
   def current: WorkflowService = if (cond().orElseSucceed(false).runNow) whenTrue else whenFalse
 
-  override def startWorkflow(changeRequest: ChangeRequest)(implicit cc: ChangeContext):                     IOResult[ChangeRequestId]                      =
+  override def startWorkflow(changeRequest: ChangeRequest)(implicit cc: ChangeContext): IOResult[ChangeRequestId]                      =
     current.startWorkflow(changeRequest)
-  override def openSteps:                                                                                   List[WorkflowNodeId]                           =
+  override def openSteps:                                                               List[WorkflowNodeId]                           =
     current.openSteps
-  override def closedSteps:                                                                                 List[WorkflowNodeId]                           =
+  override def closedSteps:                                                             List[WorkflowNodeId]                           =
     current.closedSteps
-  override def stepsValue:                                                                                  List[WorkflowNodeId]                           =
+  override def stepsValue:                                                              List[WorkflowNodeId]                           =
     current.stepsValue
-  override def findNextSteps(currentStep: WorkflowNodeId)(implicit auth: AuthenticatedUser):                WorkflowAction                                 =
-    current.findNextSteps(currentStep)
-  override def findBackSteps(currentStep: WorkflowNodeId)(implicit
+  override def findNextSteps(currentStep: WorkflowNodeId, authorship: ChangeRequestAuthorship)(implicit
+      auth: AuthenticatedUser
+  ): WorkflowAction =
+    current.findNextSteps(currentStep, authorship)
+  override def findBackSteps(currentStep: WorkflowNodeId, authorship: ChangeRequestAuthorship)(implicit
       auth: AuthenticatedUser
   ): Seq[(WorkflowNodeId, (ChangeRequestId, EventActor, Option[String]) => IOResult[WorkflowNodeId])] =
-    current.findBackSteps(currentStep)
-  override def findStep(changeRequestId: ChangeRequestId):                                                  IOResult[WorkflowNodeId]                       =
+    current.findBackSteps(currentStep, authorship)
+  override def findStep(changeRequestId: ChangeRequestId):                              IOResult[WorkflowNodeId]                       =
     current.findStep(changeRequestId)
-  override def getAllChangeRequestsStep():                                                                  IOResult[Map[ChangeRequestId, WorkflowNodeId]] =
+  override def getAllChangeRequestsStep():                                              IOResult[Map[ChangeRequestId, WorkflowNodeId]] =
     current.getAllChangeRequestsStep()
-  override def isEditable(currentUserRights: Seq[String], currentStep: WorkflowNodeId, isCreator: Boolean): Boolean                                        =
-    current.isEditable(currentUserRights, currentStep, isCreator)
-  override def isPending(currentStep: WorkflowNodeId):                                                      Boolean                                        =
+  override def isPending(currentStep: WorkflowNodeId):                                  Boolean                                        =
     current.isPending(currentStep)
-  override def needExternalValidation():                                                                    Boolean                                        = current.needExternalValidation()
-  override def findBackStatus(currentStep: WorkflowNodeId):                                                 Option[WorkflowNodeId]                         =
+  override def needExternalValidation():                                                Boolean                                        = current.needExternalValidation()
+  override def findBackStatus(currentStep: WorkflowNodeId):                             Option[WorkflowNodeId]                         =
     current.findBackStatus(currentStep)
-  override def findNextStatus(currentStep: WorkflowNodeId):                                                 Option[WorkflowNodeId]                         =
+  override def findNextStatus(currentStep: WorkflowNodeId):                             Option[WorkflowNodeId]                         =
     current.findNextStatus(currentStep)
 }
 
@@ -194,11 +212,13 @@ class TwoValidationStepsWorkflowServiceImpl(
    * Find available next steps for the current user.
    * The given rights are expected to be the string representation of atomic permissions.
    */
-  def findNextSteps(currentStep: WorkflowNodeId)(implicit auth: AuthenticatedUser): WorkflowAction = {
+  def findNextSteps(currentStep: WorkflowNodeId, authorship: ChangeRequestAuthorship)(implicit
+      auth: AuthenticatedUser
+  ): WorkflowAction = {
     implicit val qc: QueryContext = auth.qc
 
     def deployAction(action: (ChangeRequestId, EventActor, Option[String]) => IOResult[WorkflowNodeId]) = {
-      if (canDeploy)
+      if (canDeploy(authorship))
         Seq((Deployed.id, action))
       else Seq()
     }
@@ -206,7 +226,7 @@ class TwoValidationStepsWorkflowServiceImpl(
     currentStep match {
       case Validation.id =>
         val validatorActions = {
-          (if (canValidate) {
+          (if (canValidate(authorship)) {
              Seq((Deployment.id, stepValidationToDeployment))
            } else Seq()) ++ deployAction(stepValidationToDeployed)
         }
@@ -225,16 +245,16 @@ class TwoValidationStepsWorkflowServiceImpl(
     }
   }
 
-  def findBackSteps(currentStep: WorkflowNodeId)(implicit
+  def findBackSteps(currentStep: WorkflowNodeId, authorship: ChangeRequestAuthorship)(implicit
       auth: AuthenticatedUser
   ): Seq[(WorkflowNodeId, (ChangeRequestId, EventActor, Option[String]) => IOResult[WorkflowNodeId])] = {
     currentStep match {
       case Validation.id     =>
-        if (canValidate)
+        if (canValidate(authorship))
           Seq((Cancelled.id, stepValidationToCancelled))
         else Seq()
       case Deployment.id     =>
-        if (canDeploy)
+        if (canDeploy(authorship))
           Seq((Cancelled.id, stepDeploymentToCancelled))
         else Seq()
       case Deployed.id       => Seq()
@@ -244,22 +264,6 @@ class TwoValidationStepsWorkflowServiceImpl(
           s"An unknown workflow state was reached with ID: '${x}'. It is likely to be a bug, please report it"
         )
         Seq()
-    }
-  }
-
-  def isEditable(currentUserRights: Seq[String], currentStep: WorkflowNodeId, isCreator: Boolean): Boolean = {
-    val authorizedRoles =
-      currentUserRights.filter(role => role == Role.BuiltinName.Validator.value || role == Role.BuiltinName.Deployer.value)
-    currentStep match {
-      case Validation.id     => authorizedRoles.contains(Role.BuiltinName.Validator.value) || isCreator
-      case Deployment.id     => authorizedRoles.contains(Role.BuiltinName.Deployer.value)
-      case Deployed.id       => false
-      case Cancelled.id      => false
-      case WorkflowNodeId(x) =>
-        ChangeValidationLogger.warn(
-          s"An unknown workflow state was reached with ID: '${x}'. It is likely to be a bug, please report it"
-        )
-        false
     }
   }
 
@@ -318,17 +322,16 @@ class TwoValidationStepsWorkflowServiceImpl(
   }
 
   /*
-   * Validation rule logic:
-   * - check for self validation (only needed if current user is the CR author)
-   * - check for current user rights.
-   *   WARNING: WE ARE SIDE STEPPING authz check until https://issues.rudder.io/issues/22595 is solved
+   * A transition is allowed when BOTH:
+   * - the self-validation / self-deployment control allows it (see [[SelfActionControl]]), and
+   * - the current user has the required right.
    */
-  private def canValidate(implicit auth: AuthenticatedUser): Boolean = {
-    auth.checkRights(AuthorizationType.Validator.Edit)
+  private def canValidate(authorship: ChangeRequestAuthorship)(implicit auth: AuthenticatedUser): Boolean = {
+    SelfActionControl.isAllowed(authorship, selfValidation).runNow && auth.checkRights(AuthorizationType.Validator.Edit)
   }
 
-  private def canDeploy(implicit auth: AuthenticatedUser): Boolean = {
-    auth.checkRights(AuthorizationType.Deployer.Edit)
+  private def canDeploy(authorship: ChangeRequestAuthorship)(implicit auth: AuthenticatedUser): Boolean = {
+    SelfActionControl.isAllowed(authorship, selfDeployment).runNow && auth.checkRights(AuthorizationType.Deployer.Edit)
   }
 
   /**

--- a/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ChangeRequestApi.scala
+++ b/change-validation/src/main/scala/com/normation/plugins/changevalidation/api/ChangeRequestApi.scala
@@ -47,6 +47,7 @@ import com.normation.errors.OptionToIoResult
 import com.normation.errors.OptionToPureResult
 import com.normation.errors.PureResult
 import com.normation.errors.PureToIoResult
+import com.normation.errors.SecurityError
 import com.normation.errors.Unexpected
 import com.normation.plugins.PluginLiftApiModuleProvider
 import com.normation.plugins.PluginStatus
@@ -55,6 +56,7 @@ import com.normation.plugins.changevalidation.ChangeRequestInfoJson
 import com.normation.plugins.changevalidation.ChangeRequestJson
 import com.normation.plugins.changevalidation.RoChangeRequestRepository
 import com.normation.plugins.changevalidation.RoWorkflowRepository
+import com.normation.plugins.changevalidation.SelfActionControl
 import com.normation.plugins.changevalidation.TwoValidationStepsWorkflowServiceImpl
 import com.normation.plugins.changevalidation.TwoValidationStepsWorkflowServiceImpl.*
 import com.normation.plugins.changevalidation.WoChangeRequestRepository
@@ -90,6 +92,7 @@ import com.normation.rudder.rest.lift.DefaultParams
 import com.normation.rudder.rest.lift.LiftApiModule
 import com.normation.rudder.rest.lift.LiftApiModule0
 import com.normation.rudder.services.modification.DiffService
+import com.normation.rudder.services.workflows.ChangeRequestAuthorship
 import com.normation.rudder.services.workflows.CommitAndDeployChangeRequestService
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.users.AuthenticatedUser
@@ -168,6 +171,9 @@ object ChangeRequestApi extends Enum[ChangeRequestApi] with ApiModuleProvider[Ch
   def values = findValues
 }
 
+// a denial caused by the self-validation / self-deployment (segregation of duties) control
+final case class ChangeValidationSecurityError(msg: String) extends SecurityError
+
 class ChangeRequestApiImpl(
     diffService:          DiffService,
     readTechnique:        TechniqueRepository,
@@ -176,7 +182,9 @@ class ChangeRequestApiImpl(
     readWorkflow:         RoWorkflowRepository,
     workflowLevelService: WorkflowLevelService,
     commitRepository:     CommitAndDeployChangeRequestService,
-    userPropertyService:  UserPropertyService
+    userPropertyService:  UserPropertyService,
+    selfValidation:       () => IOResult[Boolean],
+    selfDeployment:       () => IOResult[Boolean]
 )(using status: PluginStatus)
     extends PluginLiftApiModuleProvider[ChangeRequestApi] {
   import com.normation.plugins.changevalidation.api.ChangeRequestApi as API
@@ -213,6 +221,11 @@ class ChangeRequestApiImpl(
     }
   }
 
+  /*
+   * RBAC check for a workflow step transition. This is the API-level guard; the workflow
+   * service enforces the same rights (and the self-validation control) when building the
+   * available transitions. See `checkSelfAction` for the self-validation/self-deployment part.
+   */
   def checkUserAction(workflowNodeId: WorkflowNodeId, target: WorkflowNodeId)(implicit authz: AuthzToken): PureResult[String] = {
     if (workflowNodeId == Validation.id) {
       if (!authz.checkRights(AuthorizationType.Validator.Write)) {
@@ -230,6 +243,38 @@ class ChangeRequestApiImpl(
       Left(Inconsistency("User is not authorized to update a 'pending deployment' change"))
     } else {
       Right("user is authorized to do step")
+    }
+  }
+
+  /*
+   * Segregation-of-duties (four-eyes) enforcement, as a defense-in-depth layer independent
+   * from the workflow service: when the current user is the author of the change request and
+   * the relevant setting (self-validation for a validation step, self-deployment for a
+   * deployment step) is disabled, the transition is denied. We fail closed: if reading the
+   * setting fails, the self action is treated as forbidden.
+   */
+  def checkSelfAction(
+      workflowNodeId: WorkflowNodeId,
+      target:         WorkflowNodeId,
+      authorship:     ChangeRequestAuthorship
+  ): IOResult[Unit] = {
+    def denyIfForbidden(settingEnabled: () => IOResult[Boolean], action: String): IOResult[Unit] = {
+      SelfActionControl.isAllowed(authorship, settingEnabled).flatMap {
+        case true  => ZIO.unit
+        case false =>
+          ChangeValidationSecurityError(
+            s"You are not authorized to do that action on your own change request: self-${action} is disabled."
+          ).fail
+      }
+    }
+
+    (workflowNodeId, target) match {
+      // validate: move a pending-validation change forward to pending-deployment
+      case (Validation.id, Deployment.id) => denyIfForbidden(selfValidation, "validation")
+      // validate and deploy in one step, or deploy a pending-deployment change
+      case (Validation.id, Deployed.id)   => denyIfForbidden(selfDeployment, "deployment")
+      case (Deployment.id, Deployed.id)   => denyIfForbidden(selfDeployment, "deployment")
+      case _                              => ZIO.unit
     }
   }
 
@@ -299,7 +344,8 @@ class ChangeRequestApiImpl(
           techniqueByDirective: Map[DirectiveId, Technique]
       ): IOResult[ChangeRequestJson] = {
         for {
-          backSteps  <- workflowLevelService.getWorkflowService().findBackSteps(step).succeed
+          backSteps  <-
+            workflowLevelService.getWorkflowService().findBackSteps(step, ChangeRequestAuthorship.of(changeRequest, auth)).succeed
           optStep     = backSteps.find(_._1 == WorkflowNodeId("Cancelled"))
           stepFunc   <-
             optStep.notOptional(
@@ -338,7 +384,8 @@ class ChangeRequestApiImpl(
           techniqueByDirective: Map[DirectiveId, Technique]
       ): IOResult[ChangeRequestJson] = {
         for {
-          nextSteps  <- workflowLevelService.getWorkflowService().findNextSteps(step).succeed
+          nextSteps  <-
+            workflowLevelService.getWorkflowService().findNextSteps(step, ChangeRequestAuthorship.of(changeRequest, auth)).succeed
           optStep     = nextSteps.actions.find(_._1 == targetStep)
           stepFunc   <-
             optStep.notOptional(
@@ -359,6 +406,7 @@ class ChangeRequestApiImpl(
           withChangeRequestContext(id, "accept") { (changeRequest, currentState, techniqueByDirective) =>
             implicit val directiveCtx: Map[DirectiveId, Technique] = techniqueByDirective
             checkUserAction(currentState, targetStep).toIO *>
+            checkSelfAction(currentState, targetStep, ChangeRequestAuthorship.of(changeRequest, auth)) *>
             (currentState match {
               case Deployment.id | Validation.id =>
                 actualAccept(changeRequest, currentState, targetStep)

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/SelfValidationWorkflowTest.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/SelfValidationWorkflowTest.scala
@@ -1,0 +1,284 @@
+/*
+ *************************************************************************************
+ * Copyright 2026 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.plugins.changevalidation
+
+import com.normation.errors.*
+import com.normation.plugins.AlwaysEnabledPluginStatus
+import com.normation.plugins.changevalidation.TwoValidationStepsWorkflowServiceImpl.*
+import com.normation.plugins.changevalidation.api.ChangeRequestApiImpl
+import com.normation.plugins.changevalidation.api.ChangeValidationSecurityError
+import com.normation.rudder.AuthorizationType
+import com.normation.rudder.Rights
+import com.normation.rudder.api.ApiAuthorization
+import com.normation.rudder.batch.AsyncWorkflowInfo
+import com.normation.rudder.domain.workflows.WorkflowNodeId
+import com.normation.rudder.facts.nodes.NodeSecurityContext
+import com.normation.rudder.rest.RestTestSetUp
+import com.normation.rudder.services.modification.DiffServiceImpl
+import com.normation.rudder.services.workflows.ChangeRequestAuthorship
+import com.normation.rudder.services.workflows.ChangeRequestAuthorship.*
+import com.normation.rudder.users.AuthenticatedUser
+import com.normation.rudder.users.RudderAccount
+import com.normation.rudder.users.UserPassword
+import org.junit.runner.RunWith
+import zio.*
+import zio.syntax.*
+import zio.test.*
+import zio.test.junit.ZTestJUnitRunner
+
+/*
+ * Tests for the self-validation / self-deployment control after regression in https://issues.rudder.io/issues/29240
+ *  We check both enforcement layers:
+ * - the workflow service, which offers or omits transitions (`findNextSteps`/`findBackSteps`);
+ * - the API guard `ChangeRequestApiImpl.checkSelfAction`, which denies them.
+ *
+ * The core rule: a user can only validate/deploy their OWN change request when the matching
+ * setting (self-validation / self-deployment) is enabled; acting on someone else's change is
+ * always allowed (subject to rights). It must fail closed if a setting cannot be read.
+ * ┌─────┬────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────┐
+ * │     │           Matrix           │                                                     What it locks in                  │
+ * ├─────┼────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
+ * │ A   │ findNextSteps @ validation │ self-validation gates the validate transition — incl. the regressed case (author +    │
+ * │     │                            │ disabled → no Deployment)                                                             │
+ * ├─────┼────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
+ * │ B   │ findNextSteps @ deployment │ self-deployment gates the deploy transition                                           │
+ * ├─────┼────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
+ * │ C   │ findBackSteps (cancel)     │ cancel follows the same canValidate/canDeploy control                                 │
+ * ├─────┼────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
+ * │ D   │ RBAC not bypassed          │ self-* setting never grants a missing Validator.Edit/Deployer.Edit                    │
+ * ├─────┼────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
+ * │ E   │ checkSelfAction (API       │ denies forbidden self actions with ChangeValidationSecurityError, allows non-authors, │
+ * │     │ guard)                     │ and fails closed when a setting can't be read                                         │
+ * └─────┴────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────┘
+ */
+@RunWith(classOf[ZTestJUnitRunner])
+class SelfValidationWorkflowTest extends ZIOSpecDefault {
+
+  private val restTestSetUp = RestTestSetUp.newEnv
+  private val mockServices  = new MockServices()
+
+  // an authenticated user granted exactly `granted`; `name` is what a change request `owner` is matched against
+  private def userWith(granted: Set[AuthorizationType], userLogin: String = "some-user"): AuthenticatedUser = {
+    new AuthenticatedUser {
+      override val account:   RudderAccount       = RudderAccount.User(userLogin, UserPassword.fromSecret("pwd"))
+      override val authz:     Rights              = Rights.AnyRights
+      override val apiAuthz:  ApiAuthorization    = ApiAuthorization.RW
+      override val nodePerms: NodeSecurityContext = NodeSecurityContext.All
+
+      override def checkRights(auth: AuthorizationType): Boolean = granted.contains(auth)
+    }
+  }
+
+  // a user holding both workflow rights, so tests can isolate the self-validation control from RBAC
+  private val validatorAndDeployer =
+    userWith(Set(AuthorizationType.Validator.Edit, AuthorizationType.Deployer.Edit))
+
+  private def mkService(
+      selfValidation: () => IOResult[Boolean],
+      selfDeployment: () => IOResult[Boolean]
+  ): TwoValidationStepsWorkflowServiceImpl = {
+    new TwoValidationStepsWorkflowServiceImpl(
+      mockServices.workflowEventLogService,
+      mockServices.commitAndDeployChangeRequest,
+      mockServices.workflowRepository,
+      mockServices.workflowRepository,
+      new AsyncWorkflowInfo,
+      restTestSetUp.uuidGen,
+      mockServices.changeRequestEventLogService,
+      mockServices.changeRequestRepository,
+      mockServices.changeRequestRepository,
+      mockServices.notificationService,
+      mockServices.userService,
+      () => true.succeed,
+      selfValidation,
+      selfDeployment
+    )
+  }
+
+  private def mkApi(
+      selfValidation: () => IOResult[Boolean],
+      selfDeployment: () => IOResult[Boolean]
+  ): ChangeRequestApiImpl = {
+    new ChangeRequestApiImpl(
+      new DiffServiceImpl,
+      restTestSetUp.mockTechniques.techniqueRepo,
+      mockServices.changeRequestRepository,
+      mockServices.changeRequestRepository,
+      mockServices.workflowRepository,
+      restTestSetUp.workflowLevelService,
+      mockServices.commitAndDeployChangeRequest,
+      mockServices.userPropertyService,
+      selfValidation,
+      selfDeployment
+    )(using AlwaysEnabledPluginStatus)
+  }
+
+  private val selfValidateOK:     () => IOResult[Boolean] = () => true.succeed
+  private val cannotSelfValidate: () => IOResult[Boolean] = () => false.succeed
+  private val selfDeployOK:       () => IOResult[Boolean] = () => true.succeed
+  private val cannotSelfDeploy:   () => IOResult[Boolean] = () => false.succeed
+  private val failing:            () => IOResult[Boolean] = () => Inconsistency("cannot read setting").fail
+
+  // the transitions offered from a step, by target id
+  private def nextTargets(
+      svc:        TwoValidationStepsWorkflowServiceImpl,
+      step:       WorkflowNodeId,
+      authorship: ChangeRequestAuthorship
+  )(implicit user: AuthenticatedUser): Seq[WorkflowNodeId] =
+    svc.findNextSteps(step, authorship).actions.map(_._1)
+
+  given user: AuthenticatedUser = validatorAndDeployer
+
+  override def spec: Spec[TestEnvironment & Scope, Any] = suite("self-validation / self-deployment control")(
+    // ---------------------------------------------------------------------------------------
+    // Matrix A: findNextSteps at "Pending validation" — the "validate" transition to
+    // "Pending deployment" is gated by self-validation when the user is the author.
+    // ---------------------------------------------------------------------------------------
+    suite("A - findNextSteps: self-validation gates the validate transition")(
+      test("author CAN validate when self-validation is enabled") {
+        val targets = nextTargets(mkService(selfValidateOK, selfDeployOK), Validation.id, Author)
+        assertTrue(targets.contains(Deployment.id))
+      },
+      test("author CANNOT validate their own change when self-validation is disabled") {
+        val targets = nextTargets(mkService(cannotSelfValidate, selfDeployOK), Validation.id, Author)
+        assertTrue(!targets.contains(Deployment.id))
+      },
+      test("a non-author CAN validate even when self-validation is disabled") {
+        val targets = nextTargets(mkService(cannotSelfValidate, selfDeployOK), Validation.id, NotAuthor)
+        assertTrue(targets.contains(Deployment.id))
+      }
+    ),
+
+    // ---------------------------------------------------------------------------------------
+    // Matrix B: findNextSteps deploy transition ("Pending deployment" -> "Deployed") is gated
+    // by self-deployment when the user is the author.
+    // ---------------------------------------------------------------------------------------
+    suite("B - findNextSteps: self-deployment gates the deploy transition")(
+      test("author CAN deploy when self-deployment is enabled") {
+        val targets = nextTargets(mkService(selfValidateOK, selfDeployOK), Deployment.id, Author)
+        assertTrue(targets.contains(Deployed.id))
+      },
+      test("author CANNOT deploy their own change when self-deployment is disabled") {
+        val targets = nextTargets(mkService(selfValidateOK, cannotSelfDeploy), Deployment.id, Author)
+        assertTrue(!targets.contains(Deployed.id))
+      },
+      test("a non-author CAN deploy even when self-deployment is disabled") {
+        val targets = nextTargets(mkService(selfValidateOK, cannotSelfDeploy), Deployment.id, NotAuthor)
+        assertTrue(targets.contains(Deployed.id))
+      }
+    ),
+
+    // ---------------------------------------------------------------------------------------
+    // Matrix C: findBackSteps (cancel) uses the same control — canValidate at "Pending
+    // validation", canDeploy at "Pending deployment".
+    // ---------------------------------------------------------------------------------------
+    suite("C - findBackSteps: cancel follows the same self-* control")(
+      test("author CANNOT cancel from validation when self-validation is disabled") {
+        val backs = mkService(cannotSelfValidate, selfDeployOK).findBackSteps(Validation.id, Author).map(_._1)
+        assertTrue(!backs.contains(Cancelled.id))
+      },
+      test("author CAN cancel from validation when self-validation is enabled") {
+        val backs = mkService(selfValidateOK, selfDeployOK).findBackSteps(Validation.id, Author).map(_._1)
+        assertTrue(backs.contains(Cancelled.id))
+      },
+      test("author CANNOT cancel from deployment when self-deployment is disabled") {
+        val backs = mkService(selfValidateOK, cannotSelfDeploy).findBackSteps(Deployment.id, Author).map(_._1)
+        assertTrue(!backs.contains(Cancelled.id))
+      }
+    ),
+
+    // ---------------------------------------------------------------------------------------
+    // Matrix D: the self-* setting NEVER grants a missing right. A user without Validator.Edit
+    // gets no validate transition even for someone else's change with self-validation enabled.
+    // ---------------------------------------------------------------------------------------
+    suite("D - RBAC is still required (self-* never bypasses rights)")(
+      test("no validate transition without Validator.Edit, even for a non-author with self-validation enabled") {
+        implicit val user: AuthenticatedUser = userWith(Set(AuthorizationType.Deployer.Edit))
+        val targets = nextTargets(mkService(selfValidateOK, selfDeployOK), Validation.id, NotAuthor)
+        assertTrue(!targets.contains(Deployment.id))
+      },
+      test("no deploy transition without Deployer.Edit, even for a non-author with self-deployment enabled") {
+        implicit val user: AuthenticatedUser = userWith(Set(AuthorizationType.Validator.Edit))
+        val targets = nextTargets(mkService(selfValidateOK, selfDeployOK), Deployment.id, NotAuthor)
+        assertTrue(!targets.contains(Deployed.id))
+      }
+    ),
+
+    // ---------------------------------------------------------------------------------------
+    // Matrix E: checkSelfAction (API defense-in-depth) denies the forbidden self actions.
+    // ---------------------------------------------------------------------------------------
+    suite("E - checkSelfAction: API guard denies forbidden self actions")(
+      test("author validating their own change is denied (SecurityError) when self-validation is disabled") {
+        mkApi(cannotSelfValidate, selfDeployOK)
+          .checkSelfAction(Validation.id, Deployment.id, Author)
+          .either
+          .map(res => assertTrue(res.left.toOption.exists(_.isInstanceOf[ChangeValidationSecurityError])))
+      },
+      test("author validating their own change is allowed when self-validation is enabled") {
+        mkApi(selfValidateOK, selfDeployOK)
+          .checkSelfAction(Validation.id, Deployment.id, Author)
+          .either
+          .map(res => assertTrue(res.isRight))
+      },
+      test("a non-author is allowed even when self-validation is disabled") {
+        mkApi(cannotSelfValidate, cannotSelfDeploy)
+          .checkSelfAction(Validation.id, Deployment.id, NotAuthor)
+          .either
+          .map(res => assertTrue(res.isRight))
+      },
+      test("author deploying their own change is denied when self-deployment is disabled") {
+        mkApi(selfValidateOK, cannotSelfDeploy)
+          .checkSelfAction(Deployment.id, Deployed.id, Author)
+          .either
+          .map(res => assertTrue(res.left.toOption.exists(_.isInstanceOf[ChangeValidationSecurityError])))
+      },
+      test("validate-and-deploy in one step is a deployment: denied for the author when self-deployment is disabled") {
+        mkApi(selfValidateOK, cannotSelfDeploy)
+          .checkSelfAction(Validation.id, Deployed.id, Author)
+          .either
+          .map(res => assertTrue(res.left.toOption.exists(_.isInstanceOf[ChangeValidationSecurityError])))
+      },
+      test("fails closed: a setting that cannot be read denies the author's self action") {
+        mkApi(failing, selfDeployOK)
+          .checkSelfAction(Validation.id, Deployment.id, Author)
+          .either
+          .map(res => assertTrue(res.left.toOption.exists(_.isInstanceOf[ChangeValidationSecurityError])))
+      }
+    )
+  )
+}

--- a/change-validation/src/test/scala/com/normation/plugins/changevalidation/api/ChangeRequestApiTest.scala
+++ b/change-validation/src/test/scala/com/normation/plugins/changevalidation/api/ChangeRequestApiTest.scala
@@ -607,7 +607,9 @@ class ChangeRequestApiTest extends ZIOSpecDefault {
       mockServices.workflowRepository,
       restTestSetUp.workflowLevelService,
       mockServices.commitAndDeployChangeRequest,
-      mockServices.userPropertyService
+      mockServices.userPropertyService,
+      () => true.succeed,
+      () => true.succeed
     )(using AlwaysEnabledPluginStatus)
   )
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29240

Based on https://github.com/Normation/rudder/pull/7290
There is two commit, the first one is the actual implementation of the check - nothing complicated, we just use the check about author/authenticated user introduced in the other PR. See  `checkSelfAction`
The second introduce unit testing to avoid regression on that part. 

Also propagate deletion of `isEditable`. Let me know if it was used somewhere in the UI I didn't find. 