### PR TITLE
Fixes #29245: Missing tenant checking for node external reports

### DIFF
--- a/node-external-reports/README.adoc
+++ b/node-external-reports/README.adoc
@@ -85,7 +85,7 @@ plugin.node-external-reports.reports {
   01_security= {
     title=Security Report
     description=This report display pen test results
-    dirname=/var/reports/security
+    dirname=/var/rudder/plugins/node-external-reports/security
     filename="report-@@node@@-sec.html"
     content-type=text/html
   }
@@ -93,7 +93,7 @@ plugin.node-external-reports.reports {
   02_monitoring {
     title=Monitoring Report
     description=Monitoring information about the node
-    dirname=/var/reports/monitoring
+    dirname=/var/rudder/plugins/node-external-reports/monitoring
     filename="monitor-@@node@@.txt"
     content-type=text/plain
   }
@@ -101,17 +101,17 @@ plugin.node-external-reports.reports {
   03_compliance {
     title=Third party compliance report
     description=Compliance reports from CMDB
-    dirname=/var/reports/compliance
+    dirname=/var/rudder/plugins/node-external-reports/compliance
     filename="compliance-@@node@@.pdf"
     content-type=application/pdf
   }
 }
 ----
 
-And the content of  `/var/reports/` will looks like:
+And the content of  `/var/rudder/plugins/node-external-reports/` will looks like:
 
 ----
-/tmp/reports
+/var/rudder/plugins/node-external-reports
 ├── compliance
 │   ├── compliance-node34.china1.bigcorp.com.html
 │   │   .....

--- a/node-external-reports/src/main/resources/node-external-reports.properties
+++ b/node-external-reports/src/main/resources/node-external-reports.properties
@@ -21,7 +21,7 @@ plugin.node-external-reports.reports {
   01_security= {
     title=Security Report
     description=This report display pen test results
-    dirname=/tmp/security
+    dirname=/var/rudder/plugins/node-external-reports/security
     filename="@@node@@.html"
     content-type=text/html
   }
@@ -29,7 +29,7 @@ plugin.node-external-reports.reports {
   02_monitoring {
     title=Monitoring Report
     description=Monitoring information about the node
-    dirname=/tmp/monitoring
+    dirname=/var/rudder/plugins/node-external-reports/monitoring
     filename="@@node@@.txt"
     content-type=text/plain
   }
@@ -37,7 +37,7 @@ plugin.node-external-reports.reports {
   03_compliance {
     title=Third party compliance report
     description=Other compliance reports
-    dirname=/tmp/compliance
+    dirname=/var/rudder/plugins/node-external-reports/compliance
     filename="@@node@@.pdf"
     content-type=application/pdf
   }

--- a/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/extension/CreateNodeDetailsExtension.scala
+++ b/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/extension/CreateNodeDetailsExtension.scala
@@ -36,6 +36,7 @@
 
 package com.normation.plugins.nodeexternalreports.extension
 
+import com.normation.inventory.domain.NodeId
 import com.normation.plugins.PluginExtensionPoint
 import com.normation.plugins.PluginStatus
 import com.normation.plugins.nodeexternalreports.service.NodeExternalReport
@@ -71,11 +72,11 @@ class CreateNodeDetailsExtension(externalReport: ReadExternalReports, val status
         val e = eb ?~! "Can not display external reports for that node"
         addTab(tabId, "External reports", <div class="error">{e.messageChain}</div>)
       case Full(config) =>
-        addTab(tabId, config.tabTitle, tabContent(config.reports)(myXml))
+        addTab(tabId, config.tabTitle, tabContent(snippet.nodeId, config.reports)(myXml))
     })(xml)
   }
 
-  def tabContent(reports: Map[String, NodeExternalReport]): CssSel = {
+  def tabContent(nodeId: NodeId, reports: Map[String, NodeExternalReport]): CssSel = {
 
     ".nodeReports" #> reports.map {
       case (key, report) =>
@@ -85,9 +86,10 @@ class CreateNodeDetailsExtension(externalReport: ReadExternalReports, val status
           & ".reportLink" #> (report.fileName match {
             case None    =>
               <span>No report of that type is available</span>
-            case Some(f) =>
+            case Some(_) =>
+              // the file name is resolved server-side from the node id and report type
               <a href={
-                s"/secure/nodeManager/externalInformation/${urlEncode(key)}/${urlEncode(f)}/raw"
+                s"/secure/nodeManager/externalInformation/${urlEncode(nodeId.value)}/${urlEncode(key)}/raw"
               } target="_blank">Display report in a new window</a>
           })
         )

--- a/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/service/NodeExternalReportApi.scala
+++ b/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/service/NodeExternalReportApi.scala
@@ -36,9 +36,16 @@
 
 package com.normation.plugins.nodeexternalreports.service
 
+import com.normation.box.*
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.AuthorizationType
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.users.CurrentUser
 import java.io.FileInputStream
 import net.liftweb.common.*
+import net.liftweb.http.ForbiddenResponse
 import net.liftweb.http.LiftResponse
+import net.liftweb.http.NotFoundResponse
 import net.liftweb.http.Req
 import net.liftweb.http.StreamingResponse
 import net.liftweb.http.rest.RestHelper
@@ -46,8 +53,11 @@ import net.liftweb.util.Helpers.tryo
 import net.liftweb.util.Helpers.urlDecode
 
 /**
- * Class in charge of generating the JSON from the
- * iTop compliance status and serving it to the API URL.
+ * Class in charge of serving external report files for a node.
+ *
+ * The endpoint is scoped to a `NodeId` and a report type; it requires `Node.Read` and resolves the
+ * file server-side under the caller's `QueryContext` (so node/tenant ACLs are enforced). It never
+ * accepts a client-supplied file name.
  */
 class NodeExternalReportApi(
     readReport: ReadExternalReports
@@ -55,26 +65,38 @@ class NodeExternalReportApi(
 
   val requestDispatch: PartialFunction[Req, () => Box[LiftResponse]] = {
 
-    case Get(reportType :: fileName :: "raw" :: Nil, req) => {
+    case Get(nodeId :: reportType :: "raw" :: Nil, req) => {
       // capture values
-      val tpe  = urlDecode(reportType)
-      val name = urlDecode(fileName)
+      val id  = urlDecode(nodeId)
+      val tpe = urlDecode(reportType)
 
-      () =>
-        for {
-          (file, contentType) <- readReport.getFileContent(tpe, name)
-          stream              <- tryo(new FileInputStream(file))
-          if null ne stream
-        } yield {
-          StreamingResponse(
-            stream,
-            () => stream.close,
-            stream.available.toLong,
-            List("Content-Type" -> contentType),
-            Nil,
-            200
-          )
+      () => {
+        // fail closed: any authenticated user without Node.Read (incl. no authenticated context) is denied
+        if (!CurrentUser.checkRights(AuthorizationType.Node.Read)) {
+          Full(ForbiddenResponse("You don't have sufficient rights to access node external reports"))
+        } else {
+          implicit val qc: QueryContext = CurrentUser.queryContext
+          readReport.getReportFile(NodeId(id), tpe).toBox match {
+            case Full(Some((file, contentType))) =>
+              tryo(new FileInputStream(file)).map { stream =>
+                StreamingResponse(
+                  stream,
+                  () => stream.close,
+                  stream.available.toLong,
+                  List("Content-Type" -> contentType),
+                  Nil,
+                  200
+                )
+              }
+            case Full(None)                      =>
+              Full(NotFoundResponse(s"No external report of type '${tpe}' is available for node '${id}'"))
+            case eb: EmptyBox =>
+              val e = eb ?~! s"Error when accessing external report '${tpe}' for node '${id}'"
+              logger.warn(e.messageChain)
+              Full(ForbiddenResponse("Could not access the requested external report"))
+          }
         }
+      }
     }
   }
 

--- a/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/service/ReadExternalReports.scala
+++ b/node-external-reports/src/main/scala/com/normation/plugins/nodeexternalreports/service/ReadExternalReports.scala
@@ -37,15 +37,18 @@
 package com.normation.plugins.nodeexternalreports.service
 
 import com.normation.box.*
+import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.utils.FileUtils
 import com.typesafe.config.*
 import java.io.File
 import net.liftweb.common.*
 import net.liftweb.util.Helpers.tryo
 import scala.collection.immutable.SortedMap
 import scala.jdk.CollectionConverters.*
+import zio.syntax.*
 
 final case class ExternalReport(
     title:         String,
@@ -140,29 +143,56 @@ class ReadExternalReports(nodeFactRepo: NodeFactRepository, val reportConfigFile
         tabTitle = conf.tabTitle,
         reports = conf.reports.map {
           case (key, report) =>
-            val fileName = {
-              val uuidName     = report.reportName(node.id.value).toLowerCase
-              val hostnameName = report.reportName(node.fqdn).toLowerCase
-
-              if ((new File(report.rootDirectory, hostnameName)).exists) {
-                Some(hostnameName)
-              } else if ((new File(report.rootDirectory, uuidName)).exists) {
-                Some(uuidName)
-              } else None
-            }
-            (key, NodeExternalReport(report.title, report.description, fileName))
+            (key, NodeExternalReport(report.title, report.description, resolveExistingFileName(report, node.id.value, node.fqdn)))
         }
       )
     }
   }
 
-  def getFileContent(reportType: String, fileName: String): Box[(File, String)] = {
+  /**
+   * Resolve, server-side, the report file name for a node: try the hostname-based name first,
+   * then the uuid-based one, and only return a name whose file actually exists. The node uuid
+   * and fqdn are the only inputs used to build the name - never a client-supplied file name.
+   */
+  private def resolveExistingFileName(report: ExternalReport, nodeUuid: String, fqdn: String): Option[String] = {
+    val uuidName     = report.reportName(nodeUuid).toLowerCase
+    val hostnameName = report.reportName(fqdn).toLowerCase
+
+    if ((new File(report.rootDirectory, hostnameName)).exists) {
+      Some(hostnameName)
+    } else if ((new File(report.rootDirectory, uuidName)).exists) {
+      Some(uuidName)
+    } else None
+  }
+
+  /**
+   * Return the report file and its content type for the given node and report type.
+   *
+   * The file name is resolved server-side from the node (looked up through the fact repository,
+   * so tenant/node ACLs carried by `qc` are enforced) - the caller never supplies a file name.
+   * As defense in depth, the resolved name is still run through `sanitizePath` and fails closed
+   * on any attempt to escape the report root directory.
+   *
+   * `None` means either: the report type is unknown, the node is not visible to the caller, or no
+   * report file exists for that node.
+   */
+  def getReportFile(nodeId: NodeId, reportType: String)(implicit qc: QueryContext): IOResult[Option[(File, String)]] = {
+    if (config == null) loadAndUpdateConfig()
     for {
-      conf   <- config
-      report <- Box(conf.reports.get(reportType))
-    } yield {
-      (new File(report.rootDirectory, fileName), report.contentType)
-    }
+      conf <- config.toIO
+      opt  <- nodeFactRepo.get(nodeId)
+      res  <- (opt, conf.reports.get(reportType)) match {
+                case (Some(node), Some(report)) =>
+                  resolveExistingFileName(report, node.id.value, node.fqdn) match {
+                    case Some(fileName) =>
+                      FileUtils
+                        .sanitizePath(better.files.File(report.rootDirectory.getPath), fileName)
+                        .map(f => Some((f.toJava, report.contentType)))
+                    case None           => None.succeed
+                  }
+                case _                          => None.succeed
+              }
+    } yield res
   }
 
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/29245

Several things to hardened node external reports: 
- don't give bad advice: use the plugin default var path in doc/examples, 
- resolve file name server side from node Id / node hostname and plugin config
- user needs `Node.Read` right to see the node reports, 
- paths are sanitized