### PR TITLE
Fixes #29479: SSO provisioned users see 0 node by default

### DIFF
--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -809,9 +809,29 @@ object RudderTokenMapping {
   }
 
   /*
+   * Enforces that when tenants are disabled, give access by default to "all tenants".
+   *
+   * To be used when there are no known default tenants.
+   */
+  def getTenants(
+      reg:             RudderOAuth2Registration & RegistrationWithRoles,
+      principal:       String, // user name or token id
+      protocolName:    String  // oauth2Api, oauth2, oidc
+  )(
+      getTokenTenants: String => Option[Set[String]]
+  ): NodeSecurityContext = {
+    val defaultNsc = if (reg.tenants.enabled) {
+      NodeSecurityContext.None
+    } else {
+      NodeSecurityContext.All
+    }
+    getTenants(reg, principal, protocolName, defaultNsc)(getTokenTenants)
+  }
+
+  /*
    * This is the way to get the list of defined tenants given what an OAuth2 token gives.
    * - we have a notion of "default tenants" which are the one the user or the token have by default, without
-   *   token info
+   *   token info. When tenants are disabled, default is access to all tenants for compatibility
    * - we can map tenants to rudder ones so that IdP tenant names and Rudder ones are independent
    * - we can restrict the available tenants to the ones mapped so that a Rogue IdP can't use Rudder internal
    *   tenants names (and chaos ensues if those internal name change - even if tenants should be public names)
@@ -875,8 +895,12 @@ object RudderTokenMapping {
       tenants
 
     } else {
-      AuthBackendsLogger.debug(s"${protocolName} configuration is not configured to use token provided tenants")
-      default
+      // compatibility: disabled tenants configuration means access to all tenants
+      val fallback = NodeSecurityContext.All
+      AuthBackendsLogger.debug(
+        s"${protocolName} configuration is not configured to use token provided tenants, falling back to '${fallback.serialize}'"
+      )
+      fallback
     }
 
     tenants
@@ -1323,8 +1347,7 @@ class RudderJwtAuthenticationConverter(
       }
 
       val roles    = RudderTokenMapping.getRoles(registration, t.getName, PROTOCOL_ID, default = Set())(getAttr)
-      val nsc      =
-        RudderTokenMapping.getTenants(registration, t.getName, PROTOCOL_ID, default = NodeSecurityContext.None)(getAttr)
+      val nsc      = RudderTokenMapping.getTenants(registration, t.getName, PROTOCOL_ID)(getAttr)
       val apiAuthz = RudderTokenMapping.getApiAuthorization(roleApiMapping, roles)
 
       // create RudderUserDetails from token

--- a/auth-backends/src/test/resources/oidc/oidc_tenants.properties
+++ b/auth-backends/src/test/resources/oidc/oidc_tenants.properties
@@ -1,4 +1,4 @@
-rudder.auth.oauth2.provider.registrations=someidp
+rudder.auth.oauth2.provider.registrations=someidp,notenantsidp
 rudder.auth.oauth2.provider.someidp.name=Some ID
 rudder.auth.oauth2.provider.someidp.ui.infoMessage="Hey, log in to Some Idp!"
 rudder.auth.oauth2.provider.someidp.client.id=xxxClientIdxxx
@@ -27,3 +27,18 @@ rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_TA=TA
 rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_TB=TB
 rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_all=*
 rudder.auth.oauth2.provider.someidp.tenants.mapping.entitlements.rudder_none=-
+
+rudder.auth.oauth2.provider.notenantsidp.name=Notenants ID
+rudder.auth.oauth2.provider.notenantsidp.ui.infoMessage="Hey, log in to Notenants IdP!"
+rudder.auth.oauth2.provider.notenantsidp.client.id=xxxClientIdxxx
+rudder.auth.oauth2.provider.notenantsidp.client.secret=xxxClientPassxxx
+rudder.auth.oauth2.provider.notenantsidp.scope=openid email profile groups
+rudder.auth.oauth2.provider.notenantsidp.userNameAttributeName=email
+rudder.auth.oauth2.provider.notenantsidp.uri.auth="https://notenantsidp/oauth2/v1/authorize"
+rudder.auth.oauth2.provider.notenantsidp.uri.token="https://notenantsidp/oauth2/v1/token"
+rudder.auth.oauth2.provider.notenantsidp.uri.userInfo="https://notenantsidp/oauth2/v1/userinfo"
+rudder.auth.oauth2.provider.notenantsidp.uri.jwkSet="https://notenantsidp/oauth2/v1/keys"
+rudder.auth.oauth2.provider.notenantsidp.client.redirect="{baseUrl}/login/oauth2/code/{registrationId}"
+rudder.auth.oauth2.provider.notenantsidp.grantType=authorization_code
+rudder.auth.oauth2.provider.notenantsidp.authMethod=basic
+rudder.auth.oauth2.provider.notenantsidp.tenants.enabled=false

--- a/auth-backends/src/test/scala/com/normation/plugins/authbackends/TestReadOidcConfig.scala
+++ b/auth-backends/src/test/scala/com/normation/plugins/authbackends/TestReadOidcConfig.scala
@@ -111,7 +111,7 @@ class TestReadOidcConfig extends Specification {
     "work for simple tenants" in {
       val tokenValues = Set("rudder_TA", "rudder_TB")
       val tenants     =
-        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt", NodeSecurityContext.None)(_ => Some(tokenValues))
+        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt")(_ => Some(tokenValues))
 
       tenants === NodeSecurityContext.ByTenants(Chunk(TenantId("TA"), TenantId("TB")))
     }
@@ -119,7 +119,7 @@ class TestReadOidcConfig extends Specification {
     "work for no tenants" in {
       val tokenValues = Set.empty[String]
       val tenants     =
-        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt", NodeSecurityContext.None)(_ => Some(tokenValues))
+        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt")(_ => Some(tokenValues))
 
       tenants === NodeSecurityContext.None
     }
@@ -127,7 +127,7 @@ class TestReadOidcConfig extends Specification {
     "work for none" in {
       val tokenValues = Set("rudder_none", "rudder_TA")
       val tenants     =
-        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt", NodeSecurityContext.None)(_ => Some(tokenValues))
+        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt")(_ => Some(tokenValues))
 
       tenants === NodeSecurityContext.None
     }
@@ -135,7 +135,14 @@ class TestReadOidcConfig extends Specification {
     "work for all" in {
       val tokenValues = Set("rudder_all", "rudder_TA")
       val tenants     =
-        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt", NodeSecurityContext.None)(_ => Some(tokenValues))
+        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt")(_ => Some(tokenValues))
+
+      tenants === NodeSecurityContext.All
+    }
+
+    "fallback to '*' when tenants not enabled" in {
+      val tenants =
+        RudderTokenMapping.getTenants(regs("notenantsidp"), "user", "jwt")(_ => None)
 
       tenants === NodeSecurityContext.All
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/29479

When tenants are not supposed to be configured, the default logic was "use the tenant `-`" every time (both for JWT and OAuth2/OIDC user login).

That logic branch is not the expected behavior, the fallback when tenants are not enabled should be the retro-compatible behavior of provisioning user with "all tenants", upon every login/JWT authentication.


**Change:**
* fix the branch of logic where `tenants.enable=false`, to use `*` tenants
* fix JWT to use the default based on `tenants.enable` configuration too
* add tests of the `tenants.enable=false` case