### PR TITLE
Fixes #29375: Validation button are present when you can't self-validate

### DIFF
--- a/change-validation/src/main/elm/sources/ChangeRequestDetails.elm
+++ b/change-validation/src/main/elm/sources/ChangeRequestDetails.elm
@@ -5,11 +5,11 @@ import ChangeRequestChangesForm as ChangesForm
 import ChangeRequestEditForm as EditForm
 import ErrorMessages exposing (decodeErrorDetails)
 import Html exposing (Attribute, Html, a, b, button, div, form, h1, h2, h3, h4, h5, label, option, p, select, span, text, textarea)
-import Html.Attributes exposing (attribute, class, disabled, href, id, placeholder, selected, style, tabindex, type_, value)
+import Html.Attributes exposing (attribute, class, disabled, href, id, placeholder, selected, style, tabindex, title, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Http exposing (Error, emptyBody, header, request)
 import Http.Detailed as Detailed
-import Json.Decode exposing (Decoder, Value, at, bool, field, index, int, map2)
+import Json.Decode exposing (Decoder, Value, at, bool, field, index, int, map4)
 import List
 import List.Extra exposing (uniqueBy)
 import Ports exposing (errorNotification, readUrl, successNotification)
@@ -47,7 +47,7 @@ init flags =
                 (ChangesForm.initModel { contextPath = flags.contextPath })
                 NoView
                 NoView
-                (ChangeMessageSettings False False)
+                (ChangeMessageSettings False False False False)
     in
     ( initModel, getChangeMessageSettings initModel )
 
@@ -67,6 +67,8 @@ type alias ChangeStepForm =
 type alias ChangeMessageSettings =
     { changeMessageEnabled : Bool
     , changeMessageMandatory : Bool
+    , enableSelfDeployment : Bool
+    , enableSelfValidation : Bool
     }
 
 
@@ -201,9 +203,11 @@ decodeChangeMessageSettings : Decoder ChangeMessageSettings
 decodeChangeMessageSettings =
     at [ "data" ]
         (field "settings"
-            (map2 ChangeMessageSettings
+            (map4 ChangeMessageSettings
                 (field "enable_change_message" bool)
                 (field "mandatory_change_message" bool)
+                (field "enable_self_deployment" bool)
+                (field "enable_self_validation" bool)
             )
         )
 
@@ -268,6 +272,7 @@ update msg model =
                             , eventLogs = cr.eventLogs
                             , prevStatus = cr.prevStatus
                             , reachableNextSteps = next
+                            , isAuthor = cr.isAuthor
                             }
 
                         formDetails =
@@ -494,7 +499,7 @@ bannerView model cr =
                 [ div [ class "d-flex" ] [ h1 [] [ span [ id "nameTitle" ] [ text cr.changeRequest.title ] ] ]
                 , div [ class "flex-container" ]
                     [ div [ id "CRStatus" ] [ text cr.changeRequest.state ]
-                    , actionButtons model cr.changeRequest.id canChangeStep cr.prevStatus cr.reachableNextSteps
+                    , actionButtons model cr canChangeStep
                     ]
                 ]
             ]
@@ -509,9 +514,25 @@ bannerView model cr =
         ]
 
 
-actionButtons : Model -> Int -> Bool -> Maybe BackStatus -> Maybe AllNextSteps -> Html Msg
-actionButtons model crId canChangeStep backStatus allNextSteps =
+actionButtons : Model -> ChangeRequestMainDetails -> Bool -> Html Msg
+actionButtons model cr canChangeStep =
     let
+        enableSelfValidation =
+            model.changeMessageSettings.enableSelfValidation
+
+        enableSelfDeployment =
+            model.changeMessageSettings.enableSelfDeployment
+
+        getDisabledAttributes : Bool -> String -> List (Attribute Msg)
+        getDisabledAttributes enabledAction action =
+            if cr.isAuthor && not enabledAction then
+                [ disabled True
+                , title ("You are not authorized to do that action on your own change request: self-" ++ action ++ " is disabled.")
+                ]
+
+            else
+                [ canChangeStepAttr ]
+
         canChangeStepAttr =
             disabled (not canChangeStep)
 
@@ -519,34 +540,42 @@ actionButtons model crId canChangeStep backStatus allNextSteps =
             case back of
                 Cancelled ->
                     button
-                        [ id "backStep"
-                        , class backStepBtnClass
-                        , canChangeStepAttr
-                        , onClick (OpenChangeStepPopup (BackSteps back))
-                        ]
+                        (List.append
+                            (getDisabledAttributes (cr.changeRequest.state == "Pending validation" || (cr.changeRequest.state == "Pending deployment" && enableSelfDeployment)) "deployment")
+                            [ id "backStep"
+                            , class backStepBtnClass
+                            , onClick (OpenChangeStepPopup (BackSteps back))
+                            ]
+                        )
                         [ text "Decline" ]
 
         nextStepButton next =
             let
-                action =
+                ( action, disabledAttributes ) =
                     case next.selected of
                         PendingDeployment ->
-                            "Validate"
+                            ( "Validate"
+                            , getDisabledAttributes enableSelfValidation "validation"
+                            )
 
                         Deployed ->
-                            "Deploy"
+                            ( "Deploy"
+                            , getDisabledAttributes enableSelfDeployment "deployment"
+                            )
             in
             button
-                [ id "nextStep"
-                , style "float" "right"
-                , class "btn btn-success"
-                , canChangeStepAttr
-                , onClick (OpenChangeStepPopup (NextSteps next))
-                ]
+                (List.append
+                    disabledAttributes
+                    [ id "nextStep"
+                    , style "float" "right"
+                    , class "btn btn-success"
+                    , onClick (OpenChangeStepPopup (NextSteps next))
+                    ]
+                )
                 [ text action ]
 
         buttons =
-            case ( backStatus, allNextSteps ) of
+            case ( cr.prevStatus, cr.reachableNextSteps ) of
                 ( Just back, Just next ) ->
                     [ backStepButton back, nextStepButton next ]
 
@@ -561,7 +590,7 @@ actionButtons model crId canChangeStep backStatus allNextSteps =
     in
     div [ id "actionBtns" ]
         [ div [ class "header-buttons flex-nowrap", id "workflowActionButtons" ] buttons
-        , changeStepPopupView model.changeStepPopup model.changeMessageSettings.changeMessageEnabled crId
+        , changeStepPopupView model.changeStepPopup model.changeMessageSettings.changeMessageEnabled cr.changeRequest.id
         ]
 
 

--- a/change-validation/src/main/elm/sources/RudderDataTypes.elm
+++ b/change-validation/src/main/elm/sources/RudderDataTypes.elm
@@ -78,6 +78,7 @@ type alias ChangeRequestMainDetailsMetadata =
     , eventLogs : List EventLog
     , prevStatus : Maybe BackStatus
     , allNextSteps : List NextStatus
+    , isAuthor : Bool
     }
 
 
@@ -87,6 +88,7 @@ type alias ChangeRequestMainDetails =
     , eventLogs : List EventLog
     , prevStatus : Maybe BackStatus
     , reachableNextSteps : Maybe AllNextSteps
+    , isAuthor : Bool
     }
 
 
@@ -446,12 +448,13 @@ decodeChangeRequestMainDetails =
                 (field "changeRequest" decodeChangeRequestDetails
                     |> andThen
                         (\changeRequestDetails ->
-                            map5 ChangeRequestMainDetailsMetadata
+                            map6 ChangeRequestMainDetailsMetadata
                                 (succeed changeRequestDetails)
                                 (field "isPending" bool)
                                 (field "eventLogs" (decodeEventLogList changeRequestDetails.state))
                                 (maybe (field "backStatus" decodePrevStatus))
                                 (field "allNextSteps" (list decodeNextStatus))
+                                (field "isAuthor" bool)
                         )
                 )
             )

--- a/change-validation/src/main/style/change-validation.scss
+++ b/change-validation/src/main/style/change-validation.scss
@@ -451,6 +451,11 @@ body.sidebar-mini.sidebar-collapse #supervised-targets-app .toolbar {
   margin-top: 16px;
 }
 
+.btn.btn-success:disabled[title] {
+  pointer-events: auto;
+  cursor: help;
+}
+
 // KEYFRAMES
 @keyframes bounceH {
   0%   {transform: translateX(0);}


### PR DESCRIPTION
https://issues.rudder.io/issues/29375

Action buttons are not accessible anymore if the user is the author, and:
- change request state is "pending validation" and "enable self validation" setting is disabled
- change request state is "pending deployment" and "enable self deployment" setting is disabled

---- 
### EDIT:

Finally, if the user is the autor:
- "Validate" button is disabled if change request state is "pending validation" and "enable self validation" setting is disabled
- "Deploy" button is disabled if change request state is "pending deployment" and "enable self deployment" setting is disabled
- "Decline" button is disabled if change request state is "pending deployment" and "enable self deployment" setting is disabled, but it is still active if the change request state is "pending validation" and  "enable self validation" is disabled, to ensure that users can cancel their CRs that have not yet been validated.

A message appears when you hover over the disabled buttons to explain why they are disabled:
<img width="681" height="118" alt="Capture d’écran du 2026-08-14 15-27-07" src="https://github.com/user-attachments/assets/691f3616-ec9a-4944-ab2b-0e622c9f57c1" />

