### PR TITLE
Fixes #29548: Manual tenant config is ignored on OIDC provisioned users

### DIFF
--- a/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
+++ b/auth-backends/src/main/scala/bootstrap/rudder/plugin/AuthBackendsConf.scala
@@ -809,9 +809,11 @@ object RudderTokenMapping {
   }
 
   /*
-   * Enforces that when tenants are disabled, give access by default to "all tenants".
+   * Enforces that when tenants are disabled, give access by default to "all tenants", if no tenants are found in token.
    *
    * To be used when there are no known default tenants.
+   * E.g. for JWT, if tenants are not provisioned, keep the same behavior as an API account with no tenant attribute,
+   * that is '*'
    */
   def getTenants(
       reg:             RudderOAuth2Registration & RegistrationWithRoles,
@@ -895,8 +897,8 @@ object RudderTokenMapping {
       tenants
 
     } else {
-      // compatibility: disabled tenants configuration means access to all tenants
-      val fallback = NodeSecurityContext.All
+      // disabled tenants configuration means tenant should be resolved as the default
+      val fallback = default
       AuthBackendsLogger.debug(
         s"${protocolName} configuration is not configured to use token provided tenants, falling back to '${fallback.serialize}'"
       )
@@ -991,7 +993,7 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
     val optReg = registrationRepository.registrations.get(userRequest.getClientRegistration.getRegistrationId)
 
     // check that we know that user in our DB, else if "provisioning" is enabled, create it
-    val rudderUser = {
+    val rudderUser   = {
       try {
         rudderUserDetailsService.loadUserByUsername(user.getName)
       } catch {
@@ -1015,10 +1017,33 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
           rudderUserDetailsService.loadUserByUsername(user.getName)
       }
     }
+    val resolvedUser = if (optReg.map(_.tenants.enabled).getOrElse(false)) {
+      // ok because tenants in file are ignored/merged, see `RudderTokenMapping.getTenants` for the tenant provisioning
+      rudderUser
+    } else {
+      // tenants in base, if present, are the only source of truth since tenant are not provisioned
+      // default tenant, if absent (even from file), is '*'
+      def defaultTenant = NodeSecurityContext.All
 
-    buildUser(optReg, userRequest, user, roleApiMapping, rudderUser, newUserDetails)
+      rudderUserDetailsService.authConfigProvider.getUserByName(rudderUser.getUsername) match {
+        case Left(_)  => // user not in XML file, use default
+          AuthBackendsLogger.debug(
+            s"User '${user.getName}' is not in file or has no 'tenants' defined, falling back to ${defaultTenant.serialize}"
+          )
+          rudderUser.copy(nodePerms = defaultTenant)
+        case Right(u) => // user in XML file, use its tenants
+          AuthBackendsLogger.debug(
+            s"User '${user.getName}' has resolved tenants from file: ${u.nodePerms.serialize}"
+          )
+          // provided user already has the right tenant, no need for copy
+          rudderUser
+      }
+    }
+
+    buildUser(optReg, userRequest, user, roleApiMapping, resolvedUser, newUserDetails)
   }
 
+  // resolved user can have default fields that we don't want to compute
   def buildUser(
       optReg:         Option[RudderOAuth2Registration & RegistrationWithRoles],
       userRequest:    R,
@@ -1042,9 +1067,9 @@ trait RudderUserServerMapping[R <: OAuth2UserRequest, U <: OAuth2User, T <: Rudd
             Some(user.getAttribute[java.util.ArrayList[String]](attributeName).asScala.toSet)
           } else None
         }
-
-        val roles = RudderTokenMapping.getRoles(reg, rudder.getUsername, protocolId, rudder.roles)(getAttr)
-        val nsc   = RudderTokenMapping.getTenants(reg, rudder.getUsername, protocolId, rudder.nodePerms)(getAttr)
+        val tenants = rudder.nodePerms
+        val roles   = RudderTokenMapping.getRoles(reg, rudder.getUsername, protocolId, rudder.roles)(getAttr)
+        val nsc     = RudderTokenMapping.getTenants(reg, rudder.getUsername, protocolId, tenants)(getAttr)
 
         (roles, nsc)
     }

--- a/auth-backends/src/test/scala/com/normation/plugins/authbackends/TestReadOidcConfig.scala
+++ b/auth-backends/src/test/scala/com/normation/plugins/authbackends/TestReadOidcConfig.scala
@@ -140,11 +140,27 @@ class TestReadOidcConfig extends Specification {
       tenants === NodeSecurityContext.All
     }
 
-    "fallback to '*' when tenants not enabled" in {
+    "override user tenant" in {
+      def defaultTenant = NodeSecurityContext.ByTenants(Chunk(TenantId("TC"))) // gets ignored
+      val tenants       =
+        RudderTokenMapping.getTenants(regs("someidp"), "user", "jwt", defaultTenant)(_ => None)
+
+      tenants === NodeSecurityContext.None
+    }
+
+    "fallback to '*' when user has no defined tenant and tenants provisioning is not enabled" in {
       val tenants =
         RudderTokenMapping.getTenants(regs("notenantsidp"), "user", "jwt")(_ => None)
 
       tenants === NodeSecurityContext.All
+    }
+
+    "fallback to user tenant when tenants provisioning is not enabled" in {
+      val defaultTenant = NodeSecurityContext.ByTenants(Chunk(TenantId("TC")))
+      val tenants       =
+        RudderTokenMapping.getTenants(regs("notenantsidp"), "user", "jwt", defaultTenant)(_ => None)
+
+      tenants === defaultTenant
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29548

For now that the parsed user tenant from base is not an `Option`, we need to get the parsed user from file:
* if it's there and has a tenant, fallback must be that one
* if not, fallback is same as for compat: `*`
