### PR TITLE
Fixes #29243: Tenant configuration for auto-provided users are not taken into acount when override is enforced

### DIFF
--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -861,7 +861,12 @@ object RudderTokenMapping {
         // override means: don't use user tenants configured in rudder-users.xml
         parsedTenants
       } else {
-        default.plus(parsedTenants)
+        default match {
+          // we don't want that None is absorbent in that case
+          case NodeSecurityContext.None => parsedTenants
+          // other cases are ok for plus
+          case _                        => default.plus(parsedTenants)
+        }
       }
       AuthBackendsLogger.debug(
         s"Principal '${principal}' final list of tenants: '${tenants.value}'"
@@ -985,15 +990,8 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
           rudderUserDetailsService.loadUserByUsername(user.getName)
       }
     }
-    // for now, tenants are not configurable by OIDC
-    val tenants    = rudderUserDetailsService.authConfigProvider.getUserByName(user.getName) match {
-      // when the user is not defined in rudder-users.xml, we give it the whole perm on nodes for compatibility
-      case Left(_)  => NodeSecurityContext.All
-      // if the user is defined in rudder-users.xml, we get whatever is defined there.
-      case Right(u) => u.nodePerms
-    }
 
-    buildUser(optReg, userRequest, user, roleApiMapping, rudderUser, newUserDetails, tenants)
+    buildUser(optReg, userRequest, user, roleApiMapping, rudderUser, newUserDetails)
   }
 
   def buildUser(
@@ -1002,8 +1000,7 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
       user:           U,
       roleApiMapping: RoleApiMapping,
       rudder:         RudderUserDetail,
-      userBuilder:    (U, RudderUserDetail) => T,
-      tenants:        NodeSecurityContext
+      userBuilder:    (U, RudderUserDetail) => T
   ): T = {
 
     val (roles, nsc) = optReg match {
@@ -1011,7 +1008,7 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
         AuthBackendsLogger.trace(
           s"No configuration found for ${protocolName} registration id: ${userRequest.getClientRegistration.getRegistrationId}"
         )
-        (rudder.roles, tenants) // if no registration, use defaults
+        (rudder.roles, rudder.nodePerms) // if no registration, use defaults
 
       case Some(reg) =>
         val getAttr = (attributeName: String) => {
@@ -1022,7 +1019,7 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
         }
 
         val roles = RudderTokenMapping.getRoles(reg, rudder.getUsername, protocolId, rudder.roles)(getAttr)
-        val nsc   = RudderTokenMapping.getTenants(reg, rudder.getUsername, protocolId, tenants)(getAttr)
+        val nsc   = RudderTokenMapping.getTenants(reg, rudder.getUsername, protocolId, rudder.nodePerms)(getAttr)
 
         (roles, nsc)
     }

--- a/auth-backends/src/main/scala/com/normation/plugins/authbackends/Oauth2Authentication.scala
+++ b/auth-backends/src/main/scala/com/normation/plugins/authbackends/Oauth2Authentication.scala
@@ -199,7 +199,7 @@ final case class RudderClientRegistration(
 
   // avoid that in logs etc, use only for interactive debugging sessions
   def toDebugStringWithSecret: String =
-    s"""{${registration.toString}}, '${infoMsg}', roles: ${roles.toString}, user provisioning enabled: ${provisioning}"""
+    s"""{${registration.toString}}, '${infoMsg}', roles: ${roles.toString}, tenants: ${tenants.toString}, user provisioning enabled: ${provisioning}"""
 }
 
 /*


### PR DESCRIPTION
https://issues.rudder.io/issues/29243

Some code for tenant default predated the changes in tenant management with OIDC in 8.3. That lead to a too large default with some cases of configuration options.
Now, we have everything in `RudderUserDetails`, so just use that. 