### PR TITLE
Fixes #29414: Remove interpolation of $rudder.parameters in datasources

### DIFF
--- a/datasources/src/main/elm/sources/DataSourceForm.elm
+++ b/datasources/src/main/elm/sources/DataSourceForm.elm
@@ -259,7 +259,7 @@ urlForm httpData displayError =
         , urlError
         , div [ class "example-help" ]
             [ text "You can use Rudder variable expansion ("
-            , pre [] [ text "${rudder.node.xxx}, ${rudder.param.xxx}, ${node.properties[xxx]}" ]
+            , pre [] [ text "${rudder.node.xxx}, ${node.properties[xxx]}" ]
             , text ") here. They will be replaced by their values for each node at the time the HTTP query is run."
             ]
         ]

--- a/datasources/src/main/scala/bootstrap/rudder/plugin/DataSourcesConf.scala
+++ b/datasources/src/main/scala/bootstrap/rudder/plugin/DataSourcesConf.scala
@@ -82,7 +82,6 @@ object DatasourcesConf extends RudderPluginModule {
     new DataSourceJdbcRepository(Cfg.doobie),
     new HttpQueryDataSourceService(
       Cfg.nodeFactRepository,
-      Cfg.roLDAPParameterRepository,
       Cfg.interpolationCompiler,
       regenerationHook.hook,
       () => Cfg.configService.rudder_global_policy_mode()

--- a/datasources/src/main/scala/com/normation/plugins/datasources/QueryService.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/QueryService.scala
@@ -42,13 +42,11 @@ import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.properties.CompareProperties
-import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.NodeFactChangeEvent
 import com.normation.rudder.facts.nodes.NodeFactRepository
-import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.services.policies.InterpolatedValueCompiler
 import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
@@ -79,7 +77,7 @@ trait QueryDataSourceService {
   def queryAll(datasource: DataSource, cause: UpdateCause): IOResult[Set[NodeUpdateResult]]
 
   /**
-   * A version that use provided nodeinfo / parameters to only query a subpart of nodes
+   * A version that use provided nodeinfo to only query a subpart of nodes
    */
   def querySubset(datasource: DataSource, info: PartialNodeUpdate, cause: UpdateCause): IOResult[Set[NodeUpdateResult]]
 
@@ -149,7 +147,6 @@ object QueryService {
  */
 class HttpQueryDataSourceService(
     factRepository:   NodeFactRepository,
-    parameterRepo:    RoParameterRepository,
     interpolCompiler: InterpolatedValueCompiler,
     onUpdatedHook:    (Set[NodeId], UpdateCause) => IOResult[Unit],
     globalPolicyMode: () => IOResult[GlobalPolicyMode]
@@ -234,7 +231,6 @@ class HttpQueryDataSourceService(
       nodeInfo:         CoreNodeFact,
       policyServers:    Map[NodeId, CoreNodeFact],
       globalPolicyMode: GlobalPolicyMode,
-      parameters:       Set[GlobalParameter],
       cause:            UpdateCause
   ): IOResult[NodeUpdateResult] = {
     (for {
@@ -252,7 +248,6 @@ class HttpQueryDataSourceService(
                         nodeInfo,
                         policyServer,
                         globalPolicyMode,
-                        parameters,
                         datasource.requestTimeOut,
                         datasource.requestTimeOut
                       )
@@ -276,8 +271,7 @@ class HttpQueryDataSourceService(
     def tasks(
         nodes:            Map[NodeId, CoreNodeFact],
         policyServers:    Map[NodeId, CoreNodeFact],
-        globalPolicyMode: GlobalPolicyMode,
-        parameters:       Set[GlobalParameter]
+        globalPolicyMode: GlobalPolicyMode
     ): IOResult[List[Either[RudderError, NodeUpdateResult]]] = {
 
       /*
@@ -288,7 +282,7 @@ class HttpQueryDataSourceService(
        */
       ZIO
         .foreachPar(nodes.values.toList) { nodeInfo =>
-          buildOneNodeTask(datasourceId, datasource, nodeInfo, policyServers, globalPolicyMode, parameters, cause).either
+          buildOneNodeTask(datasourceId, datasource, nodeInfo, policyServers, globalPolicyMode, cause).either
         }
         .withParallelism(datasource.maxParallelRequest)
     }
@@ -320,7 +314,7 @@ class HttpQueryDataSourceService(
     for {
       mode         <- globalPolicyMode()
       _            <- DataSourceLoggerPure.trace(s"Start querying data for ${nodes.size} nodes")
-      updated      <- tasks(nodes, info.policyServers, mode, info.parameters)
+      updated      <- tasks(nodes, info.policyServers, mode)
                         .timeout(timeout)
                         .notOptional(
                           s"Timeout error after ${zio.Duration.fromJava(timeout).render}"
@@ -341,18 +335,14 @@ class HttpQueryDataSourceService(
       globalPolicyMode: () => IOResult[GlobalPolicyMode],
       cause:            UpdateCause
   ): IOResult[Set[NodeUpdateResult]] = {
-    // datasources need all tenant access
-    given qc: QueryContext = QueryContext.systemQC
-
     for {
       nodes        <- factRepository.getAll()(using QueryContext.systemQC)
       policyServers = nodes.filter(_._2.rudderSettings.isPolicyServer)
-      parameters   <- parameterRepo.getAllGlobalParameters().map(_.toSet)
       updated      <- querySubsetByNode(
                         datasourceId,
                         datasource,
                         globalPolicyMode,
-                        PartialNodeUpdate(nodes.toMap, policyServers.toMap, parameters),
+                        PartialNodeUpdate(nodes.toMap, policyServers.toMap),
                         cause,
                         onUpdatedHook
                       )
@@ -379,17 +369,13 @@ class HttpQueryDataSourceService(
       nodeId:           NodeId,
       cause:            UpdateCause
   ): IOResult[NodeUpdateResult] = {
-    // datasources need all tenant access
-    given qc: QueryContext = QueryContext.systemQC
-
     for {
       mode         <- globalPolicyMode()
       allNodes     <- factRepository.getAll()(using QueryContext.systemQC)
       node         <- allNodes.get(nodeId).notOptional(s"The node with id '${nodeId.value}' was not found")
       policyServers = allNodes.filter(_._1 == node.rudderSettings.policyServerId)
-      parameters   <- parameterRepo.getAllGlobalParameters().map(_.toSet)
       updated      <-
-        buildOneNodeTask(datasourceId, datasource, node, policyServers.toMap, mode, parameters, cause)
+        buildOneNodeTask(datasourceId, datasource, node, policyServers.toMap, mode, cause)
           .timeout(datasource.requestTimeOut)
           .notOptional(
             s"Timeout error after ${datasource.requestTimeOut.asScala.toString()} for update of datasource '${datasourceId.value}'"

--- a/datasources/src/main/scala/com/normation/plugins/datasources/Repository.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/Repository.scala
@@ -45,7 +45,6 @@ import com.normation.plugins.PluginStatus
 import com.normation.plugins.datasources.DataSourceSchedule.*
 import com.normation.rudder.db.Doobie
 import com.normation.rudder.domain.eventlog.*
-import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio.*
@@ -62,8 +61,7 @@ final case class PartialNodeUpdate(
     // the node to update
     nodes:         Map[NodeId, CoreNodeFact],
     // there policy servers
-    policyServers: Map[NodeId, CoreNodeFact],
-    parameters:    Set[GlobalParameter]
+    policyServers: Map[NodeId, CoreNodeFact]
 )
 
 object DataSourceRepository {

--- a/datasources/src/main/scala/com/normation/plugins/datasources/UpdateHttpDataset.scala
+++ b/datasources/src/main/scala/com/normation/plugins/datasources/UpdateHttpDataset.scala
@@ -95,7 +95,6 @@ class GetDataset(valueCompiler: InterpolatedValueCompiler) {
       node:              CoreNodeFact,
       policyServer:      CoreNodeFact,
       globalPolicyMode:  GlobalPolicyMode,
-      parameters:        Set[GlobalParameter],
       connectionTimeout: Duration,
       readTimeOut:       Duration
   ): IOResult[Option[NodeProperty]] = {
@@ -116,11 +115,9 @@ class GetDataset(valueCompiler: InterpolatedValueCompiler) {
 
     // actual logic
 
+    val expand = compiler.compileInput(node, policyServer, globalPolicyMode)
+
     for {
-      parameters <- ZIO
-                      .foreach(parameters)(compiler.compileParameters(_).toIO)
-                      .chainError("Error when transforming Rudder parameter for variable interpolation")
-      expand      = compiler.compileInput(node, policyServer, globalPolicyMode, parameters.toMap)
       url        <- expand(datasource.url).chainError(s"Error when trying to parse URL ${datasource.url}")
       path       <- expand(datasource.path).chainError(s"Error when trying to compile JSON path ${datasource.path}")
       headers    <- expandMap(expand, datasource.headers)
@@ -231,15 +228,10 @@ object QueryHttp {
  */
 class InterpolateNode(compiler: InterpolatedValueCompiler) {
 
-  def compileParameters(parameter: GlobalParameter): PureResult[(String, ParamInterpolationContext => IOResult[String])] = {
-    compiler.compileParam(serializeToHocon(parameter.value)).map(v => (parameter.name, v))
-  }
-
   def compileInput(
       node:             CoreNodeFact,
       policyServer:     CoreNodeFact,
-      globalPolicyMode: GlobalPolicyMode,
-      parameters:       Map[String, ParamInterpolationContext => IOResult[String]]
+      globalPolicyMode: GlobalPolicyMode
   )(input: String): IOResult[String] = {
 
     // we inject some props that are useful as identity pivot (like short name)
@@ -252,7 +244,7 @@ class InterpolateNode(compiler: InterpolatedValueCompiler) {
       // build interpolation context from node:
       enhanced  =
         node.modify(_.properties).using(props => NodeProperty.apply("datasources-injected", injected, None, None) +: props)
-      context   = ParamInterpolationContext(enhanced, policyServer, globalPolicyMode, parameters, 5)
+      context   = ParamInterpolationContext(enhanced, policyServer, globalPolicyMode)
       bounded  <- compiled(context)
     } yield {
       bounded

--- a/datasources/src/test/scala/com/normation/plugins/datasources/ZioUpdateHttpDatasetTest.scala
+++ b/datasources/src/test/scala/com/normation/plugins/datasources/ZioUpdateHttpDatasetTest.scala
@@ -51,10 +51,8 @@ import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.PolicyModeOverrides
 import com.normation.rudder.domain.properties.GenericProperty
 import com.normation.rudder.domain.properties.GenericProperty.*
-import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.facts.nodes.*
-import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.services.nodes.PropertyEngineServiceImpl
 import com.normation.rudder.services.policies.InterpolatedValueCompilerImpl
 import com.normation.rudder.services.policies.NodeConfigData
@@ -345,13 +343,6 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
   )
   val fetch: GetDataset = new GetDataset(interpolation)
 
-  val parameterRepo = new RoParameterRepository() {
-    override def getGlobalParameter(parameterName: String)(using qc: QueryContext): IOResult[Option[GlobalParameter]] =
-      None.succeed
-
-    override def getAllGlobalParameters()(using qc: QueryContext): IOResult[Seq[GlobalParameter]] = Seq().succeed
-  }
-
   def buildNodeRepo(initNodeInfo: Map[NodeId, CoreNodeFact]): UIO[(Ref[Map[NodeId, Int]], NodeFactRepository)] = {
 
     // used for test
@@ -448,7 +439,6 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
       repo <- buildNodeRepo(NodeConfigData.allNodeFacts)
     } yield new HttpQueryDataSourceService(
       repo._2,
-      parameterRepo,
       interpolation,
       noPostHook,
       () => alwaysEnforce.succeed
@@ -517,7 +507,7 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
 
       for {
         (updates, infos) <- buildNodeRepo(NodeConfigData.allNodeFacts)
-        http              = new HttpQueryDataSourceService(infos, parameterRepo, interpolation, noPostHook, () => alwaysEnforce.succeed)
+        http              = new HttpQueryDataSourceService(infos, interpolation, noPostHook, () => alwaysEnforce.succeed)
         _                <- updates.set(Map())
         res              <- http.queryAll(datasource, UpdateCause(modId, actor, None))
         // let hooks happens - this is magical, it tells zio to let finish things started
@@ -699,7 +689,6 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
                               new MemoryDataSourceRepository(),
                               new HttpQueryDataSourceService(
                                 infos,
-                                parameterRepo,
                                 interpolation,
                                 noPostHook,
                                 () => alwaysEnforce.succeed
@@ -756,7 +745,6 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
                               new MemoryDataSourceRepository(),
                               new HttpQueryDataSourceService(
                                 infos,
-                                parameterRepo,
                                 interpolation,
                                 noPostHook,
                                 () => alwaysEnforce.succeed
@@ -811,7 +799,6 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
         (updates, infos) <- buildNodeRepo(nodes)
         http              = new HttpQueryDataSourceService(
                               infos,
-                              parameterRepo,
                               interpolation,
                               noPostHook,
                               () => alwaysEnforce.succeed
@@ -947,7 +934,6 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
                  n1,
                  root,
                  alwaysEnforce,
-                 Set(),
                  1.second,
                  5.seconds
                )
@@ -981,7 +967,7 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
     suite("The full http service")(
       for {
         (updates, infos) <- buildNodeRepo(NodeConfigData.allNodeFacts)
-        http              = new HttpQueryDataSourceService(infos, parameterRepo, interpolation, noPostHook, () => alwaysEnforce.succeed)
+        http              = new HttpQueryDataSourceService(infos, interpolation, noPostHook, () => alwaysEnforce.succeed)
       } yield Chunk(
         test("correctly update all nodes") {
           val datasource = NewDataSource(
@@ -1112,7 +1098,7 @@ class ZioUpdateHttpDatasetTest extends ZIOSpecDefault {
       (for {
         (updates, infos) <- buildNodeRepo(initNodeFacts)
         http              =
-          new HttpQueryDataSourceService(infos, parameterRepo, interpolation, noPostHook, () => alwaysEnforce.succeed)
+          new HttpQueryDataSourceService(infos, interpolation, noPostHook, () => alwaysEnforce.succeed)
         datasource        = NewDataSource(propName, url = s"${REST_SERVER_URL}/404", path = "$.some.prop", onMissing = onMissing)
 
         nodes  <- infos.getAll()


### PR DESCRIPTION
https://issues.rudder.io/issues/29414

Needs https://github.com/Normation/rudder/pull/7350

Same thing as in the other PR, for datasources. 